### PR TITLE
small fix to IT help, readme improved and added yelp opt dep to PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -14,7 +14,8 @@ optdepends=('calf: limiter, compressor exciter, bass enhancer and others'
             'zam-plugins: maximizer'
             'rubberband: pitch shifting'
             'lsp-plugins: equalizer, delay'
-            'mda.lv2: loudness')
+            'mda.lv2: loudness'
+            'yelp: documentation')
 makedepends=('meson' 'boost' 'itstool')
 options=(!emptydirs)
 provides=("${_pkgname}")

--- a/README.md
+++ b/README.md
@@ -64,8 +64,6 @@ Version 1.12.5 or higher
 - [zita-convolver](https://kokkinizita.linuxaudio.org/linuxaudio/)
 - [libebur128](https://github.com/jiixyj/libebur128)
 
-To be able to read documentation inside the GUI, you need [yelp](https://gitlab.gnome.org/GNOME/yelp) package.
-
 ## Changelog
 - For information about changes between versions take a look at our
 [changelog](https://github.com/wwmm/pulseeffects/blob/master/CHANGELOG.md)
@@ -103,6 +101,11 @@ flatpak install flathub com.github.wwmm.pulseeffects
 #### Installing from source
 
 See the wiki: [Installing from Source](https://github.com/wwmm/pulseeffects/wiki/Installation-from-Source), for detailed instructions.
+
+## Documentation
+
+PulseEffects documentation can be read inside the GUI installing 
+[yelp](https://gitlab.gnome.org/GNOME/yelp) package.
 
 ## Frequently asked questions
 

--- a/help/it_IT/it_IT.po
+++ b/help/it_IT/it_IT.po
@@ -187,7 +187,6 @@ msgstr "Soglia"
 
 #. (itstool) path: item/p
 #: C/compressor.page:45
-#, fuzzy
 msgid "If a signal surpass this level it will trigger the compression stage."
 msgstr "Se il segnale supera il valore specificato, verrà applicata la compressione. "
 "In modalità discendente, il segnale verrà ridotto in ampiezza se salirà oltre la "
@@ -1695,7 +1694,7 @@ msgstr "Fattore di qualità."
 #. (itstool) path: page/title
 #: C/pitch.page:9
 msgid "Pitch"
-msgstr "Intonazione"
+msgstr "Pitch"
 
 #. (itstool) path: page/p
 #: C/pitch.page:10
@@ -2117,7 +2116,7 @@ msgid ""
 "automatically switch on the per application switch that can be seen in the "
 "Applications entry."
 msgstr ""
-"Applica effetti all'ingresso(microfono) di tutte le applicazioni audio. "
+"Applica effetti all'ingresso (microfono) di tutte le applicazioni audio. "
 "Questa opzione attiverà automaticamente il selettore di tutti i programmi in "
 "registrazione elencati nella voce Applicazioni."
 
@@ -2549,8 +2548,8 @@ msgid ""
 "audio volume to a perceived loudness level that can be tweaked by the user."
 msgstr ""
 "Il Normalizzatore di PulseEffects si basa sulla libreria libebur128. Questo "
-"plugin modifica il volume dell'audio basandosi su un livello di intensità "
-"percepita che può essere regolato dall'utente."
+"plugin modifica il volume dell'audio basandosi su un livello di Loudness "
+"(intensità del volume) percepito che può essere regolato dall'utente."
 
 #. (itstool) path: title/em
 #: C/autogain.page:17


### PR DESCRIPTION
- Due to a `fuzzy` row, Italian translation for Compressor threshold in documentation was not showing correctly.
- Other small grammatical fix to Italian documentation.
- Added yelp optional dependency to AUR PKGBUILD
- Made a separate section for Documentation inside README file

Compilation done.