### PR TITLE
Add meson version check

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
 project('PulseEffects',
-  version: '3.0.0'
+  version: '3.0.0',
+  meson_version: '>= 0.40.0'
 )
 
 py3_mod = import('python3')


### PR DESCRIPTION
If nothing else this documents what version of Meson is required to
build/install PulseEffects.

Unfortunately since version 0.40.0 brings the change that removes the
requirement to define a language in project() and that is the very same
place the meson version check happens Meson will still report:

"Not enough arguments to project(). Needs at least the project name and
one language"