### PR TITLE
New dependencies for debian/control

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
-pulseeffects (3.1.6) artful; urgency=low
+pulseeffects (3.1.6-2) artful; urgency=low
 
   * update to version 3.1.6 upstream
+  * add zam-plugins as a new dependency
   
- -- Mikhail Novosyolov <mikhailnov@dumalogiya.ru>  Tue, 14 Dec 2017 20:02:00 +0300 
+ -- Mikhail Novosyolov <mikhailnov@dumalogiya.ru>  Sun, 21 Jan 2018 00:27:00 +0300 
 
 pulseeffects (3.1.3-3) artful; urgency=low
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pulseeffects (3.1.6) artful; urgency=low
+
+  * update to version 3.1.6 upstream
+  
+ -- Mikhail Novosyolov <mikhailnov@dumalogiya.ru>  Tue, 14 Dec 2017 20:02:00 +0300 
+
 pulseeffects (3.1.3-3) artful; urgency=low
 
   * fix dependency: calf-ladspa --> calf-plugins

--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,6 @@ Homepage: https://github.com/wwmm/pulseeffects
 Package: pulseeffects
 Architecture: all
 Depends: ${misc:Depends}, pulseaudio, python3, libgtk-3-0 (>= 3.18), python3-gi, python3-gi-cairo, gstreamer1.0-plugins-bad (>= 1.12), gstreamer1.0-plugins-good (>= 1.12), swh-plugins, python3-scipy (>= 0.18), python3-gst-1.0, gir1.2-gst-plugins-bad-1.0, gstreamer1.0-pulseaudio
-Recommends: liblilv-0-0, calf-plugins
+Recommends: liblilv-0-0, calf-plugins, zam-plugins
 Description: Sound input and output effects for PulseAudio
  Many sound effects for PulseAudio input and output.

--- a/debian/control
+++ b/debian/control
@@ -1,5 +1,5 @@
 Source: pulseeffects
-Section: Multimedia
+Section: sound
 Priority: optional
 Maintainer: Mikhail Novosyolov <mikhailnov@dumalogiya.ru>
 Build-Depends: debhelper (>=10), python3-cairo-dev, python-gi-dev, libgstreamer1.0-dev (>= 1.12), libgstreamer-plugins-bad1.0-dev (>=1.12), libpulse-dev, libpango1.0-dev, libgtk-3-dev (>= 3.18), meson (>=0.40), ninja-build, pkg-config

--- a/debian/control
+++ b/debian/control
@@ -1,5 +1,5 @@
 Source: pulseeffects
-Section: Audio
+Section: Multimedia
 Priority: optional
 Maintainer: Mikhail Novosyolov <mikhailnov@dumalogiya.ru>
 Build-Depends: debhelper (>=10), python3-cairo-dev, python-gi-dev, libgstreamer1.0-dev (>= 1.12), libgstreamer-plugins-bad1.0-dev (>=1.12), libpulse-dev, libpango1.0-dev, libgtk-3-dev (>= 3.18), meson (>=0.40), ninja-build, pkg-config


### PR DESCRIPTION
Added zam-plugins for the maximizer plugins, but I still get 
```00:19:02.249 - PulseEffects - WARNING - Stereo Spread plugin was not found. Disabling it!```
calf-plugins is a dependency, but it's version is 0.60 in Debian/Ubuntu vs 0.90 in Arch, is that plugin really from this package of a newer version? What is the file name of this plugin?
If yes, than it probably cannot be fixed easily right now and you can merge it, if there are other ideas, please don't merge it right now.