### PR TITLE
Inform translators not to translate icon name

### DIFF
--- a/data/com.github.wwmm.pulseeffects.desktop.in
+++ b/data/com.github.wwmm.pulseeffects.desktop.in
@@ -5,6 +5,7 @@ Comment=Audio Effects for PulseAudio Applications
 Keywords=limiter;compressor;reverberation;equalizer;autovolume;
 Categories=GTK;AudioVideo;Audio;
 Exec=pulseeffects
+# Translators: This is an icon name, don't translate!
 Icon=pulseeffects
 StartupNotify=true
 Terminal=false


### PR DESCRIPTION
It seems to be a common issue with Gnome apps, that for some reason the
icon name string is made translatable.

This temporary solution seems to be widely accepted. It is not visible
in POEdit. Maybe it is in other editors, maybe not. At least it will
serve as a reminder during a pull request review.

DO NOT accept pull requests that fail to notice this.