### PR TITLE
Add Flatpak to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ change was necessary to support presets for microphone processing.
 
 - [Arch Linux](https://aur.archlinux.org/packages/pulseeffects/)
 
+### Flatpak
+
+[Flatpak](https://flatpak.org) packages support multiple distributions and are sandboxed.
+
+Stable releases are hosted on [Flathub](https://flathub.org):
+
+```
+flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+flatpak install flathub com.github.wwmm.pulseeffects
+```
+
 ### Source Code
 
 Required libraries:


### PR DESCRIPTION
The latest version of PulseEffects is now hosted on Flathub and
available for all supported distributions.

Currently it is limited to the x86 and x86_64 architectures. This is due to the gfortran extension being unavailable for ARM.