### PR TITLE
Fix appid for calibration tool

### DIFF
--- a/PulseEffectsCalibration/application.py
+++ b/PulseEffectsCalibration/application.py
@@ -17,7 +17,7 @@ from PulseEffectsCalibration.test_signal import TestSignal
 class Application(Gtk.Application):
 
     def __init__(self):
-        app_id = 'com.github.wwmm.pulseeffects_calibration'
+        app_id = 'com.github.wwmm.pulseeffects.calibration'
 
         Gtk.Application.__init__(self, application_id=app_id)
 


### PR DESCRIPTION
Because the calibration tool did not share the namespace of the main
application you would need to explicitly add ownership of the name
com.github.wwmm.pulseeffects_calibration.

With this simple change the calibration tool appid is under the same
namespace and granted dbus access by default in the flatpak sandbox.