### PR TITLE
Use XDG instead of hard coding

### DIFF
--- a/PulseEffects/application.py
+++ b/PulseEffects/application.py
@@ -80,7 +80,8 @@ class Application(Gtk.Application):
         self.ts.set_state('ready')
 
         # creating user presets folder
-        self.user_config_dir = os.path.expanduser('~/.config/PulseEffects')
+        self.user_config_dir = os.path.join(GLib.get_user_config_dir(),
+                                            'PulseEffects')
         os.makedirs(self.user_config_dir, exist_ok=True)
 
     def do_startup(self):


### PR DESCRIPTION
GLib provides a way to properly respect the XDG Base Directory
Specification.

It is true that the directory would almost always be the same.
However a user should be to change this by, for example setting
$XDG_CONFIG_HOME and the application should respect that change.