### PR TITLE
Emphasize that PulseEffects is equalizer

### DIFF
--- a/data/com.github.wwmm.pulseeffects.desktop.in
+++ b/data/com.github.wwmm.pulseeffects.desktop.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=PulseEffects
-GenericName=Audio Enhancer
+GenericName=Audio Enhancer and Equalizer
 Comment=Audio Effects for PulseAudio Applications
 Keywords=limiter;compressor;reverberation;equalizer;autovolume;
 Categories=GTK;AudioVideo;Audio;

--- a/data/com.github.wwmm.pulseeffects.desktop.in
+++ b/data/com.github.wwmm.pulseeffects.desktop.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=PulseEffects
-GenericName=Audio Enhancer and Equalizer
+GenericName=Equalizer, Compressor and Other Audio Effects
 Comment=Audio Effects for PulseAudio Applications
 Keywords=limiter;compressor;reverberation;equalizer;autovolume;
 Categories=GTK;AudioVideo;Audio;


### PR DESCRIPTION
It might be not convenient for the ordinary user to find pulseeffects application from KDE/Gnome. I suggest we emphasize that PulseEffects is equalizer mostly. Eventually we will benefit once PulseEffects becomes a part of default set of applications installed with major distributions. Users will try to type in "equalizer" and will be able to find PulseEffects because "PulseEffects" is too technical (relates to pulseaudio), not everyone will know it / remember it.