### PR TITLE
Fix issues with documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,29 +36,23 @@ output at the same time it applies them for applications output:
 9. Output Limiter (Ladspa Fast Lookahead Limiter)
 10. Spectrum Analyzer (Gstreamer)
 
-## Build and install
+## Installation
 
 Users upgrading from 1.x to 2.x will have to rebuild their presets. Since
 version 2.0.0 PulseEffects uses a different format. This
 change was necessary to support presets for microphone processing.
 
-```
-$ meson _build --prefix=/usr
-$ cd _build
-$ sudo ninja install
-```
-
 ### GNU/Linux Packages
 
 - [Arch Linux](https://aur.archlinux.org/packages/pulseeffects/)
 
-Ubuntu >=17.10 repository:
-```
-wget -q -O- http://repo.dumalogiya.ru/keys/mikhailnov_pub.gpg | sudo apt-key add -
-echo "deb http://repo.dumalogiya.ru/aptly/public artful main" | sudo tee /etc/apt/sources.list.d/dumalogiya-artful.list
-sudo apt update
-sudo apt install pulseeffects
-```
+#### Community Packages
+
+These are community maintained repositories of distribution packages. You can
+find more information about these in the
+[wiki](https://github.com/wwmm/pulseeffects/wiki/Package-Repositories#package-repositories).
+
+- [Ubuntu](https://github.com/wwmm/pulseeffects/wiki/Package-Repositories#ubuntu-1710-and-newer)
 
 ### Flatpak
 
@@ -67,8 +61,8 @@ sudo apt install pulseeffects
 Stable releases are hosted on [Flathub](https://flathub.org):
 
 ```
-$ flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-$ flatpak install flathub com.github.wwmm.pulseeffects
+flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+flatpak install flathub com.github.wwmm.pulseeffects
 ```
 
 ### Source Code
@@ -87,13 +81,9 @@ Required libraries:
  (Since version 1.4.3 Pulseeffects needs Gstreamer 1.12 or above)
 - [swh-plugins](https://github.com/swh/ladspa) from Ladspa
 
-See the wiki: [Installing from Source](https://github.com/wwmm/pulseeffects/wiki/Installation-from-Source), for detailed instructions.
+#### Installing from Source
 
-### Build Debian/Ubuntu .deb package
-```
-$ debuild -I
-```
-The built deb package will be located in ../
+See the wiki: [Installing from Source](https://github.com/wwmm/pulseeffects/wiki/Installation-from-Source), for detailed instructions.
 
 ## Command Line Options
 


### PR DESCRIPTION
The recent introduction of debian build files also modified the
documentation in less than ideal ways.

This fix solves this by staying consistent with previous changes that
moved distribution specific instructions to the wiki. Specifically a
wiki page for community maintained distribution packages is introduced
and linked to.

Build instructions is removed altogether since it has long since had a
dedicated wiki page. Some instructions were incomplete anyhow or located
in the wrong section.

Showing incomplete build instructions at the top is bad, because it
decreases the likelihood of a user reading the complete wiki page, thus
missing information. This in turn leads to an increase in support issues.