### PR TITLE
Added rubberband pitch-shifting to sinks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Audio effects for Pulseaudio applications
 - Stereo Tools
 - Loudness
 - Maximizer
+- Pitch
 - Gate
 - Multiband Gate
 - Deesser

--- a/data/meson.build
+++ b/data/meson.build
@@ -17,6 +17,7 @@ install_data([
   'schemas/com.github.wwmm.pulseeffects.sinkinputs.crossfeed.gschema.xml',
   'schemas/com.github.wwmm.pulseeffects.sinkinputs.maximizer.gschema.xml',
   'schemas/com.github.wwmm.pulseeffects.sinkinputs.loudness.gschema.xml',
+  'schemas/com.github.wwmm.pulseeffects.sinkinputs.pitch.gschema.xml',
   'schemas/com.github.wwmm.pulseeffects.sinkinputs.gate.gschema.xml',
   'schemas/com.github.wwmm.pulseeffects.sinkinputs.multibandgate.gschema.xml',
   'schemas/com.github.wwmm.pulseeffects.sinkinputs.stereotools.gschema.xml',

--- a/data/schemas/com.github.wwmm.pulseeffects.sinkinputs.gschema.xml
+++ b/data/schemas/com.github.wwmm.pulseeffects.sinkinputs.gschema.xml
@@ -8,7 +8,7 @@
                 ["limiter","autogain","gate","multiband_gate","compressor",
                 "multiband_compressor","convolver","bass_enhancer","exciter",
                 "crystalizer","stereo_tools","reverb","equalizer","deesser",
-                "crossfeed","loudness","maximizer","filter"]
+                "crossfeed","loudness","maximizer","filter","pitch"]
             </default>
         </key>
     </schema>

--- a/data/schemas/com.github.wwmm.pulseeffects.sinkinputs.pitch.gschema.xml
+++ b/data/schemas/com.github.wwmm.pulseeffects.sinkinputs.pitch.gschema.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
     <schema
-        id="com.github.wwmm.pulseeffects.sourceoutputs.pitch"
-        path="/com/github/wwmm/pulseeffects/sourceoutputs/pitch/">
+        id="com.github.wwmm.pulseeffects.sinkinputs.pitch"
+        path="/com/github/wwmm/pulseeffects/sinkinputs/pitch/">
         <key name="state" type="b">
             <default>false</default>
         </key>
@@ -35,11 +35,11 @@
             <default>false</default>
         </key>
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1"/>
+            <range min="-20.0" max="20.0"/>
             <default>0.0</default>
         </key>
         <key name="output-gain" type="d">
-            <range min="-36.1" max="36.1"/>
+            <range min="-20.0" max="20.0"/>
             <default>0.0</default>
         </key>
     </schema>

--- a/include/pitch_preset.hpp
+++ b/include/pitch_preset.hpp
@@ -11,7 +11,7 @@ class PitchPreset : public PluginPresetBase {
   void read(boost::property_tree::ptree& root) override;
 
  private:
-  Glib::RefPtr<Gio::Settings> input_settings;
+  Glib::RefPtr<Gio::Settings> input_settings, output_settings;
 
   void save(boost::property_tree::ptree& root,
             const std::string& section,

--- a/include/sink_input_effects.hpp
+++ b/include/sink_input_effects.hpp
@@ -12,6 +12,7 @@
 #include "exciter.hpp"
 #include "filter.hpp"
 #include "gate.hpp"
+#include "pitch.hpp"
 #include "limiter.hpp"
 #include "loudness.hpp"
 #include "maximizer.hpp"
@@ -46,6 +47,7 @@ class SinkInputEffects : public PipelineBase {
   std::unique_ptr<MultibandCompressor> multiband_compressor;
   std::unique_ptr<Loudness> loudness;
   std::unique_ptr<Gate> gate;
+  std::unique_ptr<Pitch> pitch;
   std::unique_ptr<MultibandGate> multiband_gate;
   std::unique_ptr<Deesser> deesser;
   std::unique_ptr<StereoTools> stereo_tools;
@@ -57,6 +59,8 @@ class SinkInputEffects : public PipelineBase {
   sigc::signal<void, std::array<double, 2>> compressor_output_level;
   sigc::signal<void, std::array<double, 2>> equalizer_input_level;
   sigc::signal<void, std::array<double, 2>> equalizer_output_level;
+  sigc::signal<void, std::array<double, 2>> pitch_input_level;
+  sigc::signal<void, std::array<double, 2>> pitch_output_level;
   sigc::signal<void, std::array<double, 2>> bass_enhancer_input_level;
   sigc::signal<void, std::array<double, 2>> bass_enhancer_output_level;
   sigc::signal<void, std::array<double, 2>> exciter_input_level;

--- a/include/sink_input_effects_ui.hpp
+++ b/include/sink_input_effects_ui.hpp
@@ -14,6 +14,7 @@
 #include "exciter_ui.hpp"
 #include "filter_ui.hpp"
 #include "gate_ui.hpp"
+#include "pitch_ui.hpp"
 #include "limiter_ui.hpp"
 #include "loudness_ui.hpp"
 #include "maximizer_ui.hpp"
@@ -45,6 +46,7 @@ class SinkInputEffectsUi : public Gtk::Box, public EffectsBaseUi {
   CompressorUi* compressor_ui;
   FilterUi* filter_ui;
   EqualizerUi* equalizer_ui;
+  PitchUi* pitch_ui;
   ReverbUi* reverb_ui;
   BassEnhancerUi* bass_enhancer_ui;
   ExciterUi* exciter_ui;

--- a/src/pitch_preset.cpp
+++ b/src/pitch_preset.cpp
@@ -2,7 +2,9 @@
 
 PitchPreset::PitchPreset()
     : input_settings(Gio::Settings::create(
-          "com.github.wwmm.pulseeffects.sourceoutputs.pitch")) {}
+          "com.github.wwmm.pulseeffects.sourceoutputs.pitch")),
+      output_settings(Gio::Settings::create(
+          "com.github.wwmm.pulseeffects.sinkinputs.pitch")) {}
 
 void PitchPreset::save(boost::property_tree::ptree& root,
                        const std::string& section,
@@ -44,8 +46,10 @@ void PitchPreset::load(boost::property_tree::ptree& root,
 
 void PitchPreset::write(boost::property_tree::ptree& root) {
   save(root, "input", input_settings);
+  save(root, "output", output_settings);
 }
 
 void PitchPreset::read(boost::property_tree::ptree& root) {
   load(root, "input", input_settings);
+  load(root, "output", output_settings);
 }

--- a/src/sink_input_effects.cpp
+++ b/src/sink_input_effects.cpp
@@ -12,6 +12,10 @@ void on_message_element(const GstBus* gst_bus,
     sie->compressor_input_level.emit(sie->get_peak(message));
   } else if (src_name == std::string("compressor_output_level")) {
     sie->compressor_output_level.emit(sie->get_peak(message));
+  } else if (src_name == std::string("pitch_input_level")) {
+    sie->pitch_input_level.emit(sie->get_peak(message));
+  } else if (src_name == std::string("pitch_output_level")) {
+    sie->pitch_output_level.emit(sie->get_peak(message));
   } else if (src_name == std::string("equalizer_input_level")) {
     sie->equalizer_input_level.emit(sie->get_peak(message));
   } else if (src_name == std::string("equalizer_output_level")) {
@@ -264,6 +268,8 @@ SinkInputEffects::SinkInputEffects(PulseManager* pulse_manager)
       log_tag, "com.github.wwmm.pulseeffects.sinkinputs.loudness");
   gate = std::make_unique<Gate>(log_tag,
                                 "com.github.wwmm.pulseeffects.sinkinputs.gate");
+  pitch = std::make_unique<Pitch>(
+      log_tag, "com.github.wwmm.pulseeffects.sinkinputs.pitch");
   multiband_gate = std::make_unique<MultibandGate>(
       log_tag, "com.github.wwmm.pulseeffects.sinkinputs.multibandgate");
   deesser = std::make_unique<Deesser>(
@@ -290,6 +296,7 @@ SinkInputEffects::SinkInputEffects(PulseManager* pulse_manager)
       std::make_pair(multiband_compressor->name, multiband_compressor->plugin));
   plugins.insert(std::make_pair(loudness->name, loudness->plugin));
   plugins.insert(std::make_pair(gate->name, gate->plugin));
+  plugins.insert(std::make_pair(pitch->name, pitch->plugin));
   plugins.insert(std::make_pair(multiband_gate->name, multiband_gate->plugin));
   plugins.insert(std::make_pair(deesser->name, deesser->plugin));
   plugins.insert(std::make_pair(stereo_tools->name, stereo_tools->plugin));

--- a/src/sink_input_effects_ui.cpp
+++ b/src/sink_input_effects_ui.cpp
@@ -18,6 +18,8 @@ SinkInputEffectsUi::SinkInputEffectsUi(
       "/com/github/wwmm/pulseeffects/ui/filter.glade");
   auto b_equalizer = Gtk::Builder::create_from_resource(
       "/com/github/wwmm/pulseeffects/ui/equalizer.glade");
+  auto b_pitch = Gtk::Builder::create_from_resource(
+      "/com/github/wwmm/pulseeffects/ui/pitch.glade");
   auto b_reverb = Gtk::Builder::create_from_resource(
       "/com/github/wwmm/pulseeffects/ui/reverb.glade");
   auto b_bass_enhancer = Gtk::Builder::create_from_resource(
@@ -61,6 +63,9 @@ SinkInputEffectsUi::SinkInputEffectsUi(
       "com.github.wwmm.pulseeffects.sinkinputs.equalizer",
       "com.github.wwmm.pulseeffects.sinkinputs.equalizer.leftchannel",
       "com.github.wwmm.pulseeffects.sinkinputs.equalizer.rightchannel");
+  b_pitch->get_widget_derived(
+      "widgets_grid", pitch_ui,
+      "com.github.wwmm.pulseeffects.sinkinputs.pitch");
   b_reverb->get_widget_derived(
       "widgets_grid", reverb_ui,
       "com.github.wwmm.pulseeffects.sinkinputs.reverb");
@@ -107,6 +112,7 @@ SinkInputEffectsUi::SinkInputEffectsUi(
   stack->add(*compressor_ui, compressor_ui->name);
   stack->add(*filter_ui, filter_ui->name);
   stack->add(*equalizer_ui, equalizer_ui->name);
+  stack->add(*pitch_ui, pitch_ui->name);
   stack->add(*reverb_ui, reverb_ui->name);
   stack->add(*bass_enhancer_ui, bass_enhancer_ui->name);
   stack->add(*exciter_ui, exciter_ui->name);
@@ -128,6 +134,7 @@ SinkInputEffectsUi::SinkInputEffectsUi(
   add_to_listbox(compressor_ui);
   add_to_listbox(filter_ui);
   add_to_listbox(equalizer_ui);
+  add_to_listbox(pitch_ui);
   add_to_listbox(reverb_ui);
   add_to_listbox(bass_enhancer_ui);
   add_to_listbox(exciter_ui);
@@ -202,6 +209,13 @@ void SinkInputEffectsUi::level_meters_connections() {
       sigc::mem_fun(*equalizer_ui, &EqualizerUi::on_new_input_level_db)));
   connections.push_back(sie->equalizer_output_level.connect(
       sigc::mem_fun(*equalizer_ui, &EqualizerUi::on_new_output_level_db)));
+
+  // pitch level meters connections
+
+  connections.push_back(sie->pitch_input_level.connect(
+      sigc::mem_fun(*pitch_ui, &PitchUi::on_new_input_level_db)));
+  connections.push_back(sie->pitch_output_level.connect(
+      sigc::mem_fun(*pitch_ui, &PitchUi::on_new_output_level_db)));
 
   // reverb level meters connections
 
@@ -421,6 +435,11 @@ void SinkInputEffectsUi::up_down_connections() {
       [=]() { on_up(filter_ui); }));
   connections.push_back(filter_ui->plugin_down->signal_clicked().connect(
       [=]() { on_down(filter_ui); }));
+
+  connections.push_back(pitch_ui->plugin_up->signal_clicked().connect(
+      [=]() { on_up(pitch_ui); }));
+  connections.push_back(pitch_ui->plugin_down->signal_clicked().connect(
+      [=]() { on_down(pitch_ui); }));
 
   connections.push_back(equalizer_ui->plugin_up->signal_clicked().connect(
       [=]() { on_up(equalizer_ui); }));


### PR DESCRIPTION
Hey. I play in a few bands and it's quite common to transpose the songs to different pitches. I noticed pulseeffects on Phoronix and was excited as it had rubberband in it. But noticed it was only for recording. I did some copy-pasting and got it working for output also. This is really nice for singing / playing along with the songs in a different key. 

Couldn't get the faster-option to work, but also didn't get it to do
anything in sourceoutputs.