### PR TITLE
Unhardcoded app launcher icon filetype

### DIFF
--- a/share/applications/pulseeffects.desktop
+++ b/share/applications/pulseeffects.desktop
@@ -3,5 +3,5 @@ Comment=Audio Effects for Pulseaudio Applications
 Name=PulseEffects
 Exec=pulseeffects
 Type=Application
-Icon=pulseeffects.png
+Icon=pulseeffects
 StartupNotify=true


### PR DESCRIPTION
Since you're going to install the icon to a location compliant with [freedesktop.org standards](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html) (I take it that way, otherwise you'd have to specify the full path) you don't need to specify the icon file extension in the `.desktop` launcher. It will be found anyway.

This facilitates the use of non-PNG (e.g. SVG) app icon themes.
Cf. this [example `.desktop` launcher](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#example).
