### PR TITLE
support for system configs

### DIFF
--- a/include/presets_manager.hpp
+++ b/include/presets_manager.hpp
@@ -39,6 +39,7 @@ class PresetsManager {
   ~PresetsManager();
 
   auto get_names(PresetType preset_type) -> std::vector<std::string>;
+  auto search_names(boost::filesystem::directory_iterator& it) -> std::vector<std::string>;
   void add(PresetType preset_type, const std::string& name);
   void save(PresetType preset_type, const std::string& name);
   void remove(PresetType preset_type, const std::string& name);
@@ -53,7 +54,10 @@ class PresetsManager {
  private:
   std::string log_tag = "presets_manager: ";
 
-  boost::filesystem::path presets_dir, input_dir, output_dir, autoload_dir;
+  boost::filesystem::path user_presets_dir, user_input_dir, user_output_dir,
+    autoload_dir;
+
+  std::vector<boost::filesystem::path> system_input_dirs, system_output_dirs;
 
   Glib::RefPtr<Gio::Settings> settings, sie_settings, soe_settings;
 
@@ -127,7 +131,7 @@ class PresetsManager {
     return a != b;
   }
 
-  void create_directory(boost::filesystem::path& path);
+  void create_user_directory(boost::filesystem::path& path);
 
   void save_blacklist(PresetType preset_type, boost::property_tree::ptree& root);
 

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -6,9 +6,9 @@
 #include "util.hpp"
 
 PresetsManager::PresetsManager()
-    : presets_dir(Glib::get_user_config_dir() + "/PulseEffects"),
-      input_dir(Glib::get_user_config_dir() + "/PulseEffects/input"),
-      output_dir(Glib::get_user_config_dir() + "/PulseEffects/output"),
+    : user_presets_dir(Glib::get_user_config_dir() + "/PulseEffects"),
+      user_input_dir(Glib::get_user_config_dir() + "/PulseEffects/input"),
+      user_output_dir(Glib::get_user_config_dir() + "/PulseEffects/output"),
       autoload_dir(Glib::get_user_config_dir() + "/PulseEffects/autoload"),
       settings(Gio::Settings::create("com.github.wwmm.pulseeffects")),
       sie_settings(Gio::Settings::create("com.github.wwmm.pulseeffects.sinkinputs")),
@@ -35,17 +35,23 @@ PresetsManager::PresetsManager()
       autogain(std::make_unique<AutoGainPreset>()),
       delay(std::make_unique<DelayPreset>()),
       spectrum(std::make_unique<SpectrumPreset>()) {
-  create_directory(presets_dir);
-  create_directory(input_dir);
-  create_directory(output_dir);
-  create_directory(autoload_dir);
+  // system presets directories
+  for (auto& scd : Glib::get_system_config_dirs()) {
+    system_input_dirs.push_back(scd + "/PulseEffects/input");
+    system_output_dirs.push_back(scd + "/PulseEffects/output");
+  }
+
+  create_user_directory(user_presets_dir);
+  create_user_directory(user_input_dir);
+  create_user_directory(user_output_dir);
+  create_user_directory(autoload_dir);
 }
 
 PresetsManager::~PresetsManager() {
   util::debug(log_tag + "destroyed");
 }
 
-void PresetsManager::create_directory(boost::filesystem::path& path) {
+void PresetsManager::create_user_directory(boost::filesystem::path& path) {
   auto dir_exists = boost::filesystem::is_directory(path);
 
   if (!dir_exists) {
@@ -63,22 +69,52 @@ void PresetsManager::create_directory(boost::filesystem::path& path) {
 auto PresetsManager::get_names(PresetType preset_type) -> std::vector<std::string> {
   boost::filesystem::directory_iterator it;
   std::vector<std::string> names;
+  std::vector<boost::filesystem::path> sys_dirs;
 
+  // system directories search
   if (preset_type == PresetType::output) {
-    it = boost::filesystem::directory_iterator{output_dir};
+    sys_dirs.insert(sys_dirs.end(), system_output_dirs.begin(), system_output_dirs.end());
   } else {
-    it = boost::filesystem::directory_iterator{input_dir};
+    sys_dirs.insert(sys_dirs.end(), system_input_dirs.begin(), system_input_dirs.end());
   }
 
-  while (it != boost::filesystem::directory_iterator{}) {
-    if (boost::filesystem::is_regular_file(it->status())) {
-      if (it->path().extension().string() == ".json") {
-        names.push_back(it->path().stem().string());
+  for (auto& dir : sys_dirs) {
+    it = boost::filesystem::directory_iterator{dir};
+    auto vn = search_names(it);
+    names.insert(names.end(), vn.begin(), vn.end());
+  }
+
+  // user directory search
+  if (preset_type == PresetType::output) {
+    it = boost::filesystem::directory_iterator{user_output_dir};
+  } else {
+    it = boost::filesystem::directory_iterator{user_input_dir};
+  }
+  auto vn = search_names(it);
+  names.insert(names.end(), vn.begin(), vn.end());
+
+  // removing duplicates
+  std::sort(names.begin(), names.end());
+  names.erase(std::unique(names.begin(), names.end()), names.end());
+
+  return names;
+}
+
+auto PresetsManager::search_names(boost::filesystem::directory_iterator& it)
+                                              -> std::vector<std::string> {
+  std::vector<std::string> names;
+
+  try {
+    while (it != boost::filesystem::directory_iterator{}) {
+      if (boost::filesystem::is_regular_file(it->status())) {
+        if (it->path().extension().string() == ".json") {
+          names.push_back(it->path().stem().string());
+        }
       }
-    }
 
-    it++;
-  }
+      it++;
+    }
+  } catch (std::exception & e) {}
 
   return names;
 }
@@ -170,7 +206,7 @@ void PresetsManager::save(PresetType preset_type, const std::string& name) {
 
     root.add_child("output.plugins_order", node_out);
 
-    output_file = output_dir / boost::filesystem::path{name + ".json"};
+    output_file = user_output_dir / boost::filesystem::path{name + ".json"};
   } else {
     std::vector<std::string> input_plugins = soe_settings->get_string_array("plugins");
 
@@ -182,7 +218,7 @@ void PresetsManager::save(PresetType preset_type, const std::string& name) {
 
     root.add_child("input.plugins_order", node_in);
 
-    output_file = input_dir / boost::filesystem::path{name + ".json"};
+    output_file = user_input_dir / boost::filesystem::path{name + ".json"};
   }
 
   bass_enhancer->write(preset_type, root);
@@ -216,9 +252,9 @@ void PresetsManager::remove(PresetType preset_type, const std::string& name) {
   boost::filesystem::path preset_file;
 
   if (preset_type == PresetType::output) {
-    preset_file = output_dir / boost::filesystem::path{name + ".json"};
+    preset_file = user_output_dir / boost::filesystem::path{name + ".json"};
   } else {
-    preset_file = input_dir / boost::filesystem::path{name + ".json"};
+    preset_file = user_input_dir / boost::filesystem::path{name + ".json"};
   }
 
   if (boost::filesystem::exists(preset_file)) {
@@ -232,10 +268,25 @@ void PresetsManager::load(PresetType preset_type, const std::string& name) {
   boost::property_tree::ptree root;
   std::vector<std::string> input_plugins;
   std::vector<std::string> output_plugins;
+  std::vector<boost::filesystem::path> conf_dirs;
   boost::filesystem::path input_file;
+  bool preset_found = false;
 
   if (preset_type == PresetType::output) {
-    input_file = output_dir / boost::filesystem::path{name + ".json"};
+    conf_dirs.push_back(user_output_dir);
+    conf_dirs.insert(conf_dirs.end(), system_output_dirs.begin(), system_output_dirs.end());
+
+    for (auto& dir : conf_dirs) {
+      input_file = dir / boost::filesystem::path{name + ".json"};
+      if (boost::filesystem::exists(input_file)) {
+        preset_found = true;
+        break;
+      }
+    }
+
+    if (!preset_found) {
+      util::debug("can't found the preset " + name + " on the filesystem");
+    }
 
     try {
       boost::property_tree::read_json(input_file.string(), root);
@@ -264,13 +315,24 @@ void PresetsManager::load(PresetType preset_type, const std::string& name) {
       Glib::Variant<std::vector<std::string>> aux;
       sie_settings->get_default_value("plugins", aux);
       output_plugins = aux.get();
-    } catch (std::exception & e) {
-      util::debug("an error occurred during the parsing of the preset file");
     }
 
     sie_settings->set_string_array("plugins", output_plugins);
   } else {
-    input_file = input_dir / boost::filesystem::path{name + ".json"};
+    conf_dirs.push_back(user_input_dir);
+    conf_dirs.insert(conf_dirs.end(), system_input_dirs.begin(), system_input_dirs.end());
+
+    for (auto& dir : conf_dirs) {
+      input_file = dir / boost::filesystem::path{name + ".json"};
+      if (boost::filesystem::exists(input_file)) {
+        preset_found = true;
+        break;
+      }
+    }
+
+    if (!preset_found) {
+      util::debug("can't found the preset " + name + " on the filesystem");
+    }
 
     try {
       boost::property_tree::read_json(input_file.string(), root);
@@ -299,8 +361,6 @@ void PresetsManager::load(PresetType preset_type, const std::string& name) {
       Glib::Variant<std::vector<std::string>> aux;
       soe_settings->get_default_value("plugins", aux);
       input_plugins = aux.get();
-    } catch (std::exception & e) {
-      util::debug("an error occurred during the parsing of the preset file");    
     }
 
     soe_settings->set_string_array("plugins", input_plugins);
@@ -342,9 +402,9 @@ void PresetsManager::import(PresetType preset_type, const std::string& file_path
       boost::filesystem::path out_path;
 
       if (preset_type == PresetType::output) {
-        out_path = output_dir / p.filename();
+        out_path = user_output_dir / p.filename();
       } else {
-        out_path = input_dir / p.filename();
+        out_path = user_input_dir / p.filename();
       }
 
       boost::filesystem::copy_file(p, out_path, boost::filesystem::copy_option::overwrite_if_exists);
@@ -415,14 +475,30 @@ void PresetsManager::autoload(PresetType preset_type, const std::string& device)
 
 auto PresetsManager::preset_file_exists(PresetType preset_type, const std::string& name) -> bool {
   boost::filesystem::path input_file;
+  std::vector<boost::filesystem::path> conf_dirs;
 
   if (preset_type == PresetType::output) {
-    input_file = output_dir / boost::filesystem::path{name + ".json"};
+    conf_dirs.push_back(user_output_dir);
+    conf_dirs.insert(conf_dirs.end(), system_output_dirs.begin(), system_output_dirs.end());
 
-    return boost::filesystem::exists(input_file);
+    for (auto& dir : conf_dirs) {
+      input_file = dir / boost::filesystem::path{name + ".json"};
+      if (boost::filesystem::exists(input_file)) {
+        return true;
+        break;
+      }
+    }
+  } else {
+    conf_dirs.push_back(user_input_dir);
+    conf_dirs.insert(conf_dirs.end(), system_input_dirs.begin(), system_input_dirs.end());
+
+    for (auto& dir : conf_dirs) {
+      input_file = dir / boost::filesystem::path{name + ".json"};
+      if (boost::filesystem::exists(input_file)) {
+        return true;
+      }
+    }
   }
 
-  input_file = input_dir / boost::filesystem::path{name + ".json"};
-
-  return boost::filesystem::exists(input_file);
+  return false;
 }

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -79,9 +79,11 @@ auto PresetsManager::get_names(PresetType preset_type) -> std::vector<std::strin
   }
 
   for (auto& dir : sys_dirs) {
-    it = boost::filesystem::directory_iterator{dir};
-    auto vn = search_names(it);
-    names.insert(names.end(), vn.begin(), vn.end());
+    if (boost::filesystem::exists(dir)) {
+      it = boost::filesystem::directory_iterator{dir};
+      auto vn = search_names(it);
+      names.insert(names.end(), vn.begin(), vn.end());
+    }
   }
 
   // user directory search

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -487,7 +487,6 @@ auto PresetsManager::preset_file_exists(PresetType preset_type, const std::strin
       input_file = dir / boost::filesystem::path{name + ".json"};
       if (boost::filesystem::exists(input_file)) {
         return true;
-        break;
       }
     }
   } else {


### PR DESCRIPTION
PresetsManager class modified to support system global presets. Related to #657.

Search for presets located under folders returned by  `Glib::get_system_config_dirs`. I thought it was `/etc`, but is `/ect/xdg` or what's specified by `$XDG_CONFIG_DIRS` environment variable as reported in [xdg specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

It seems not really used, if we want to default to /etc/PulseEffects, then we can specify a vector with `/etc`.

If there are duplicates, user preset is chosen over system one. System presets can't be removed, but if one is saved, a copy is created inside user folder.

Successfully compiled and tested, at least on my system.