### PR TITLE
Add some dependency checking to build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,13 @@ i18n_mod = import('i18n')
 message('Checking dependencies')
 py3 = py3_mod.find_python()
 
+gtk3 = dependency('gtk+-3.0', version: '>= 3.20')
+pygobj = dependency('pygobject-3.0')
+pycairo = dependency('py3cairo')
+
+gst = dependency('gstreamer-1.0', version: '>= 1.12')
+gstbad = dependency('gstreamer-plugins-bad-1.0', version: '>= 1.12')
+
 message('Getting python install path')
 py3_dir = py3_mod.sysconfig_path('purelib')
 


### PR DESCRIPTION
Meson now has some dependency checks. Unfortunately not all dependencies could get added.

This is due to the fact that Meson uses pkg-config and not all projects ship the required files. Additionally it lacks a simple way of checking for python modules, which naturally do not ship these files.

The main net positive is that the build system clearly checks your gstreamer version, which should prevent any future issue threads regarding this.