### PR TITLE
v4.2.1 deb and UI changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ level.
 - Sometimes PulseEffects was not paused when there was no application playing
 audio. Fixed that.
 
+### Note for Packagers
+- 	libebur128-dev is now a build time dependency.
+
 ## [4.2.0]
 ### Added
 - We finally have plugins documentation and a few basic explanations about some

--- a/data/ui/autogain.glade
+++ b/data/ui/autogain.glade
@@ -143,7 +143,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
-                <property name="label" translatable="yes">Momentary</property>
+                <property name="label" translatable="yes">Influence of measurements with momentary integration time</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
@@ -156,7 +156,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
-                <property name="label" translatable="yes">Short Term</property>
+                <property name="label" translatable="yes">Influence of measurements with short integration time</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
@@ -169,7 +169,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
-                <property name="label" translatable="yes">Integrated</property>
+                <property name="label" translatable="yes">Influence of integrated measurements</property>
               </object>
               <packing>
                 <property name="left_attach">3</property>

--- a/data/ui/autogain.glade
+++ b/data/ui/autogain.glade
@@ -143,7 +143,9 @@
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
-                <property name="label" translatable="yes">Influence of measurements\nwith momentary\nintegration time</property>
+                <property name="label" translatable="yes">Influence of measurements with momentary integration time</property>
+                <property name="justify">center</property>
+                <property name="wrap">True</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
@@ -157,6 +159,8 @@
                 <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="label" translatable="yes">Influence of measurements with short integration time</property>
+                <property name="justify">center</property>
+                <property name="wrap">True</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
@@ -170,6 +174,8 @@
                 <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="label" translatable="yes">Influence of integrated measurements</property>
+                <property name="justify">center</property>
+                <property name="wrap">True</property>
               </object>
               <packing>
                 <property name="left_attach">3</property>
@@ -183,6 +189,8 @@
                 <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="label" translatable="yes">Target</property>
+                <property name="justify">center</property>
+                <property name="wrap">True</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>

--- a/data/ui/autogain.glade
+++ b/data/ui/autogain.glade
@@ -143,7 +143,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
-                <property name="label" translatable="yes">Influence of measurements with momentary integration time</property>
+                <property name="label" translatable="yes">Influence of measurements\nwith momentary\nintegration time</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+pulseeffects (4.2.1-1) unstable; urgency=low
+
+  * update to version 4.2.1 upstream
+  * fixed Russian localization
+  
+ -- Mikhail Novosyolov <mikhailnov@dumalogiya.ru>  Sun, 29 Jul 2018 12:54:00 +0300 
+
 pulseeffects (4.2.0-1) unstable; urgency=low
 
   * update to version 4.2.0 upstream

--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,8 @@ Build-Depends: debhelper (>=11),
                libzita-convolver-dev,
                libsndfile1-dev,
                libsamplerate0-dev,
-               itstool
+               itstool,
+               libebur128-dev
 
 Package: pulseeffects
 Architecture: any

--- a/debian/control
+++ b/debian/control
@@ -50,10 +50,8 @@ Depends: ${misc:Depends},
 Provides: peconvolver, gstreamer1.0-convolver
 Replaces: pulseeffects (<< 4.1.7-3)
 Description: Gstreamer convolver
- Gstreamer convolver plugin from PulseEffects.
- .
- Example command-line:
- gst-launch-1.0 audiotestsrc blocksize=512 ! peconvolver kernel-path=full_path_to_file ! pulsesink
+ Simple Gstreamer crystalizer plugin based on
+ the library Zita-convolver.
  
 Package: gstreamer1.0-crystalizer-pulseeffects
 Architecture: any
@@ -61,4 +59,14 @@ Depends: ${misc:Depends},
          ${shlibs:Depends}
 Provides: pecrystalizer, gstreamer1.0-crystalizer
 Description: Gstreamer crystalizer
- Gstreamer crystalizer plugin from PulseEffects.
+ Simple Gstreamer plugin useful to add more dynamic range
+ to songs that were overly compressed.
+ 
+Package: gstreamer1.0-autogain-pulseeffects
+Architecture: any
+Depends: ${misc:Depends},
+         ${shlibs:Depends}
+Provides: peautogain, gstreamer1.0-autogain
+Description: Gstreamer crystalizer
+ Simple Gstreamer plugin that changes audio gain
+ to match the levels recommended by the ebur128 standard.

--- a/debian/gstreamer1.0-autogain-pulseeffects.install
+++ b/debian/gstreamer1.0-autogain-pulseeffects.install
@@ -1,0 +1,1 @@
+usr/lib/*/gstreamer-1.0/libgstpeautogain.so

--- a/po/ru.po
+++ b/po/ru.po
@@ -235,8 +235,8 @@ msgid "Loudness"
 msgstr "Громкость"
 
 #: data/ui/autogain.glade:739
-msgid "Range"
 # ??? не уверен в переводе
+msgid "Range"
 msgstr "Диапазон"
 
 #: data/ui/limiter.glade:30 data/ui/webrtc.glade:377

--- a/po/ru.po
+++ b/po/ru.po
@@ -41,7 +41,7 @@ msgstr "Настройки"
 
 #: data/ui/application.glade:228
 msgid "Help"
-msgstr ""
+msgstr "Справка"
 
 #: data/ui/application.glade:251 data/ui/compressor.glade:205
 #: data/ui/filter.glade:203 data/ui/equalizer.glade:280
@@ -152,19 +152,36 @@ msgstr "Состояние"
 
 #: data/ui/autogain.glade:24
 msgid "Auto Gain"
-msgstr "Авто предусиление"
+msgstr "Контроль громкости по EBU R 128"
 
-#: data/ui/autogain.glade:146 data/ui/autogain.glade:496
+#: data/ui/autogain.glade:146
+# Время интеграции — это величина, характеризующая быстродействие измерителя.
+# https://tech.ebu.ch/docs/factsheets/Factsheet-R128-2011-RUS.pdf
+# В документе выше переводчик перевел 'Integrated' как 'Интегрированные',
+# хотя сам же написал, что это "измерения от начала до конца"
+# Яндекс.Переводчик перевел лучше — "Комплексные измерения"
+msgid "Influence of measurements with momentary integration time"
+msgstr "Влияние измерений с моментальным временем интеграции"
+
+#: data/ui/autogain.glade:159
+msgid "Influence of measurements with short integration time"
+msgstr "Влияние измерений с малым временем интеграции"
+
+#: data/ui/autogain.glade:172
+msgid "Influence of integrated measurements"
+msgstr "Влияние комплексных измерений"
+
+#: data/ui/autogain.glade:496
 msgid "Momentary"
-msgstr ""
+msgstr "Моментальные измерения"
 
-#: data/ui/autogain.glade:159 data/ui/autogain.glade:509
+#: data/ui/autogain.glade:509
 msgid "Short Term"
-msgstr ""
+msgstr "Короткие измерения"
 
-#: data/ui/autogain.glade:172 data/ui/autogain.glade:522
+#: data/ui/autogain.glade:522
 msgid "Integrated"
-msgstr ""
+msgstr "Комплексные измерения"
 
 #: data/ui/autogain.glade:185
 msgid "Target"
@@ -206,7 +223,7 @@ msgstr "Выход"
 
 #: data/ui/autogain.glade:610
 msgid "Relative"
-msgstr ""
+msgstr "Относительное значение"
 
 #: data/ui/autogain.glade:623 data/ui/deesser.glade:298
 msgid "Gain"
@@ -219,7 +236,8 @@ msgstr "Громкость"
 
 #: data/ui/autogain.glade:739
 msgid "Range"
-msgstr ""
+# ??? не уверен в переводе
+msgstr "Диапазон"
 
 #: data/ui/limiter.glade:30 data/ui/webrtc.glade:377
 msgid "Limiter"
@@ -703,7 +721,7 @@ msgstr "Баланс"
 
 #: data/ui/stereo_tools.glade:246
 msgid "S/C Level"
-msgstr ""
+msgstr "Уровень Раздельный/Центр"
 
 #: data/ui/stereo_tools.glade:275
 msgid "Softclip"
@@ -711,31 +729,31 @@ msgstr ""
 
 #: data/ui/stereo_tools.glade:325
 msgid "LR > LR (Stereo Default)"
-msgstr ""
+msgstr "Стерео"
 
 #: data/ui/stereo_tools.glade:326
 msgid "LR > MS (Stereo to Mid-Side)"
-msgstr ""
+msgstr "Стерео > Моно-Раздельно"
 
 #: data/ui/stereo_tools.glade:327
 msgid "MS > LR (Mid-Side to Stereo)"
-msgstr ""
+msgstr "Моно-Разделно > Стерео"
 
 #: data/ui/stereo_tools.glade:328
 msgid "LR > LL (Mono Left Channel)"
-msgstr ""
+msgstr "Стерео > Моно левый канал"
 
 #: data/ui/stereo_tools.glade:329
 msgid "LR > RR (Mono Right Channel)"
-msgstr ""
+msgstr "Стерео > Моно правый канал"
 
 #: data/ui/stereo_tools.glade:330
 msgid "LR > L+R (Mono Sum L+R)"
-msgstr ""
+msgstr "Стерео > Моно левый+правый каналы"
 
 #: data/ui/stereo_tools.glade:331
 msgid "LR > RL (Stereo Flip Channels)"
-msgstr ""
+msgstr "Стерео > Поменять каналы местами"
 
 #: data/ui/stereo_tools.glade:351
 msgid "Side Level"

--- a/po/ru.po
+++ b/po/ru.po
@@ -151,9 +151,8 @@ msgid "State"
 msgstr "Состояние"
 
 #: data/ui/autogain.glade:24
-#, fuzzy
 msgid "Auto Gain"
-msgstr "Уровень предусиления"
+msgstr "Авто предусиление"
 
 #: data/ui/autogain.glade:146 data/ui/autogain.glade:496
 msgid "Momentary"


### PR DESCRIPTION
* v4.2.1 debian package
* `gstreamer1.0-autogain-pulseeffects` package
* updated Russian localization
* you forgot to mansion `libebur128-dev` as a new build dependency 

* changes to UI: I tried to make the new 'Auto Gain' UI better understandable; did not update any .po files except ru.po, they should be updated after this change

![deepinscreenshot_pulseeffects_20180729145707](https://user-images.githubusercontent.com/15802528/43366087-014ead5e-9340-11e8-8471-7afd9dbc4e81.png)
![deepinscreenshot_pulseeffects_20180729145418](https://user-images.githubusercontent.com/15802528/43366094-07cd0f68-9340-11e8-806d-0885dc89c99b.png)
