### PR TITLE
Add nullptr check for server_info.channel_map

### DIFF
--- a/src/pulse_manager.cpp
+++ b/src/pulse_manager.cpp
@@ -332,7 +332,12 @@ void PulseManager::update_server_info(const pa_server_info* info) {
   server_info.format = pa_sample_format_to_string(info->sample_spec.format);
   server_info.rate = info->sample_spec.rate;
   server_info.channels = info->sample_spec.channels;
-  server_info.channel_map = pa_channel_map_to_pretty_name(&info->channel_map);
+  if (pa_channel_map_to_pretty_name(&info->channel_map) != nullptr) {
+      server_info.channel_map = pa_channel_map_to_pretty_name(&info->channel_map)
+  }
+  else {
+      server_info.channel_map = "unknown";
+  }
 }
 
 void PulseManager::get_server_info() {

--- a/src/pulse_manager.cpp
+++ b/src/pulse_manager.cpp
@@ -333,7 +333,7 @@ void PulseManager::update_server_info(const pa_server_info* info) {
   server_info.rate = info->sample_spec.rate;
   server_info.channels = info->sample_spec.channels;
   if (pa_channel_map_to_pretty_name(&info->channel_map) != nullptr) {
-      server_info.channel_map = pa_channel_map_to_pretty_name(&info->channel_map)
+      server_info.channel_map = pa_channel_map_to_pretty_name(&info->channel_map);
   }
   else {
       server_info.channel_map = "unknown";


### PR DESCRIPTION
Pulseaudio API states that pa_channel_map_to_pretty_name will return NULL for unknown pretty names.
This results in a SEGV for me.
Fix by checking if pa_channel_map_to_pretty_name eventually is NULL.