### PR TITLE
script to build and publish packages for the PPA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ debian/*
 !debian/pycompat
 !debian/rules
 !debian/source/format
+!debian/build-ppa.sh
 
 # Dolphin file manager creates the file .directory to save some folder-specific settings
 *.directory

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ These are community maintained repositories of distribution packages. You can
 find more information about these in the
 [wiki](https://github.com/wwmm/pulseeffects/wiki/Package-Repositories#package-repositories).
 
-- [Ubuntu and Debian](https://github.com/wwmm/pulseeffects/wiki/Package-Repositories#ubuntu-1710-and-newer-debian-9-and-newer)
+- [Ubuntu and Debian](https://github.com/wwmm/pulseeffects/wiki/Package-Repositories#debian--ubuntu)
 
 ### Flatpak
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ These are community maintained repositories of distribution packages. You can
 find more information about these in the
 [wiki](https://github.com/wwmm/pulseeffects/wiki/Package-Repositories#package-repositories).
 
-- [Ubuntu](https://github.com/wwmm/pulseeffects/wiki/Package-Repositories#ubuntu-1710-and-newer)
+- [Ubuntu and Debian](https://github.com/wwmm/pulseeffects/wiki/Package-Repositories#ubuntu-1710-and-newer-debian-9-and-newer)
 
 ### Flatpak
 

--- a/debian/build-ppa.sh
+++ b/debian/build-ppa.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # I use this script to build and publish deb packages in ppa:mikhailnov/pulseeffects (https://launchpad.net/~mikhailnov/+archive/ubuntu/pulseeffects)
 # I publish it to allow other people to use it and make it possible to maintain a new PPA easily in case I stop doing it for some reason
+# I think, it can also be used for maintaining packages in mainline Debian (minor modifications required)
 
 dir0="$(pwd)"
 old_header=$(head -1 ./changelog)
@@ -15,6 +16,9 @@ do
 	dpkg-buildpackage -S -sa
 	sed  -i -re "1s/.*/${old_header}/" ./debian/changelog
 	cd ..
+	# change ppa:mikhailnov/pulseeffects to your PPA at Launchpad.net
+	# you must add your public GPG key to Launchpad
+	# and add your public SSH key to Launchpad before running dput
 	dput -f ppa:mikhailnov/pulseeffects "$(ls -tr pulseeffects_*_source.changes | tail -n 1)" || exit 1
 	cd "${dir0}"
 	sleep 1

--- a/debian/build-ppa.sh
+++ b/debian/build-ppa.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# I use this script to build and publish deb packages in ppa:mikhailnov/pulseeffects (https://launchpad.net/~mikhailnov/+archive/ubuntu/pulseeffects)
+# I publish it to allow other people to use it and make it possible to maintain a new PPA easily in case I stop doing it for some reason
+
+dir0="$(pwd)"
+old_header=$(head -1 ./changelog)
+
+for i in artful bionic
+do
+	old_version="$(cat ./changelog | head -n 1 | awk -F "(" '{print $2}' | awk -F ")" '{print $1}')"
+	new_version="${old_version}~${i}1"
+	sed -i -re "s/${old_version}/${new_version}/g" ./changelog
+	sed -i -re "1s/unstable/$i/" ./changelog
+	cd ..
+	dpkg-buildpackage -S -sa
+	sed  -i -re "1s/.*/${old_header}/" ./debian/changelog
+	cd ..
+	dput -f ppa:mikhailnov/pulseeffects "$(ls -tr pulseeffects_*_source.changes | tail -n 1)" || exit 1
+	cd "${dir0}"
+	sleep 1
+done
+
+cd ..

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,72 +1,78 @@
-pulseeffects (3.1.6-2) artful; urgency=low
+pulseeffects (3.2.0-1) unstable; urgency=low
+
+  * update to version 3.2.0 upstream
+  
+ -- Mikhail Novosyolov <mikhailnov@dumalogiya.ru>  Tue, 13 Feb 2018 05:12:00 +0300 
+
+pulseeffects (3.1.6-2) unstable; urgency=low
 
   * update to version 3.1.6 upstream
   * add zam-plugins as a new dependency
   
  -- Mikhail Novosyolov <mikhailnov@dumalogiya.ru>  Sun, 21 Jan 2018 00:27:00 +0300 
 
-pulseeffects (3.1.3-3) artful; urgency=low
+pulseeffects (3.1.3-3) unstable; urgency=low
 
   * fix dependency: calf-ladspa --> calf-plugins
   
  -- Mikhail Novosyolov <mikhailnov@dumalogiya.ru>  Tue, 14 Dec 2017 20:02:00 +0300 
  
-pulseeffects (3.1.3-2) artful; urgency=low
+pulseeffects (3.1.3-2) unstable; urgency=low
 
   * Make the package architecture-independent
   
  -- Mikhail Novosyolov <mikhailnov@dumalogiya.ru>  Tue, 14 Dec 2017 19:51:00 +0300 
  
-pulseeffects (3.1.3) artful; urgency=low
+pulseeffects (3.1.3) unstable; urgency=low
 
   * Level meters: conversion from decibel to linear scale uses the correct factor
   * Auto volume: It is working in service mode and it does not reset the limiter
   
  -- Mikhail Novosyolov <mikhailnov@dumalogiya.ru>  Tue, 14 Dec 2017 19:43:00 +0300 
 
-pulseeffects (3.1.2-git131220170843msk) artful; urgency=low
+pulseeffects (3.1.2-git131220170843msk) unstable; urgency=low
 
   * add gstreamer1.0-pulseaudio as a dependency
 
  -- Mikhail Novosyolov <mikhailnov@dumalogiya.ru>  Wed, 13 Dec 2017 08:43:00 +0300 
  
-pulseeffects (3.1.2-git131220170732msk) artful; urgency=low
+pulseeffects (3.1.2-git131220170732msk) unstable; urgency=low
 
   * version 3.1.2 + latest Git
 
  -- Mikhail Novosyolov <mikhailnov@dumalogiya.ru>  Wed, 13 Dec 2017 07:33:00 +0300 
  
-pulseeffects (3.0.7.5) artful; urgency=low
+pulseeffects (3.0.7.5) unstable; urgency=low
 
   * fix 3.0.7.4 git merging
 
  -- Mikhail Novosyolov <mikhailnov@dumalogiya.ru>  Mon, 08 Nov 2017 22:21:00 +0300 
  
-pulseeffects (3.0.7.4) artful; urgency=low
+pulseeffects (3.0.7.4) unstable; urgency=low
 
   * = v3.0.7 upstream (synced with upstream versioning, all previous v3.0.7 here were v.3.0.6+git-master from upstream)
 
  -- Mikhail Novosyolov <mikhailnov@dumalogiya.ru>  Mon, 08 Nov 2017 22:21:00 +0300 
 
-pulseeffects (3.0.7.3) artful; urgency=high
+pulseeffects (3.0.7.3) unstable; urgency=high
 
   * Additional fixes for https://github.com/wwmm/pulseeffects/issues/111
 
  -- Mikhail Novosyolov <mikhailnov@dumalogiya.ru>  Mon, 08 Nov 2017 22:21:00 +0300 
  
-pulseeffects (3.0.7.2) artful; urgency=high
+pulseeffects (3.0.7.2) unstable; urgency=high
 
   * Fix https://github.com/wwmm/pulseeffects/issues/111 (loosing files while building the deb package)
 
  -- Mikhail Novosyolov <mikhailnov@dumalogiya.ru>  Mon, 06 Nov 2017 22:21:00 +0300 
  
-pulseeffects (3.0.7) artful; urgency=medium
+pulseeffects (3.0.7) unstable; urgency=medium
 
   * Add Russian (ru) localisation
 
  -- Mikhail Novosyolov <mikhailnov@dumalogiya.ru>  Mon, 06 Nov 2017 22:21:00 +0300 
 
-pulseeffects (3.0.6) artful; urgency=medium
+pulseeffects (3.0.6) unstable; urgency=medium
 
   * Package pulseeffects created
 


### PR DESCRIPTION
I suggest to have debian/build-ppa.sh upstreamed to make it easy for a new person to maintain the PulseEffects repository in case I stop doing it for some reason. Automation of publishing packages on Launchpad is not as obvious as it could be. Probably, it can also be used for mainline Debian packages.

There was a PPA with Pulseffects http://www.omgubuntu.co.uk/2017/06/install-pulse-effects-ubuntu-ppa but then the maintainer stopped updating it