### PR TITLE
Fix build with GCC 10

### DIFF
--- a/include/plugin_base.hpp
+++ b/include/plugin_base.hpp
@@ -4,6 +4,7 @@
 #include <gio/gio.h>
 #include <gst/gst.h>
 #include <sigc++/sigc++.h>
+#include <string>
 
 class PluginBase {
  public:


### PR DESCRIPTION
This fix gcc 10 build error:
```
../include/plugin_base.hpp:10:25: error: expected ')' before 'tag'
   10 |   PluginBase(std::string tag, std::string plugin_name, const std::string& schema);
      |             ~           ^~~~
      |                         )
../include/plugin_base.hpp:17:8: error: 'string' in namespace 'std' does not name a type
   17 |   std::string log_tag, name;
      |        ^~~~~~
../include/plugin_base.hpp:7:1: note: 'std::string' is defined in header '<string>'; did you forget to '#include <string>'?
```