### PR TITLE
POSIX shell /bin/sh instead of /bin/bash

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-pulseeffects (4.1.9-2) unstable; urgency=low
+pulseeffects (4.1.9-3) unstable; urgency=low
 
   * updated Russian translation
   

--- a/environmental_variables.sh
+++ b/environmental_variables.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 export GSETTINGS_SCHEMA_DIR=../../data/schemas/
 export GST_PLUGIN_PATH_1_0=convolver:crystalizer


### PR DESCRIPTION
Do not require bash for the script which is fully compatible with minimal POSIX shell

(`shellcheck` can be used to check the scripts, it checks for POSIX compatibility and no bashisms if the shebang id `#!/bin/sh`, `Geany` (build->lint) can be a GUI for `shellcheck`)
![deepinscreenshot_chromium-browser_20180721174526](https://user-images.githubusercontent.com/15802528/43036636-032eb4c6-8d0e-11e8-9eef-2f233c3ee343.png)
