### PR TITLE
Fix add-appdata-release utility

### DIFF
--- a/data/com.github.wwmm.pulseeffects.appdata.xml.in
+++ b/data/com.github.wwmm.pulseeffects.appdata.xml.in
@@ -57,6 +57,14 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="4.2.8" date="2018-08-14">
+      <description>
+        <p>Added:</p>
+        <ul>
+          <li>Latency introduced by the GStreamer pipeline is now displayed in the headerbar</li>
+        </ul>
+      </description>
+    </release>
     <release version="4.2.7" date="2018-08-12"/>
     <release version="4.2.6" date="2018-08-10"/>
     <release version="4.2.5" date="2018-08-09"/>

--- a/util/add-appdata-release.xsl
+++ b/util/add-appdata-release.xsl
@@ -21,8 +21,6 @@
       <release>
         <xsl:attribute name="version"><xsl:value-of select="$version"/></xsl:attribute>
         <xsl:attribute name="date"><xsl:value-of select="$date"/></xsl:attribute>
-        <description>
-        </description>
       </release>
       <xsl:apply-templates select="node()|@*"/>
     </releases>


### PR DESCRIPTION
The initial script had a fundamental issue; the application version and
release dates were based on git tags. Since this script needs to be run
before a release is tagged, that tag will never include an up-to-date
appdata file.

Versions are now parsed from the main meson.build file. It works well
but there is one limitation, the order of the key/value pairs "version"
and "meson_version" matters. If the order of those keys changes this
script would also require adjustments.

Dates are now provided by the `date` command, using the UTC setting.
This offers consistency since it also is not affected by day light
savings.

An added benefit of these changes is that less external commands are
now used.