### PR TITLE
Plugin credits

### DIFF
--- a/data/ui/autogain.glade
+++ b/data/ui/autogain.glade
@@ -901,7 +901,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">libebur128</property>
+                <property name="label" translatable="no">libebur128</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>

--- a/data/ui/autogain.glade
+++ b/data/ui/autogain.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkImage" id="image1">
@@ -877,6 +877,46 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">5</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Provided by</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">libebur128</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">6</property>
           </packing>
         </child>
       </object>

--- a/data/ui/bass_enhancer.glade
+++ b/data/ui/bass_enhancer.glade
@@ -636,7 +636,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Calf Studio Gears</property>
+                <property name="label" translatable="no">Calf Studio Gears</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>

--- a/data/ui/bass_enhancer.glade
+++ b/data/ui/bass_enhancer.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="amount">
@@ -612,6 +612,46 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Provided by</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Calf Studio Gears</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
           </packing>
         </child>
       </object>

--- a/data/ui/compressor.glade
+++ b/data/ui/compressor.glade
@@ -737,7 +737,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="input_level_left1">
+              <object class="GtkLevelBar" id="input_level_left">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -749,7 +749,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="input_level_left_label1">
+              <object class="GtkLabel" id="input_level_left_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -777,7 +777,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="input_level_right_label1">
+              <object class="GtkLabel" id="input_level_right_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -793,7 +793,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="input_level_right1">
+              <object class="GtkLevelBar" id="input_level_right">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -805,7 +805,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_left1">
+              <object class="GtkLevelBar" id="output_level_left">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -817,7 +817,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_right1">
+              <object class="GtkLevelBar" id="output_level_right">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -829,7 +829,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_left_label1">
+              <object class="GtkLabel" id="output_level_left_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -844,7 +844,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_right_label1">
+              <object class="GtkLabel" id="output_level_right_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -859,7 +859,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="reduction1">
+              <object class="GtkLevelBar" id="reduction">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -874,7 +874,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="reduction_label1">
+              <object class="GtkLabel" id="reduction_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -915,7 +915,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="sidechain1">
+              <object class="GtkLevelBar" id="sidechain">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -929,7 +929,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="sidechain_label1">
+              <object class="GtkLabel" id="sidechain_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -991,7 +991,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="curve1">
+              <object class="GtkLevelBar" id="curve">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -1005,7 +1005,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="curve_label1">
+              <object class="GtkLabel" id="curve_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>

--- a/data/ui/compressor.glade
+++ b/data/ui/compressor.glade
@@ -1048,7 +1048,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Linux Studio Plugins</property>
+                <property name="label" translatable="no">Linux Studio Plugins</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>

--- a/data/ui/compressor.glade
+++ b/data/ui/compressor.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="attack">
@@ -714,7 +714,6 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -729,7 +728,6 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>
@@ -739,7 +737,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="input_level_left">
+              <object class="GtkLevelBar" id="input_level_left1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -751,7 +749,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="input_level_left_label">
+              <object class="GtkLabel" id="input_level_left_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -779,7 +777,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="input_level_right_label">
+              <object class="GtkLabel" id="input_level_right_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -795,7 +793,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="input_level_right">
+              <object class="GtkLevelBar" id="input_level_right1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -807,7 +805,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_left">
+              <object class="GtkLevelBar" id="output_level_left1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -819,7 +817,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_right">
+              <object class="GtkLevelBar" id="output_level_right1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -831,7 +829,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_left_label">
+              <object class="GtkLabel" id="output_level_left_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -846,7 +844,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_right_label">
+              <object class="GtkLabel" id="output_level_right_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -861,7 +859,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="reduction">
+              <object class="GtkLevelBar" id="reduction1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -876,7 +874,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="reduction_label">
+              <object class="GtkLabel" id="reduction_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -896,7 +894,6 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
                 <property name="label" translatable="yes">Gain</property>
               </object>
               <packing>
@@ -918,7 +915,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="sidechain">
+              <object class="GtkLevelBar" id="sidechain1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -932,7 +929,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="sidechain_label">
+              <object class="GtkLabel" id="sidechain_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -994,7 +991,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="curve">
+              <object class="GtkLevelBar" id="curve1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -1008,7 +1005,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="curve_label">
+              <object class="GtkLabel" id="curve_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -1020,6 +1017,46 @@
                 <property name="left_attach">3</property>
                 <property name="top_attach">4</property>
                 <property name="width">3</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Provided by</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Linux Studio Plugins</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>

--- a/data/ui/crossfeed.glade
+++ b/data/ui/crossfeed.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="fcut">
@@ -349,6 +349,46 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Provided by</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">bs2b</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/data/ui/crossfeed.glade
+++ b/data/ui/crossfeed.glade
@@ -373,7 +373,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">bs2b</property>
+                <property name="label" translatable="no">bs2b</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>

--- a/data/ui/deesser.glade
+++ b/data/ui/deesser.glade
@@ -822,7 +822,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Calf Studio Gears</property>
+                <property name="label" translatable="no">Calf Studio Gears</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>

--- a/data/ui/deesser.glade
+++ b/data/ui/deesser.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="f1_freq">
@@ -798,6 +798,46 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Provided by</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Calf Studio Gears</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
           </packing>
         </child>
       </object>

--- a/data/ui/delay.glade
+++ b/data/ui/delay.glade
@@ -142,7 +142,6 @@
                 <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="width_chars">10</property>
-                <property name="text" translatable="yes">0,00</property>
                 <property name="secondary_icon_name">pulseeffects-ms-symbolic</property>
                 <property name="secondary_icon_activatable">False</property>
                 <property name="input_purpose">number</property>
@@ -175,7 +174,6 @@
                 <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="width_chars">10</property>
-                <property name="text" translatable="yes">0,00</property>
                 <property name="secondary_icon_name">pulseeffects-ms-symbolic</property>
                 <property name="secondary_icon_activatable">False</property>
                 <property name="input_purpose">number</property>
@@ -231,7 +229,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="input_level_left_label1">
+              <object class="GtkLabel" id="input_level_left_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -259,7 +257,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="input_level_right_label1">
+              <object class="GtkLabel" id="input_level_right_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -275,7 +273,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_left_label1">
+              <object class="GtkLabel" id="output_level_left_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -290,7 +288,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_right_label1">
+              <object class="GtkLabel" id="output_level_right_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -305,7 +303,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="input_level_left1">
+              <object class="GtkLevelBar" id="input_level_left">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -317,7 +315,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="input_level_right1">
+              <object class="GtkLevelBar" id="input_level_right">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -329,7 +327,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_left1">
+              <object class="GtkLevelBar" id="output_level_left">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -341,7 +339,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_right1">
+              <object class="GtkLevelBar" id="output_level_right">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>

--- a/data/ui/delay.glade
+++ b/data/ui/delay.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkImage" id="image1">
@@ -142,6 +142,7 @@
                 <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="width_chars">10</property>
+                <property name="text" translatable="yes">0,00</property>
                 <property name="secondary_icon_name">pulseeffects-ms-symbolic</property>
                 <property name="secondary_icon_activatable">False</property>
                 <property name="input_purpose">number</property>
@@ -174,6 +175,7 @@
                 <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="width_chars">10</property>
+                <property name="text" translatable="yes">0,00</property>
                 <property name="secondary_icon_name">pulseeffects-ms-symbolic</property>
                 <property name="secondary_icon_activatable">False</property>
                 <property name="input_purpose">number</property>
@@ -192,7 +194,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
@@ -206,7 +208,6 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -221,7 +222,6 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>
@@ -231,7 +231,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="input_level_left_label">
+              <object class="GtkLabel" id="input_level_left_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -259,7 +259,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="input_level_right_label">
+              <object class="GtkLabel" id="input_level_right_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -275,7 +275,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_left_label">
+              <object class="GtkLabel" id="output_level_left_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -290,7 +290,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_right_label">
+              <object class="GtkLabel" id="output_level_right_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -305,7 +305,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="input_level_left">
+              <object class="GtkLevelBar" id="input_level_left1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -317,7 +317,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="input_level_right">
+              <object class="GtkLevelBar" id="input_level_right1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -329,7 +329,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_left">
+              <object class="GtkLevelBar" id="output_level_left1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -341,7 +341,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_right">
+              <object class="GtkLevelBar" id="output_level_right1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -384,6 +384,46 @@
                 <property name="left_attach">1</property>
                 <property name="top_attach">2</property>
                 <property name="height">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Provided by</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Linux Studio Plugins</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>

--- a/data/ui/delay.glade
+++ b/data/ui/delay.glade
@@ -413,7 +413,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Linux Studio Plugins</property>
+                <property name="label" translatable="no">Linux Studio Plugins</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>

--- a/data/ui/equalizer.glade
+++ b/data/ui/equalizer.glade
@@ -716,7 +716,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Linux Studio Plugins</property>
+                <property name="label" translatable="no">Linux Studio Plugins</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>

--- a/data/ui/equalizer.glade
+++ b/data/ui/equalizer.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkImage" id="image1">
@@ -332,12 +332,6 @@
       </object>
     </child>
   </object>
-  <object class="GtkAdjustment" id="output_gain">
-    <property name="lower">-20</property>
-    <property name="upper">20</property>
-    <property name="step_increment">0.01</property>
-    <property name="page_increment">0.01</property>
-  </object>
   <object class="GtkGrid" id="widgets_grid">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -401,14 +395,14 @@
                 <property name="vexpand">True</property>
                 <property name="shadow_type">none</property>
                 <child>
-                  <object class="GtkStack" id="stack">
+                  <object class="GtkStack" id="stack1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="vexpand">True</property>
                     <property name="transition_duration">250</property>
                     <property name="transition_type">slide-left-right</property>
                     <child>
-                      <object class="GtkGrid" id="bands_grid_left">
+                      <object class="GtkGrid" id="bands_grid_left1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">center</property>
@@ -449,7 +443,7 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkGrid" id="bands_grid_right">
+                      <object class="GtkGrid" id="bands_grid_right1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">center</property>
@@ -498,7 +492,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">3</property>
+            <property name="position">2</property>
           </packing>
         </child>
         <child>
@@ -527,7 +521,6 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_left">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>
@@ -537,7 +530,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="input_level_left_label">
+              <object class="GtkLabel" id="input_level_left_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -553,7 +546,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="input_level_right_label">
+              <object class="GtkLabel" id="input_level_right_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -569,7 +562,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_left_label">
+              <object class="GtkLabel" id="output_level_left_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -585,7 +578,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_right_label">
+              <object class="GtkLabel" id="output_level_right_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -613,7 +606,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="input_level_right">
+              <object class="GtkLevelBar" id="input_level_right1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">start</property>
@@ -625,7 +618,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_right">
+              <object class="GtkLevelBar" id="output_level_right1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">start</property>
@@ -637,7 +630,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="input_level_left">
+              <object class="GtkLevelBar" id="input_level_left1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">end</property>
@@ -649,7 +642,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_left">
+              <object class="GtkLevelBar" id="output_level_left1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">end</property>
@@ -698,6 +691,46 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Provided by</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Linux Studio Plugins</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">4</property>
           </packing>
         </child>
@@ -719,5 +752,11 @@
         <property name="top_attach">0</property>
       </packing>
     </child>
+  </object>
+  <object class="GtkAdjustment" id="output_gain">
+    <property name="lower">-20</property>
+    <property name="upper">20</property>
+    <property name="step_increment">0.01</property>
+    <property name="page_increment">0.01</property>
   </object>
 </interface>

--- a/data/ui/equalizer.glade
+++ b/data/ui/equalizer.glade
@@ -395,14 +395,14 @@
                 <property name="vexpand">True</property>
                 <property name="shadow_type">none</property>
                 <child>
-                  <object class="GtkStack" id="stack1">
+                  <object class="GtkStack" id="stack">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="vexpand">True</property>
                     <property name="transition_duration">250</property>
                     <property name="transition_type">slide-left-right</property>
                     <child>
-                      <object class="GtkGrid" id="bands_grid_left1">
+                      <object class="GtkGrid" id="bands_grid_left">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">center</property>
@@ -443,7 +443,7 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkGrid" id="bands_grid_right1">
+                      <object class="GtkGrid" id="bands_grid_right">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">center</property>
@@ -530,7 +530,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="input_level_left_label1">
+              <object class="GtkLabel" id="input_level_left_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -546,7 +546,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="input_level_right_label1">
+              <object class="GtkLabel" id="input_level_right_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -562,7 +562,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_left_label1">
+              <object class="GtkLabel" id="output_level_left_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -578,7 +578,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_right_label1">
+              <object class="GtkLabel" id="output_level_right_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -606,7 +606,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="input_level_right1">
+              <object class="GtkLevelBar" id="input_level_right">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">start</property>
@@ -618,7 +618,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_right1">
+              <object class="GtkLevelBar" id="output_level_right">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">start</property>
@@ -630,7 +630,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="input_level_left1">
+              <object class="GtkLevelBar" id="input_level_left">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">end</property>
@@ -642,7 +642,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_left1">
+              <object class="GtkLevelBar" id="output_level_left">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">end</property>

--- a/data/ui/exciter.glade
+++ b/data/ui/exciter.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="amount">
@@ -616,6 +616,46 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Provided by</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Calf Studio Gears</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
           </packing>
         </child>
       </object>

--- a/data/ui/exciter.glade
+++ b/data/ui/exciter.glade
@@ -640,7 +640,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Calf Studio Gears</property>
+                <property name="label" translatable="no">Calf Studio Gears</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>

--- a/data/ui/filter.glade
+++ b/data/ui/filter.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="frequency">
@@ -549,6 +549,46 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Provided by</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Calf Studio Gears</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
           </packing>
         </child>
       </object>

--- a/data/ui/filter.glade
+++ b/data/ui/filter.glade
@@ -573,7 +573,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Calf Studio Gears</property>
+                <property name="label" translatable="no">Calf Studio Gears</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>

--- a/data/ui/gate.glade
+++ b/data/ui/gate.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="attack">
@@ -676,6 +676,46 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Provided by</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Calf Studio Gears</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/data/ui/gate.glade
+++ b/data/ui/gate.glade
@@ -700,7 +700,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Calf Studio Gears</property>
+                <property name="label" translatable="no">Calf Studio Gears</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>

--- a/data/ui/limiter.glade
+++ b/data/ui/limiter.glade
@@ -578,7 +578,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Calf Studio Gears</property>
+                <property name="label" translatable="no">Calf Studio Gears</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>

--- a/data/ui/limiter.glade
+++ b/data/ui/limiter.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="asc_level">
@@ -554,6 +554,46 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Provided by</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Calf Studio Gears</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/data/ui/loudness.glade
+++ b/data/ui/loudness.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkImage" id="image1">
@@ -139,6 +139,7 @@
                 <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="width_chars">10</property>
+                <property name="text" translatable="yes">-3,10</property>
                 <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
                 <property name="secondary_icon_activatable">False</property>
                 <property name="input_purpose">number</property>
@@ -147,6 +148,7 @@
                 <property name="digits">2</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
+                <property name="value">-3.1000000000000001</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -173,6 +175,7 @@
                 <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="width_chars">10</property>
+                <property name="text" translatable="yes">-6,00</property>
                 <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
                 <property name="secondary_icon_activatable">False</property>
                 <property name="input_purpose">number</property>
@@ -181,6 +184,7 @@
                 <property name="digits">2</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
+                <property name="value">-6</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
@@ -207,6 +211,7 @@
                 <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="width_chars">10</property>
+                <property name="text" translatable="yes">0,00</property>
                 <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
                 <property name="secondary_icon_activatable">False</property>
                 <property name="input_purpose">number</property>
@@ -215,7 +220,6 @@
                 <property name="digits">2</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
-                <property name="value">4.5</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
@@ -226,7 +230,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
@@ -240,7 +244,6 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -255,7 +258,6 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>
@@ -265,7 +267,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="input_level_left">
+              <object class="GtkLevelBar" id="input_level_left1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -277,7 +279,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="input_level_left_label">
+              <object class="GtkLabel" id="input_level_left_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -305,7 +307,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="input_level_right_label">
+              <object class="GtkLabel" id="input_level_right_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -321,7 +323,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="input_level_right">
+              <object class="GtkLevelBar" id="input_level_right1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -333,7 +335,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_left">
+              <object class="GtkLevelBar" id="output_level_left1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -345,7 +347,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_right">
+              <object class="GtkLevelBar" id="output_level_right1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -357,7 +359,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_left_label">
+              <object class="GtkLabel" id="output_level_left_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -372,7 +374,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_right_label">
+              <object class="GtkLabel" id="output_level_right_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -384,6 +386,46 @@
                 <property name="left_attach">4</property>
                 <property name="top_attach">2</property>
                 <property name="height">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Provided by</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">MDA VST LV2</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>

--- a/data/ui/loudness.glade
+++ b/data/ui/loudness.glade
@@ -139,7 +139,6 @@
                 <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="width_chars">10</property>
-                <property name="text" translatable="yes">-3,10</property>
                 <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
                 <property name="secondary_icon_activatable">False</property>
                 <property name="input_purpose">number</property>
@@ -148,7 +147,6 @@
                 <property name="digits">2</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
-                <property name="value">-3.1000000000000001</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -175,7 +173,6 @@
                 <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="width_chars">10</property>
-                <property name="text" translatable="yes">-6,00</property>
                 <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
                 <property name="secondary_icon_activatable">False</property>
                 <property name="input_purpose">number</property>
@@ -184,7 +181,6 @@
                 <property name="digits">2</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
-                <property name="value">-6</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
@@ -211,7 +207,6 @@
                 <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="width_chars">10</property>
-                <property name="text" translatable="yes">0,00</property>
                 <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
                 <property name="secondary_icon_activatable">False</property>
                 <property name="input_purpose">number</property>
@@ -220,6 +215,7 @@
                 <property name="digits">2</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
+                <property name="value">4.5</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
@@ -267,7 +263,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="input_level_left1">
+              <object class="GtkLevelBar" id="input_level_left">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -279,7 +275,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="input_level_left_label1">
+              <object class="GtkLabel" id="input_level_left_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -307,7 +303,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="input_level_right_label1">
+              <object class="GtkLabel" id="input_level_right_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -323,7 +319,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="input_level_right1">
+              <object class="GtkLevelBar" id="input_level_right">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -335,7 +331,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_left1">
+              <object class="GtkLevelBar" id="output_level_left">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -347,7 +343,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_right1">
+              <object class="GtkLevelBar" id="output_level_right">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -359,7 +355,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_left_label1">
+              <object class="GtkLabel" id="output_level_left_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -374,7 +370,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_right_label1">
+              <object class="GtkLabel" id="output_level_right_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>

--- a/data/ui/loudness.glade
+++ b/data/ui/loudness.glade
@@ -413,7 +413,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">MDA VST LV2</property>
+                <property name="label" translatable="no">MDA VST LV2</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>

--- a/data/ui/maximizer.glade
+++ b/data/ui/maximizer.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="ceiling">
@@ -131,6 +131,32 @@
               </packing>
             </child>
             <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes">Ceiling</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes">Release</property>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkSpinButton">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -147,39 +173,6 @@
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes">Ceiling</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSpinButton">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="width_chars">10</property>
-                <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
-                <property name="secondary_icon_activatable">False</property>
-                <property name="input_purpose">number</property>
-                <property name="orientation">vertical</property>
-                <property name="adjustment">ceiling</property>
-                <property name="numeric">True</property>
-                <property name="update_policy">if-valid</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
                 <property name="top_attach">1</property>
               </packing>
             </child>
@@ -205,16 +198,23 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel">
+              <object class="GtkSpinButton">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can_focus">True</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
-                <property name="label" translatable="yes">Release</property>
+                <property name="width_chars">10</property>
+                <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
+                <property name="secondary_icon_activatable">False</property>
+                <property name="input_purpose">number</property>
+                <property name="orientation">vertical</property>
+                <property name="adjustment">ceiling</property>
+                <property name="numeric">True</property>
+                <property name="update_policy">if-valid</property>
               </object>
               <packing>
-                <property name="left_attach">2</property>
-                <property name="top_attach">0</property>
+                <property name="left_attach">1</property>
+                <property name="top_attach">1</property>
               </packing>
             </child>
           </object>
@@ -396,20 +396,6 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="reduction">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="valign">center</property>
-                <property name="margin_top">4</property>
-                <property name="hexpand">True</property>
-                <property name="max_value">40</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">4</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkLabel" id="reduction_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
@@ -424,11 +410,65 @@
                 <property name="width">3</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkLevelBar" id="reduction">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="valign">center</property>
+                <property name="margin_top">4</property>
+                <property name="hexpand">True</property>
+                <property name="max_value">40</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">4</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Provided by</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">ZamAudio</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/data/ui/maximizer.glade
+++ b/data/ui/maximizer.glade
@@ -453,7 +453,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">ZamAudio</property>
+                <property name="label" translatable="no">ZamAudio</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>

--- a/data/ui/multiband_compressor.glade
+++ b/data/ui/multiband_compressor.glade
@@ -2163,7 +2163,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Calf Studio Gear</property>
+                <property name="label" translatable="no">Calf Studio Gears</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>

--- a/data/ui/multiband_compressor.glade
+++ b/data/ui/multiband_compressor.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="attack0">
@@ -2139,6 +2139,46 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Provided by</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Calf Studio Gear</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/data/ui/multiband_gate.glade
+++ b/data/ui/multiband_gate.glade
@@ -2312,7 +2312,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Calf Studio Gears</property>
+                <property name="label" translatable="no">Calf Studio Gears</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>

--- a/data/ui/multiband_gate.glade
+++ b/data/ui/multiband_gate.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="attack0">
@@ -2288,6 +2288,46 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Provided by</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Calf Studio Gears</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/data/ui/pitch.glade
+++ b/data/ui/pitch.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="cents">
@@ -502,6 +502,46 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Provided by</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Rubber Band</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/data/ui/reverb.glade
+++ b/data/ui/reverb.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="amount">
@@ -811,6 +811,46 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Provided by</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Calf Studio Gears</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/data/ui/reverb.glade
+++ b/data/ui/reverb.glade
@@ -835,7 +835,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Calf Studio Gears</property>
+                <property name="label" translatable="no">Calf Studio Gears</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>

--- a/data/ui/stereo_tools.glade
+++ b/data/ui/stereo_tools.glade
@@ -1010,7 +1010,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Calf Studio Gears</property>
+                <property name="label" translatable="no">Calf Studio Gears</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>

--- a/data/ui/stereo_tools.glade
+++ b/data/ui/stereo_tools.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="balance_in">
@@ -986,6 +986,46 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Provided by</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Calf Studio Gears</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/data/ui/webrtc.glade
+++ b/data/ui/webrtc.glade
@@ -459,7 +459,6 @@
                             <property name="can_focus">True</property>
                             <property name="halign">center</property>
                             <property name="width_chars">10</property>
-                            <property name="text" translatable="yes">9</property>
                             <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
@@ -795,7 +794,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">WebRTC</property>
+                <property name="label" translatable="no">WebRTC</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>

--- a/data/ui/webrtc.glade
+++ b/data/ui/webrtc.glade
@@ -119,7 +119,7 @@
             <property name="halign">center</property>
             <property name="row_spacing">18</property>
             <child>
-              <object class="GtkStack" id="stack1">
+              <object class="GtkStack" id="stack">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="transition_duration">250</property>
@@ -133,7 +133,7 @@
                     <property name="row_spacing">18</property>
                     <property name="column_homogeneous">True</property>
                     <child>
-                      <object class="GtkToggleButton" id="echo_cancel1">
+                      <object class="GtkToggleButton" id="echo_cancel">
                         <property name="label" translatable="yes">Enable</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -154,7 +154,7 @@
                         <property name="column_spacing">6</property>
                         <property name="column_homogeneous">True</property>
                         <child>
-                          <object class="GtkToggleButton" id="extended_filter1">
+                          <object class="GtkToggleButton" id="extended_filter">
                             <property name="label" translatable="yes">Extended Filter</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
@@ -167,7 +167,7 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkToggleButton" id="delay_agnostic1">
+                          <object class="GtkToggleButton" id="delay_agnostic">
                             <property name="label" translatable="yes">Delay Agnostic</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
@@ -179,7 +179,7 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkToggleButton" id="high_pass_filter1">
+                          <object class="GtkToggleButton" id="high_pass_filter">
                             <property name="label" translatable="yes">High Pass Filter</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
@@ -217,7 +217,7 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkComboBoxText" id="echo_suppression_level1">
+                          <object class="GtkComboBoxText" id="echo_suppression_level">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="valign">center</property>
@@ -253,7 +253,7 @@
                     <property name="row_spacing">18</property>
                     <property name="column_homogeneous">True</property>
                     <child>
-                      <object class="GtkToggleButton" id="noise_suppression1">
+                      <object class="GtkToggleButton" id="noise_suppression">
                         <property name="label" translatable="yes">Enable</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -285,7 +285,7 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkComboBoxText" id="noise_suppression_level1">
+                          <object class="GtkComboBoxText" id="noise_suppression_level">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="valign">center</property>
@@ -323,7 +323,7 @@
                     <property name="row_spacing">18</property>
                     <property name="column_homogeneous">True</property>
                     <child>
-                      <object class="GtkToggleButton" id="gain_control1">
+                      <object class="GtkToggleButton" id="gain_control">
                         <property name="label" translatable="yes">Enable</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -355,7 +355,7 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkComboBoxText" id="gain_control_mode1">
+                          <object class="GtkComboBoxText" id="gain_control_mode">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="valign">center</property>
@@ -391,7 +391,7 @@
                     <property name="row_spacing">18</property>
                     <property name="column_homogeneous">True</property>
                     <child>
-                      <object class="GtkToggleButton" id="limiter1">
+                      <object class="GtkToggleButton" id="limiter">
                         <property name="label" translatable="yes">Limiter</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -429,7 +429,6 @@
                             <property name="can_focus">True</property>
                             <property name="halign">center</property>
                             <property name="width_chars">10</property>
-                            <property name="text" translatable="yes">3</property>
                             <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
@@ -467,7 +466,6 @@
                             <property name="adjustment">compression_gain_db</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
-                            <property name="value">9</property>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
@@ -496,7 +494,7 @@
                     <property name="row_spacing">18</property>
                     <property name="column_homogeneous">True</property>
                     <child>
-                      <object class="GtkToggleButton" id="voice_detection1">
+                      <object class="GtkToggleButton" id="voice_detection">
                         <property name="label" translatable="yes">Enable</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -543,7 +541,7 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkComboBoxText" id="voice_detection_likelihood1">
+                          <object class="GtkComboBoxText" id="voice_detection_likelihood">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="valign">center</property>
@@ -565,13 +563,11 @@
                             <property name="can_focus">True</property>
                             <property name="valign">center</property>
                             <property name="width_chars">10</property>
-                            <property name="text" translatable="yes">10</property>
                             <property name="secondary_icon_name">pulseeffects-ms-symbolic</property>
                             <property name="input_purpose">number</property>
                             <property name="adjustment">voice_detection_frame_size</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
-                            <property name="value">10</property>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
@@ -649,7 +645,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="input_level_left1">
+              <object class="GtkLevelBar" id="input_level_left">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -661,7 +657,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="input_level_left_label1">
+              <object class="GtkLabel" id="input_level_left_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -689,7 +685,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="input_level_right_label1">
+              <object class="GtkLabel" id="input_level_right_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -705,7 +701,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="input_level_right1">
+              <object class="GtkLevelBar" id="input_level_right">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -717,7 +713,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_left1">
+              <object class="GtkLevelBar" id="output_level_left">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -729,7 +725,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_right1">
+              <object class="GtkLevelBar" id="output_level_right">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -741,7 +737,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_left_label1">
+              <object class="GtkLabel" id="output_level_left_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -756,7 +752,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_right_label1">
+              <object class="GtkLabel" id="output_level_right_label">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>

--- a/data/ui/webrtc.glade
+++ b/data/ui/webrtc.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="compression_gain_db">
@@ -119,7 +119,7 @@
             <property name="halign">center</property>
             <property name="row_spacing">18</property>
             <child>
-              <object class="GtkStack" id="stack">
+              <object class="GtkStack" id="stack1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="transition_duration">250</property>
@@ -133,7 +133,7 @@
                     <property name="row_spacing">18</property>
                     <property name="column_homogeneous">True</property>
                     <child>
-                      <object class="GtkToggleButton" id="echo_cancel">
+                      <object class="GtkToggleButton" id="echo_cancel1">
                         <property name="label" translatable="yes">Enable</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -154,7 +154,7 @@
                         <property name="column_spacing">6</property>
                         <property name="column_homogeneous">True</property>
                         <child>
-                          <object class="GtkToggleButton" id="extended_filter">
+                          <object class="GtkToggleButton" id="extended_filter1">
                             <property name="label" translatable="yes">Extended Filter</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
@@ -167,7 +167,7 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkToggleButton" id="delay_agnostic">
+                          <object class="GtkToggleButton" id="delay_agnostic1">
                             <property name="label" translatable="yes">Delay Agnostic</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
@@ -179,7 +179,7 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkToggleButton" id="high_pass_filter">
+                          <object class="GtkToggleButton" id="high_pass_filter1">
                             <property name="label" translatable="yes">High Pass Filter</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
@@ -217,7 +217,7 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkComboBoxText" id="echo_suppression_level">
+                          <object class="GtkComboBoxText" id="echo_suppression_level1">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="valign">center</property>
@@ -253,7 +253,7 @@
                     <property name="row_spacing">18</property>
                     <property name="column_homogeneous">True</property>
                     <child>
-                      <object class="GtkToggleButton" id="noise_suppression">
+                      <object class="GtkToggleButton" id="noise_suppression1">
                         <property name="label" translatable="yes">Enable</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -285,7 +285,7 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkComboBoxText" id="noise_suppression_level">
+                          <object class="GtkComboBoxText" id="noise_suppression_level1">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="valign">center</property>
@@ -323,7 +323,7 @@
                     <property name="row_spacing">18</property>
                     <property name="column_homogeneous">True</property>
                     <child>
-                      <object class="GtkToggleButton" id="gain_control">
+                      <object class="GtkToggleButton" id="gain_control1">
                         <property name="label" translatable="yes">Enable</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -355,7 +355,7 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkComboBoxText" id="gain_control_mode">
+                          <object class="GtkComboBoxText" id="gain_control_mode1">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="valign">center</property>
@@ -391,7 +391,7 @@
                     <property name="row_spacing">18</property>
                     <property name="column_homogeneous">True</property>
                     <child>
-                      <object class="GtkToggleButton" id="limiter">
+                      <object class="GtkToggleButton" id="limiter1">
                         <property name="label" translatable="yes">Limiter</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -429,12 +429,14 @@
                             <property name="can_focus">True</property>
                             <property name="halign">center</property>
                             <property name="width_chars">10</property>
+                            <property name="text" translatable="yes">3</property>
                             <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">target_level_dbfs</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
+                            <property name="value">3</property>
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
@@ -458,12 +460,14 @@
                             <property name="can_focus">True</property>
                             <property name="halign">center</property>
                             <property name="width_chars">10</property>
+                            <property name="text" translatable="yes">9</property>
                             <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">compression_gain_db</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
+                            <property name="value">9</property>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
@@ -492,7 +496,7 @@
                     <property name="row_spacing">18</property>
                     <property name="column_homogeneous">True</property>
                     <child>
-                      <object class="GtkToggleButton" id="voice_detection">
+                      <object class="GtkToggleButton" id="voice_detection1">
                         <property name="label" translatable="yes">Enable</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -539,7 +543,7 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkComboBoxText" id="voice_detection_likelihood">
+                          <object class="GtkComboBoxText" id="voice_detection_likelihood1">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="valign">center</property>
@@ -561,11 +565,13 @@
                             <property name="can_focus">True</property>
                             <property name="valign">center</property>
                             <property name="width_chars">10</property>
+                            <property name="text" translatable="yes">10</property>
                             <property name="secondary_icon_name">pulseeffects-ms-symbolic</property>
                             <property name="input_purpose">number</property>
                             <property name="adjustment">voice_detection_frame_size</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
+                            <property name="value">10</property>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
@@ -606,7 +612,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
@@ -620,7 +626,6 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -635,7 +640,6 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>
@@ -645,7 +649,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="input_level_left">
+              <object class="GtkLevelBar" id="input_level_left1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -657,7 +661,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="input_level_left_label">
+              <object class="GtkLabel" id="input_level_left_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -685,7 +689,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="input_level_right_label">
+              <object class="GtkLabel" id="input_level_right_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -701,7 +705,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="input_level_right">
+              <object class="GtkLevelBar" id="input_level_right1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -713,7 +717,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_left">
+              <object class="GtkLevelBar" id="output_level_left1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -725,7 +729,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_right">
+              <object class="GtkLevelBar" id="output_level_right1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -737,7 +741,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_left_label">
+              <object class="GtkLabel" id="output_level_left_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -752,7 +756,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_right_label">
+              <object class="GtkLabel" id="output_level_right_label1">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
@@ -764,6 +768,46 @@
                 <property name="left_attach">4</property>
                 <property name="top_attach">2</property>
                 <property name="height">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Provided by</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">WebRTC</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>

--- a/po/cs.po
+++ b/po/cs.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-28 14:03-0300\n"
+"POT-Creation-Date: 2020-05-02 00:54+0200\n"
 "PO-Revision-Date: 2019-08-25 21:29+0200\n"
 "Last-Translator: Pavel Fric <pavelfric@seznam.cz>\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
@@ -45,7 +45,7 @@ msgstr "Nápověda"
 #: data/ui/application.glade:200 data/ui/filter.glade:204
 #: data/ui/equalizer.glade:309 data/ui/reverb.glade:284
 #: data/ui/crossfeed.glade:47 src/presets_menu_ui.cpp:115
-#: src/presets_menu_ui.cpp:274 src/presets_menu_ui.cpp:291
+#: src/presets_menu_ui.cpp:278 src/presets_menu_ui.cpp:295
 msgid "Presets"
 msgstr "Přednastavení"
 
@@ -327,37 +327,37 @@ msgid "Weights"
 msgstr "Váhy"
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:718
+#: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:244 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:487
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
-#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:210
+#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
 #: data/ui/presets_menu.glade:255
 msgid "Input"
 msgstr "Vstup"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:733
+#: data/ui/limiter.glade:380 data/ui/compressor.glade:731
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:531 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:259 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
 #: data/ui/convolver.glade:492 data/ui/crystalizer.glade:243
-#: data/ui/pitch.glade:336 data/ui/webrtc.glade:639 data/ui/delay.glade:225
+#: data/ui/pitch.glade:336 data/ui/webrtc.glade:638 data/ui/delay.glade:223
 #: data/ui/presets_menu.glade:146
 msgid "Output"
 msgstr "Výstup"
@@ -366,7 +366,7 @@ msgstr "Výstup"
 msgid "Relative"
 msgstr "Relativní"
 
-#: data/ui/autogain.glade:721 data/ui/compressor.glade:900
+#: data/ui/autogain.glade:721 data/ui/compressor.glade:897
 #: data/ui/deesser.glade:295
 msgid "Gain"
 msgstr "Zesílení"
@@ -379,6 +379,18 @@ msgstr "Hlasitost"
 #: data/ui/autogain.glade:840
 msgid "Range"
 msgstr "Rozsah"
+
+#: data/ui/autogain.glade:892 data/ui/limiter.glade:569
+#: data/ui/compressor.glade:1039 data/ui/multiband_compressor.glade:2154
+#: data/ui/filter.glade:564 data/ui/equalizer.glade:707
+#: data/ui/reverb.glade:826 data/ui/bass_enhancer.glade:627
+#: data/ui/exciter.glade:631 data/ui/stereo_tools.glade:1001
+#: data/ui/crossfeed.glade:364 data/ui/maximizer.glade:444
+#: data/ui/loudness.glade:404 data/ui/gate.glade:691
+#: data/ui/multiband_gate.glade:2303 data/ui/deesser.glade:813
+#: data/ui/pitch.glade:517 data/ui/webrtc.glade:785 data/ui/delay.glade:404
+msgid "Provided by"
+msgstr ""
 
 #: data/ui/limiter.glade:30 data/ui/webrtc.glade:395
 msgid "Limiter"
@@ -396,7 +408,7 @@ msgstr "Omezení"
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
-#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:213
+#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
 #: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
@@ -420,7 +432,7 @@ msgid "Attenuation"
 msgstr "Tlumení"
 
 #: data/ui/compressor.glade:30 data/ui/compressor.glade:442
-#: data/ui/webrtc.glade:482 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
+#: data/ui/webrtc.glade:483 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
 msgid "Compressor"
 msgstr "Kompresor"
 
@@ -552,12 +564,12 @@ msgstr "Střední"
 msgid "Side"
 msgstr "Postranní"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr "Levý"
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr "Pravý"
@@ -566,11 +578,11 @@ msgstr "Pravý"
 msgid "Source"
 msgstr "Zdroj"
 
-#: data/ui/compressor.glade:676 data/ui/compressor.glade:913
+#: data/ui/compressor.glade:676 data/ui/compressor.glade:910
 msgid "Sidechain"
 msgstr "Postranní řetězec"
 
-#: data/ui/compressor.glade:989
+#: data/ui/compressor.glade:986
 msgid "Curve"
 msgstr "Křivka"
 
@@ -968,7 +980,7 @@ msgstr "Spodní mez"
 msgid "Exciter"
 msgstr "Zvukový budič"
 
-#: data/ui/exciter.glade:358 data/ui/maximizer.glade:159
+#: data/ui/exciter.glade:358 data/ui/maximizer.glade:139
 msgid "Ceiling"
 msgstr "Strop"
 
@@ -1068,7 +1080,7 @@ msgstr "Useknutí"
 msgid "Feed"
 msgstr "Kanál"
 
-#: data/ui/crossfeed.glade:392
+#: data/ui/crossfeed.glade:432
 msgid "Crossfeed"
 msgstr "Prolínání kanálů"
 
@@ -1176,7 +1188,7 @@ msgstr "Doba trvání"
 msgid "Samples"
 msgstr "Vzorky"
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:251
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
 msgid "Impulse Response"
 msgstr "Odpověď impulsu"
 
@@ -1184,7 +1196,7 @@ msgstr "Odpověď impulsu"
 msgid "Select the impulse Response File"
 msgstr "Vybrat soubor s odpovědí impulsu"
 
-#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:143
+#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:145
 msgid "Spectrum"
 msgstr "Spektrum"
 
@@ -1240,12 +1252,17 @@ msgstr "Oktávy"
 msgid "Crispness"
 msgstr "Křehkost"
 
+#: data/ui/pitch.glade:529
+#, fuzzy
+msgid "Rubber Band"
+msgstr "Spodní pásmo"
+
 #: data/ui/webrtc.glade:30
 msgid "Webrtc"
 msgstr "WebRTC"
 
 #: data/ui/webrtc.glade:137 data/ui/webrtc.glade:257 data/ui/webrtc.glade:327
-#: data/ui/webrtc.glade:496
+#: data/ui/webrtc.glade:497
 msgid "Enable"
 msgstr "Povolit"
 
@@ -1265,15 +1282,15 @@ msgstr "Vysokopásmový filtr"
 msgid "Suppresion Level"
 msgstr "Úroveň potlačení"
 
-#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:549
 msgid "Low"
 msgstr "Nízký"
 
-#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:549
+#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:550
 msgid "Moderate"
 msgstr "Střední"
 
-#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:550
+#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:551
 msgid "High"
 msgstr "Vysoký"
 
@@ -1305,23 +1322,23 @@ msgstr "Ovladač zesílení"
 msgid "Target Level"
 msgstr "Úroveň cíle"
 
-#: data/ui/webrtc.glade:448
+#: data/ui/webrtc.glade:449
 msgid "Maximum Gain"
 msgstr "Největší zesílení"
 
-#: data/ui/webrtc.glade:521
+#: data/ui/webrtc.glade:522
 msgid "Detection Likelihood"
 msgstr "Pravděpodobnost zjištění"
 
-#: data/ui/webrtc.glade:534
+#: data/ui/webrtc.glade:535
 msgid "Frame Size"
 msgstr "Rozměry rámečku"
 
-#: data/ui/webrtc.glade:547
+#: data/ui/webrtc.glade:548
 msgid "Very Low"
 msgstr "Velmi nízká"
 
-#: data/ui/webrtc.glade:584
+#: data/ui/webrtc.glade:585
 msgid "Voice Detector"
 msgstr "Zjišťovatel hlasu"
 
@@ -1491,11 +1508,6 @@ msgstr "Ekvalizér, kompresor a jiné zvukové efekty"
 msgid "limiter;compressor;reverberation;equalizer;autovolume;"
 msgstr "omezovač (limiter);kompresor;dozvuk;ekvalizér;automatická hlasitost;"
 
-#. Translators: This is an icon name, don't translate!
-#: data/com.github.wwmm.pulseeffects.desktop.in:10
-msgid "pulseeffects"
-msgstr "PulseEffects"
-
 #: data/schemas/com.github.wwmm.pulseeffects.gschema.xml:201
 msgid "\"Presets\""
 msgstr "\"Přednastavení\""
@@ -1520,11 +1532,11 @@ msgstr "Vynulovat PulseEffects."
 msgid "Global bypass. 1 to enable, 2 to disable and 3 to get status"
 msgstr ""
 
-#: src/application.cpp:263
+#: src/application.cpp:250
 msgid "Output Presets: "
 msgstr "Výstupní přednastavení:"
 
-#: src/application.cpp:271
+#: src/application.cpp:258
 msgid "Input Presets: "
 msgstr "Vstupní přednastavení:"
 
@@ -1536,27 +1548,27 @@ msgstr "Programy"
 msgid "Blacklist"
 msgstr "Černá listina"
 
-#: src/general_settings_ui.cpp:121
+#: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Obecné"
 
-#: src/pulse_settings_ui.cpp:138
+#: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Open"
 msgstr "Otevřít"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: src/app_info_ui.cpp:85
+#: src/app_info_ui.cpp:86
 msgid "paused"
 msgstr "Pozastaveno"
 
-#: src/app_info_ui.cpp:87
+#: src/app_info_ui.cpp:88
 msgid "playing"
 msgstr "Přehrává se"
 
@@ -1564,21 +1576,24 @@ msgstr "Přehrává se"
 msgid "Calibration Microphone"
 msgstr "Kalibrace mikrofonu"
 
-#: src/convolver_ui.cpp:246
+#: src/convolver_ui.cpp:252
 msgid "Import Impulse File"
 msgstr "Zavést soubor s impulsem"
 
-#: src/convolver_ui.cpp:290 src/convolver_ui.cpp:291 src/convolver_ui.cpp:293
+#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
 msgid "Failed"
 msgstr "Nepodařilo se"
 
-#: src/convolver_ui.cpp:295
+#: src/convolver_ui.cpp:302
 msgid "Could Not Load The Impulse File"
 msgstr "Nepodařilo se nahrát soubor s impulsem"
 
-#: src/equalizer_ui.cpp:307 src/equalizer_ui.cpp:426
+#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
 msgid "infinity"
 msgstr "nekonečno"
+
+#~ msgid "pulseeffects"
+#~ msgstr "PulseEffects"
 
 #~ msgid "PulseEffects was updated"
 #~ msgstr "Program PulseEffects byl aktualizován"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PulseEffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-28 14:03-0300\n"
+"POT-Creation-Date: 2020-05-02 00:54+0200\n"
 "PO-Revision-Date: 2020-01-12 17:49+0100\n"
 "Last-Translator: David Keller <blobcodes@protonmail.com>\n"
 "Language-Team: \n"
@@ -45,7 +45,7 @@ msgstr "Hilfe"
 #: data/ui/application.glade:200 data/ui/filter.glade:204
 #: data/ui/equalizer.glade:309 data/ui/reverb.glade:284
 #: data/ui/crossfeed.glade:47 src/presets_menu_ui.cpp:115
-#: src/presets_menu_ui.cpp:274 src/presets_menu_ui.cpp:291
+#: src/presets_menu_ui.cpp:278 src/presets_menu_ui.cpp:295
 msgid "Presets"
 msgstr "Presets"
 
@@ -323,37 +323,37 @@ msgid "Weights"
 msgstr "Gewichte"
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:718
+#: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:244 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:487
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
-#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:210
+#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
 #: data/ui/presets_menu.glade:255
 msgid "Input"
 msgstr "Eingang"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:733
+#: data/ui/limiter.glade:380 data/ui/compressor.glade:731
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:531 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:259 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
 #: data/ui/convolver.glade:492 data/ui/crystalizer.glade:243
-#: data/ui/pitch.glade:336 data/ui/webrtc.glade:639 data/ui/delay.glade:225
+#: data/ui/pitch.glade:336 data/ui/webrtc.glade:638 data/ui/delay.glade:223
 #: data/ui/presets_menu.glade:146
 msgid "Output"
 msgstr "Ausgang"
@@ -362,7 +362,7 @@ msgstr "Ausgang"
 msgid "Relative"
 msgstr "Relativ"
 
-#: data/ui/autogain.glade:721 data/ui/compressor.glade:900
+#: data/ui/autogain.glade:721 data/ui/compressor.glade:897
 #: data/ui/deesser.glade:295
 msgid "Gain"
 msgstr "Verstärkung"
@@ -375,6 +375,18 @@ msgstr "Lautstärke"
 #: data/ui/autogain.glade:840
 msgid "Range"
 msgstr "Umfang"
+
+#: data/ui/autogain.glade:892 data/ui/limiter.glade:569
+#: data/ui/compressor.glade:1039 data/ui/multiband_compressor.glade:2154
+#: data/ui/filter.glade:564 data/ui/equalizer.glade:707
+#: data/ui/reverb.glade:826 data/ui/bass_enhancer.glade:627
+#: data/ui/exciter.glade:631 data/ui/stereo_tools.glade:1001
+#: data/ui/crossfeed.glade:364 data/ui/maximizer.glade:444
+#: data/ui/loudness.glade:404 data/ui/gate.glade:691
+#: data/ui/multiband_gate.glade:2303 data/ui/deesser.glade:813
+#: data/ui/pitch.glade:517 data/ui/webrtc.glade:785 data/ui/delay.glade:404
+msgid "Provided by"
+msgstr ""
 
 #: data/ui/limiter.glade:30 data/ui/webrtc.glade:395
 msgid "Limiter"
@@ -392,7 +404,7 @@ msgstr "Grenze"
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
-#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:213
+#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
 #: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
@@ -416,7 +428,7 @@ msgid "Attenuation"
 msgstr "Dämpfung"
 
 #: data/ui/compressor.glade:30 data/ui/compressor.glade:442
-#: data/ui/webrtc.glade:482 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
+#: data/ui/webrtc.glade:483 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
 msgid "Compressor"
 msgstr "Kompressor"
 
@@ -548,12 +560,12 @@ msgstr "Mitte"
 msgid "Side"
 msgstr "Seite"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr "Links"
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr "Rechts"
@@ -562,11 +574,11 @@ msgstr "Rechts"
 msgid "Source"
 msgstr "Quelle"
 
-#: data/ui/compressor.glade:676 data/ui/compressor.glade:913
+#: data/ui/compressor.glade:676 data/ui/compressor.glade:910
 msgid "Sidechain"
 msgstr "Sidechain"
 
-#: data/ui/compressor.glade:989
+#: data/ui/compressor.glade:986
 msgid "Curve"
 msgstr "Kurve"
 
@@ -964,7 +976,7 @@ msgstr "Boden"
 msgid "Exciter"
 msgstr "Exciter"
 
-#: data/ui/exciter.glade:358 data/ui/maximizer.glade:159
+#: data/ui/exciter.glade:358 data/ui/maximizer.glade:139
 msgid "Ceiling"
 msgstr "Grenze"
 
@@ -1064,7 +1076,7 @@ msgstr "Abgrenzung"
 msgid "Feed"
 msgstr "Speisung"
 
-#: data/ui/crossfeed.glade:392
+#: data/ui/crossfeed.glade:432
 msgid "Crossfeed"
 msgstr "Crossfeed"
 
@@ -1172,7 +1184,7 @@ msgstr "Dauer"
 msgid "Samples"
 msgstr "Probenahme"
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:251
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
 msgid "Impulse Response"
 msgstr "Impulsantwort"
 
@@ -1180,7 +1192,7 @@ msgstr "Impulsantwort"
 msgid "Select the impulse Response File"
 msgstr "Auswahl der Impulsantwortdatei"
 
-#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:143
+#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:145
 msgid "Spectrum"
 msgstr "Spektrum"
 
@@ -1236,12 +1248,17 @@ msgstr "Oktaven"
 msgid "Crispness"
 msgstr "Klarheit"
 
+#: data/ui/pitch.glade:529
+#, fuzzy
+msgid "Rubber Band"
+msgstr "Subband"
+
 #: data/ui/webrtc.glade:30
 msgid "Webrtc"
 msgstr "WebRTC"
 
 #: data/ui/webrtc.glade:137 data/ui/webrtc.glade:257 data/ui/webrtc.glade:327
-#: data/ui/webrtc.glade:496
+#: data/ui/webrtc.glade:497
 msgid "Enable"
 msgstr "Aktivieren"
 
@@ -1261,15 +1278,15 @@ msgstr "Hochpassfilter"
 msgid "Suppresion Level"
 msgstr "Unterdrückungsgrad"
 
-#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:549
 msgid "Low"
 msgstr "Tief"
 
-#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:549
+#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:550
 msgid "Moderate"
 msgstr "Mäßig"
 
-#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:550
+#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:551
 msgid "High"
 msgstr "Hoch"
 
@@ -1301,23 +1318,23 @@ msgstr "Verstärkungsregler"
 msgid "Target Level"
 msgstr "Zielwert"
 
-#: data/ui/webrtc.glade:448
+#: data/ui/webrtc.glade:449
 msgid "Maximum Gain"
 msgstr "Maximale Verstärkung"
 
-#: data/ui/webrtc.glade:521
+#: data/ui/webrtc.glade:522
 msgid "Detection Likelihood"
 msgstr "Erkennungswahrscheinlichkeit"
 
-#: data/ui/webrtc.glade:534
+#: data/ui/webrtc.glade:535
 msgid "Frame Size"
 msgstr "Rahmengröße"
 
-#: data/ui/webrtc.glade:547
+#: data/ui/webrtc.glade:548
 msgid "Very Low"
 msgstr "Sehr Tief"
 
-#: data/ui/webrtc.glade:584
+#: data/ui/webrtc.glade:585
 msgid "Voice Detector"
 msgstr "Spracherkennung"
 
@@ -1487,11 +1504,6 @@ msgstr "Equalizer, Kompressor und andere Audioeffekte"
 msgid "limiter;compressor;reverberation;equalizer;autovolume;"
 msgstr "Limiter;Kompressor;Hall;Equalizer;Autovolumen;"
 
-#. Translators: This is an icon name, don't translate!
-#: data/com.github.wwmm.pulseeffects.desktop.in:10
-msgid "pulseeffects"
-msgstr "pulseeffects"
-
 #: data/schemas/com.github.wwmm.pulseeffects.gschema.xml:201
 msgid "\"Presets\""
 msgstr "\"Presets\""
@@ -1518,11 +1530,11 @@ msgstr ""
 "Globale Umleitung. 1 zum Aktivieren, 2 zum Deaktivieren und 3 zum Erhalten "
 "des Status"
 
-#: src/application.cpp:263
+#: src/application.cpp:250
 msgid "Output Presets: "
 msgstr "Ausgabe-Presets: "
 
-#: src/application.cpp:271
+#: src/application.cpp:258
 msgid "Input Presets: "
 msgstr "Eingangs-Presets: "
 
@@ -1534,27 +1546,27 @@ msgstr "Anwendungen"
 msgid "Blacklist"
 msgstr "Sperrliste"
 
-#: src/general_settings_ui.cpp:121
+#: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Allgemein"
 
-#: src/pulse_settings_ui.cpp:138
+#: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr "PulseAudio"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Open"
 msgstr "Öffnen"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: src/app_info_ui.cpp:85
+#: src/app_info_ui.cpp:86
 msgid "paused"
 msgstr "Pausiert"
 
-#: src/app_info_ui.cpp:87
+#: src/app_info_ui.cpp:88
 msgid "playing"
 msgstr "Spielt"
 
@@ -1562,21 +1574,24 @@ msgstr "Spielt"
 msgid "Calibration Microphone"
 msgstr "Kalibrationsmikrofon"
 
-#: src/convolver_ui.cpp:246
+#: src/convolver_ui.cpp:252
 msgid "Import Impulse File"
 msgstr "Impulsdatei importieren"
 
-#: src/convolver_ui.cpp:290 src/convolver_ui.cpp:291 src/convolver_ui.cpp:293
+#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
 msgid "Failed"
 msgstr "Gescheitert"
 
-#: src/convolver_ui.cpp:295
+#: src/convolver_ui.cpp:302
 msgid "Could Not Load The Impulse File"
 msgstr "Die Impulsdatei konnte nicht geladen werden"
 
-#: src/equalizer_ui.cpp:307 src/equalizer_ui.cpp:426
+#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
 msgid "infinity"
 msgstr "Unendlich"
+
+#~ msgid "pulseeffects"
+#~ msgstr "pulseeffects"
 
 #~ msgid "PulseEffects was updated"
 #~ msgstr "PulseEffects wurde Aktualisiert"

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-28 14:03-0300\n"
+"POT-Creation-Date: 2020-05-02 00:54+0200\n"
 "PO-Revision-Date: 2017-08-29 11:00+0200\n"
 "Last-Translator: Nathan Graule <solarliner@gmail.com>\n"
 "Language-Team: \n"
@@ -46,7 +46,7 @@ msgstr ""
 #: data/ui/application.glade:200 data/ui/filter.glade:204
 #: data/ui/equalizer.glade:309 data/ui/reverb.glade:284
 #: data/ui/crossfeed.glade:47 src/presets_menu_ui.cpp:115
-#: src/presets_menu_ui.cpp:274 src/presets_menu_ui.cpp:291
+#: src/presets_menu_ui.cpp:278 src/presets_menu_ui.cpp:295
 msgid "Presets"
 msgstr "Préréglage"
 
@@ -341,37 +341,37 @@ msgid "Weights"
 msgstr ""
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:718
+#: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:244 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:487
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
-#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:210
+#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
 #: data/ui/presets_menu.glade:255
 msgid "Input"
 msgstr "Entrée"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:733
+#: data/ui/limiter.glade:380 data/ui/compressor.glade:731
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:531 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:259 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
 #: data/ui/convolver.glade:492 data/ui/crystalizer.glade:243
-#: data/ui/pitch.glade:336 data/ui/webrtc.glade:639 data/ui/delay.glade:225
+#: data/ui/pitch.glade:336 data/ui/webrtc.glade:638 data/ui/delay.glade:223
 #: data/ui/presets_menu.glade:146
 msgid "Output"
 msgstr "Sortie"
@@ -380,7 +380,7 @@ msgstr "Sortie"
 msgid "Relative"
 msgstr ""
 
-#: data/ui/autogain.glade:721 data/ui/compressor.glade:900
+#: data/ui/autogain.glade:721 data/ui/compressor.glade:897
 #: data/ui/deesser.glade:295
 #, fuzzy
 msgid "Gain"
@@ -393,6 +393,18 @@ msgstr ""
 
 #: data/ui/autogain.glade:840
 msgid "Range"
+msgstr ""
+
+#: data/ui/autogain.glade:892 data/ui/limiter.glade:569
+#: data/ui/compressor.glade:1039 data/ui/multiband_compressor.glade:2154
+#: data/ui/filter.glade:564 data/ui/equalizer.glade:707
+#: data/ui/reverb.glade:826 data/ui/bass_enhancer.glade:627
+#: data/ui/exciter.glade:631 data/ui/stereo_tools.glade:1001
+#: data/ui/crossfeed.glade:364 data/ui/maximizer.glade:444
+#: data/ui/loudness.glade:404 data/ui/gate.glade:691
+#: data/ui/multiband_gate.glade:2303 data/ui/deesser.glade:813
+#: data/ui/pitch.glade:517 data/ui/webrtc.glade:785 data/ui/delay.glade:404
+msgid "Provided by"
 msgstr ""
 
 #: data/ui/limiter.glade:30 data/ui/webrtc.glade:395
@@ -414,7 +426,7 @@ msgstr "Limite [dB]"
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
-#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:213
+#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
 #: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
@@ -439,7 +451,7 @@ msgid "Attenuation"
 msgstr "Atténuation"
 
 #: data/ui/compressor.glade:30 data/ui/compressor.glade:442
-#: data/ui/webrtc.glade:482 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
+#: data/ui/webrtc.glade:483 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
 msgid "Compressor"
 msgstr "Compresseur"
 
@@ -582,12 +594,12 @@ msgstr "Niveau"
 msgid "Side"
 msgstr "Gain d'entrée [dB]"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr ""
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr ""
@@ -596,12 +608,12 @@ msgstr ""
 msgid "Source"
 msgstr ""
 
-#: data/ui/compressor.glade:676 data/ui/compressor.glade:913
+#: data/ui/compressor.glade:676 data/ui/compressor.glade:910
 #, fuzzy
 msgid "Sidechain"
 msgstr "Gain d'entrée [dB]"
 
-#: data/ui/compressor.glade:989
+#: data/ui/compressor.glade:986
 msgid "Curve"
 msgstr ""
 
@@ -1018,7 +1030,7 @@ msgstr ""
 msgid "Exciter"
 msgstr ""
 
-#: data/ui/exciter.glade:358 data/ui/maximizer.glade:159
+#: data/ui/exciter.glade:358 data/ui/maximizer.glade:139
 #, fuzzy
 msgid "Ceiling"
 msgstr "Limite [dB]"
@@ -1132,7 +1144,7 @@ msgstr "Coupure [Hz]"
 msgid "Feed"
 msgstr "Coudée [dB]"
 
-#: data/ui/crossfeed.glade:392
+#: data/ui/crossfeed.glade:432
 msgid "Crossfeed"
 msgstr ""
 
@@ -1247,7 +1259,7 @@ msgstr "Calibration"
 msgid "Samples"
 msgstr ""
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:251
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
 #, fuzzy
 msgid "Impulse Response"
 msgstr "Réponse plane"
@@ -1257,7 +1269,7 @@ msgstr "Réponse plane"
 msgid "Select the impulse Response File"
 msgstr "Réponse plane"
 
-#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:143
+#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:145
 msgid "Spectrum"
 msgstr "Spectromètre"
 
@@ -1316,12 +1328,17 @@ msgstr ""
 msgid "Crispness"
 msgstr ""
 
+#: data/ui/pitch.glade:529
+#, fuzzy
+msgid "Rubber Band"
+msgstr "Entrée [dB]"
+
 #: data/ui/webrtc.glade:30
 msgid "Webrtc"
 msgstr ""
 
 #: data/ui/webrtc.glade:137 data/ui/webrtc.glade:257 data/ui/webrtc.glade:327
-#: data/ui/webrtc.glade:496
+#: data/ui/webrtc.glade:497
 #, fuzzy
 msgid "Enable"
 msgstr "Table sinusoïdale"
@@ -1344,15 +1361,15 @@ msgstr "Passe-haut"
 msgid "Suppresion Level"
 msgstr "Réduction de gain"
 
-#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:549
 msgid "Low"
 msgstr ""
 
-#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:549
+#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:550
 msgid "Moderate"
 msgstr ""
 
-#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:550
+#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:551
 #, fuzzy
 msgid "High"
 msgstr "Passe-haut"
@@ -1389,26 +1406,26 @@ msgstr ""
 msgid "Target Level"
 msgstr "Cible [dB]"
 
-#: data/ui/webrtc.glade:448
+#: data/ui/webrtc.glade:449
 msgid "Maximum Gain"
 msgstr ""
 
-#: data/ui/webrtc.glade:521
+#: data/ui/webrtc.glade:522
 #, fuzzy
 msgid "Detection Likelihood"
 msgstr "Atténuation"
 
 # Taking lingual shortcuts to squeeze it in the text box
-#: data/ui/webrtc.glade:534
+#: data/ui/webrtc.glade:535
 #, fuzzy
 msgid "Frame Size"
 msgstr "Taille pièce"
 
-#: data/ui/webrtc.glade:547
+#: data/ui/webrtc.glade:548
 msgid "Very Low"
 msgstr ""
 
-#: data/ui/webrtc.glade:584
+#: data/ui/webrtc.glade:585
 #, fuzzy
 msgid "Voice Detector"
 msgstr "Atténuation"
@@ -1583,12 +1600,6 @@ msgstr ""
 msgid "limiter;compressor;reverberation;equalizer;autovolume;"
 msgstr "limiter;compressor;reverberation;equalizer;autovolume;"
 
-#. Translators: This is an icon name, don't translate!
-#: data/com.github.wwmm.pulseeffects.desktop.in:10
-#, fuzzy
-msgid "pulseeffects"
-msgstr "pulseeffects"
-
 #: data/schemas/com.github.wwmm.pulseeffects.gschema.xml:201
 #, fuzzy
 msgid "\"Presets\""
@@ -1615,12 +1626,12 @@ msgstr "PulseEffects"
 msgid "Global bypass. 1 to enable, 2 to disable and 3 to get status"
 msgstr ""
 
-#: src/application.cpp:263
+#: src/application.cpp:250
 #, fuzzy
 msgid "Output Presets: "
 msgstr "Préréglage"
 
-#: src/application.cpp:271
+#: src/application.cpp:258
 #, fuzzy
 msgid "Input Presets: "
 msgstr "Ouvrir préréglage"
@@ -1634,28 +1645,28 @@ msgstr "Calibration"
 msgid "Blacklist"
 msgstr ""
 
-#: src/general_settings_ui.cpp:121
+#: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Général"
 
-#: src/pulse_settings_ui.cpp:138
+#: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr ""
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Open"
 msgstr ""
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 #, fuzzy
 msgid "Cancel"
 msgstr "Amélioration audio"
 
-#: src/app_info_ui.cpp:85
+#: src/app_info_ui.cpp:86
 msgid "paused"
 msgstr ""
 
-#: src/app_info_ui.cpp:87
+#: src/app_info_ui.cpp:88
 msgid "playing"
 msgstr ""
 
@@ -1664,22 +1675,26 @@ msgstr ""
 msgid "Calibration Microphone"
 msgstr "Calibration de la correction microphone"
 
-#: src/convolver_ui.cpp:246
+#: src/convolver_ui.cpp:252
 #, fuzzy
 msgid "Import Impulse File"
 msgstr "Réponse plane"
 
-#: src/convolver_ui.cpp:290 src/convolver_ui.cpp:291 src/convolver_ui.cpp:293
+#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
 msgid "Failed"
 msgstr ""
 
-#: src/convolver_ui.cpp:295
+#: src/convolver_ui.cpp:302
 msgid "Could Not Load The Impulse File"
 msgstr ""
 
-#: src/equalizer_ui.cpp:307 src/equalizer_ui.cpp:426
+#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
 msgid "infinity"
 msgstr ""
+
+#, fuzzy
+#~ msgid "pulseeffects"
+#~ msgstr "pulseeffects"
 
 #, fuzzy
 #~ msgid "PulseEffects was updated"

--- a/po/hr.po
+++ b/po/hr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PulseEffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-28 14:03-0300\n"
+"POT-Creation-Date: 2020-05-02 00:54+0200\n"
 "PO-Revision-Date: 2018-11-22 20:12+0200\n"
 "Last-Translator: flipwise <tyx027@gmail.com>\n"
 "Language-Team: Croatian\n"
@@ -48,7 +48,7 @@ msgstr "Pomoć"
 #: data/ui/application.glade:200 data/ui/filter.glade:204
 #: data/ui/equalizer.glade:309 data/ui/reverb.glade:284
 #: data/ui/crossfeed.glade:47 src/presets_menu_ui.cpp:115
-#: src/presets_menu_ui.cpp:274 src/presets_menu_ui.cpp:291
+#: src/presets_menu_ui.cpp:278 src/presets_menu_ui.cpp:295
 msgid "Presets"
 msgstr "Predlošci"
 
@@ -346,37 +346,37 @@ msgid "Weights"
 msgstr "Otežanja"
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:718
+#: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:244 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:487
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
-#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:210
+#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
 #: data/ui/presets_menu.glade:255
 msgid "Input"
 msgstr "Ulaz"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:733
+#: data/ui/limiter.glade:380 data/ui/compressor.glade:731
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:531 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:259 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
 #: data/ui/convolver.glade:492 data/ui/crystalizer.glade:243
-#: data/ui/pitch.glade:336 data/ui/webrtc.glade:639 data/ui/delay.glade:225
+#: data/ui/pitch.glade:336 data/ui/webrtc.glade:638 data/ui/delay.glade:223
 #: data/ui/presets_menu.glade:146
 msgid "Output"
 msgstr "Izlaz"
@@ -385,7 +385,7 @@ msgstr "Izlaz"
 msgid "Relative"
 msgstr "Relativno"
 
-#: data/ui/autogain.glade:721 data/ui/compressor.glade:900
+#: data/ui/autogain.glade:721 data/ui/compressor.glade:897
 #: data/ui/deesser.glade:295
 msgid "Gain"
 msgstr "Pojačanje"
@@ -398,6 +398,18 @@ msgstr "Glasnoća"
 #: data/ui/autogain.glade:840
 msgid "Range"
 msgstr "Raspon"
+
+#: data/ui/autogain.glade:892 data/ui/limiter.glade:569
+#: data/ui/compressor.glade:1039 data/ui/multiband_compressor.glade:2154
+#: data/ui/filter.glade:564 data/ui/equalizer.glade:707
+#: data/ui/reverb.glade:826 data/ui/bass_enhancer.glade:627
+#: data/ui/exciter.glade:631 data/ui/stereo_tools.glade:1001
+#: data/ui/crossfeed.glade:364 data/ui/maximizer.glade:444
+#: data/ui/loudness.glade:404 data/ui/gate.glade:691
+#: data/ui/multiband_gate.glade:2303 data/ui/deesser.glade:813
+#: data/ui/pitch.glade:517 data/ui/webrtc.glade:785 data/ui/delay.glade:404
+msgid "Provided by"
+msgstr ""
 
 #: data/ui/limiter.glade:30 data/ui/webrtc.glade:395
 msgid "Limiter"
@@ -415,7 +427,7 @@ msgstr "Granica"
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
-#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:213
+#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
 #: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
@@ -439,7 +451,7 @@ msgid "Attenuation"
 msgstr "Prigušenje"
 
 #: data/ui/compressor.glade:30 data/ui/compressor.glade:442
-#: data/ui/webrtc.glade:482 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
+#: data/ui/webrtc.glade:483 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
 msgid "Compressor"
 msgstr "Kompresor"
 
@@ -579,12 +591,12 @@ msgstr "Srednji nivo"
 msgid "Side"
 msgstr "Strana"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr "Lijevo"
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr "Desno"
@@ -594,12 +606,12 @@ msgstr "Desno"
 msgid "Source"
 msgstr "Izvor"
 
-#: data/ui/compressor.glade:676 data/ui/compressor.glade:913
+#: data/ui/compressor.glade:676 data/ui/compressor.glade:910
 #, fuzzy
 msgid "Sidechain"
 msgstr "Postranični ulaz"
 
-#: data/ui/compressor.glade:989
+#: data/ui/compressor.glade:986
 msgid "Curve"
 msgstr ""
 
@@ -1017,7 +1029,7 @@ msgstr "Dno"
 msgid "Exciter"
 msgstr "Uzbuđivač"
 
-#: data/ui/exciter.glade:358 data/ui/maximizer.glade:159
+#: data/ui/exciter.glade:358 data/ui/maximizer.glade:139
 msgid "Ceiling"
 msgstr "Vrh"
 
@@ -1127,7 +1139,7 @@ msgstr "Prekid"
 msgid "Feed"
 msgstr "Dovod zvuka"
 
-#: data/ui/crossfeed.glade:392
+#: data/ui/crossfeed.glade:432
 msgid "Crossfeed"
 msgstr "Križno spajanje"
 
@@ -1244,7 +1256,7 @@ msgstr "Trajanje"
 msgid "Samples"
 msgstr "Semplovi"
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:251
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
 #, fuzzy
 msgid "Impulse Response"
 msgstr "Reakcija impulsa"
@@ -1254,7 +1266,7 @@ msgstr "Reakcija impulsa"
 msgid "Select the impulse Response File"
 msgstr "Odaberite datoteku reakcije impulsa"
 
-#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:143
+#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:145
 msgid "Spectrum"
 msgstr "Spektar"
 
@@ -1314,12 +1326,17 @@ msgstr "Oktave"
 msgid "Crispness"
 msgstr "Oštrina"
 
+#: data/ui/pitch.glade:529
+#, fuzzy
+msgid "Rubber Band"
+msgstr "Sub band"
+
 #: data/ui/webrtc.glade:30
 msgid "Webrtc"
 msgstr ""
 
 #: data/ui/webrtc.glade:137 data/ui/webrtc.glade:257 data/ui/webrtc.glade:327
-#: data/ui/webrtc.glade:496
+#: data/ui/webrtc.glade:497
 msgid "Enable"
 msgstr "Omogući"
 
@@ -1340,15 +1357,15 @@ msgstr "Filter visokog prolaza"
 msgid "Suppresion Level"
 msgstr "Razina supresije"
 
-#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:549
 msgid "Low"
 msgstr "Nisko"
 
-#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:549
+#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:550
 msgid "Moderate"
 msgstr "Umjereno"
 
-#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:550
+#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:551
 msgid "High"
 msgstr "Visoko"
 
@@ -1381,23 +1398,23 @@ msgstr "Kontrola pojačanja"
 msgid "Target Level"
 msgstr "Ciljana razina"
 
-#: data/ui/webrtc.glade:448
+#: data/ui/webrtc.glade:449
 msgid "Maximum Gain"
 msgstr "Najveće pojačanje"
 
-#: data/ui/webrtc.glade:521
+#: data/ui/webrtc.glade:522
 msgid "Detection Likelihood"
 msgstr "Vjerojatnost detekcije"
 
-#: data/ui/webrtc.glade:534
+#: data/ui/webrtc.glade:535
 msgid "Frame Size"
 msgstr "Veličina okvira"
 
-#: data/ui/webrtc.glade:547
+#: data/ui/webrtc.glade:548
 msgid "Very Low"
 msgstr "Vrlo nisko"
 
-#: data/ui/webrtc.glade:584
+#: data/ui/webrtc.glade:585
 msgid "Voice Detector"
 msgstr "Detektor glasa"
 
@@ -1567,11 +1584,6 @@ msgstr "Ekvalizator, kompresor i drugi audio efekti"
 msgid "limiter;compressor;reverberation;equalizer;autovolume;"
 msgstr "graničnik;kompresor;odjek;ekvalizator;automatska glasnoća zvuka;"
 
-#. Translators: This is an icon name, don't translate!
-#: data/com.github.wwmm.pulseeffects.desktop.in:10
-msgid "pulseeffects"
-msgstr "pulseeffects"
-
 #: data/schemas/com.github.wwmm.pulseeffects.gschema.xml:201
 #, fuzzy
 msgid "\"Presets\""
@@ -1599,12 +1611,12 @@ msgstr "PulseEffects"
 msgid "Global bypass. 1 to enable, 2 to disable and 3 to get status"
 msgstr ""
 
-#: src/application.cpp:263
+#: src/application.cpp:250
 #, fuzzy
 msgid "Output Presets: "
 msgstr "Predlošci: "
 
-#: src/application.cpp:271
+#: src/application.cpp:258
 #, fuzzy
 msgid "Input Presets: "
 msgstr "Učitaj predloške"
@@ -1617,27 +1629,27 @@ msgstr "Aplikacije"
 msgid "Blacklist"
 msgstr "Crna lista"
 
-#: src/general_settings_ui.cpp:121
+#: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Općenito"
 
-#: src/pulse_settings_ui.cpp:138
+#: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Open"
 msgstr "Otvori"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Cancel"
 msgstr "Poništi"
 
-#: src/app_info_ui.cpp:85
+#: src/app_info_ui.cpp:86
 msgid "paused"
 msgstr "pauzirano"
 
-#: src/app_info_ui.cpp:87
+#: src/app_info_ui.cpp:88
 msgid "playing"
 msgstr "reprodukcija"
 
@@ -1646,22 +1658,25 @@ msgstr "reprodukcija"
 msgid "Calibration Microphone"
 msgstr "Kalibracija mikrofona"
 
-#: src/convolver_ui.cpp:246
+#: src/convolver_ui.cpp:252
 #, fuzzy
 msgid "Import Impulse File"
 msgstr "Učitaj impuls datoteku"
 
-#: src/convolver_ui.cpp:290 src/convolver_ui.cpp:291 src/convolver_ui.cpp:293
+#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
 msgid "Failed"
 msgstr "Nije uspjelo"
 
-#: src/convolver_ui.cpp:295
+#: src/convolver_ui.cpp:302
 msgid "Could Not Load The Impulse File"
 msgstr "Nije bilo moguće učitati impuls datoteku"
 
-#: src/equalizer_ui.cpp:307 src/equalizer_ui.cpp:426
+#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
 msgid "infinity"
 msgstr ""
+
+#~ msgid "pulseeffects"
+#~ msgstr "pulseeffects"
 
 #, fuzzy
 #~ msgid "PulseEffects was updated"

--- a/po/id_ID.po
+++ b/po/id_ID.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pulseeffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-28 14:03-0300\n"
+"POT-Creation-Date: 2020-05-02 00:54+0200\n"
 "PO-Revision-Date: 2019-01-17 18:30+0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -46,7 +46,7 @@ msgstr "Bantuan"
 #: data/ui/application.glade:200 data/ui/filter.glade:204
 #: data/ui/equalizer.glade:309 data/ui/reverb.glade:284
 #: data/ui/crossfeed.glade:47 src/presets_menu_ui.cpp:115
-#: src/presets_menu_ui.cpp:274 src/presets_menu_ui.cpp:291
+#: src/presets_menu_ui.cpp:278 src/presets_menu_ui.cpp:295
 msgid "Presets"
 msgstr "Preset"
 
@@ -335,37 +335,37 @@ msgid "Weights"
 msgstr "Tinggi"
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:718
+#: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:244 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:487
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
-#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:210
+#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
 #: data/ui/presets_menu.glade:255
 msgid "Input"
 msgstr "Masukan"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:733
+#: data/ui/limiter.glade:380 data/ui/compressor.glade:731
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:531 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:259 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
 #: data/ui/convolver.glade:492 data/ui/crystalizer.glade:243
-#: data/ui/pitch.glade:336 data/ui/webrtc.glade:639 data/ui/delay.glade:225
+#: data/ui/pitch.glade:336 data/ui/webrtc.glade:638 data/ui/delay.glade:223
 #: data/ui/presets_menu.glade:146
 msgid "Output"
 msgstr "Output"
@@ -374,7 +374,7 @@ msgstr "Output"
 msgid "Relative"
 msgstr "Relatif"
 
-#: data/ui/autogain.glade:721 data/ui/compressor.glade:900
+#: data/ui/autogain.glade:721 data/ui/compressor.glade:897
 #: data/ui/deesser.glade:295
 msgid "Gain"
 msgstr "Besar Gain"
@@ -387,6 +387,18 @@ msgstr "Kelantangan"
 #: data/ui/autogain.glade:840
 msgid "Range"
 msgstr "Rentang"
+
+#: data/ui/autogain.glade:892 data/ui/limiter.glade:569
+#: data/ui/compressor.glade:1039 data/ui/multiband_compressor.glade:2154
+#: data/ui/filter.glade:564 data/ui/equalizer.glade:707
+#: data/ui/reverb.glade:826 data/ui/bass_enhancer.glade:627
+#: data/ui/exciter.glade:631 data/ui/stereo_tools.glade:1001
+#: data/ui/crossfeed.glade:364 data/ui/maximizer.glade:444
+#: data/ui/loudness.glade:404 data/ui/gate.glade:691
+#: data/ui/multiband_gate.glade:2303 data/ui/deesser.glade:813
+#: data/ui/pitch.glade:517 data/ui/webrtc.glade:785 data/ui/delay.glade:404
+msgid "Provided by"
+msgstr ""
 
 #: data/ui/limiter.glade:30 data/ui/webrtc.glade:395
 msgid "Limiter"
@@ -404,7 +416,7 @@ msgstr "Batas"
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
-#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:213
+#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
 #: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
@@ -428,7 +440,7 @@ msgid "Attenuation"
 msgstr "Atenuasi"
 
 #: data/ui/compressor.glade:30 data/ui/compressor.glade:442
-#: data/ui/webrtc.glade:482 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
+#: data/ui/webrtc.glade:483 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
 msgid "Compressor"
 msgstr "Kompresor"
 
@@ -565,12 +577,12 @@ msgstr "Volume Kanal Tengah"
 msgid "Side"
 msgstr "Volume Kanal Sisi"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr "Kiri"
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr "Kanan"
@@ -579,11 +591,11 @@ msgstr "Kanan"
 msgid "Source"
 msgstr "Sumber"
 
-#: data/ui/compressor.glade:676 data/ui/compressor.glade:913
+#: data/ui/compressor.glade:676 data/ui/compressor.glade:910
 msgid "Sidechain"
 msgstr "Sidechain"
 
-#: data/ui/compressor.glade:989
+#: data/ui/compressor.glade:986
 msgid "Curve"
 msgstr "Bentuk Kurva"
 
@@ -983,7 +995,7 @@ msgstr "Monitor Lantai"
 msgid "Exciter"
 msgstr "Penguat Frekuensi Tinggi"
 
-#: data/ui/exciter.glade:358 data/ui/maximizer.glade:159
+#: data/ui/exciter.glade:358 data/ui/maximizer.glade:139
 msgid "Ceiling"
 msgstr "Langit-langit"
 
@@ -1083,7 +1095,7 @@ msgstr "Frekuensi Potong"
 msgid "Feed"
 msgstr "Volume Penyuapan"
 
-#: data/ui/crossfeed.glade:392
+#: data/ui/crossfeed.glade:432
 msgid "Crossfeed"
 msgstr "Crossfeed"
 
@@ -1191,7 +1203,7 @@ msgstr "Durasi"
 msgid "Samples"
 msgstr "Jumlah Sampel"
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:251
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
 msgid "Impulse Response"
 msgstr "Respons Impuls"
 
@@ -1199,7 +1211,7 @@ msgstr "Respons Impuls"
 msgid "Select the impulse Response File"
 msgstr "Pilih Berkas Repons Impuls"
 
-#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:143
+#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:145
 msgid "Spectrum"
 msgstr "Spektrum"
 
@@ -1257,12 +1269,17 @@ msgstr "Oktav"
 msgid "Crispness"
 msgstr "Kerenyahan"
 
+#: data/ui/pitch.glade:529
+#, fuzzy
+msgid "Rubber Band"
+msgstr "Band Sub"
+
 #: data/ui/webrtc.glade:30
 msgid "Webrtc"
 msgstr "Webrtc"
 
 #: data/ui/webrtc.glade:137 data/ui/webrtc.glade:257 data/ui/webrtc.glade:327
-#: data/ui/webrtc.glade:496
+#: data/ui/webrtc.glade:497
 msgid "Enable"
 msgstr "Hidupkan"
 
@@ -1282,15 +1299,15 @@ msgstr "Filter High Pass"
 msgid "Suppresion Level"
 msgstr "Tingkat Supresi"
 
-#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:549
 msgid "Low"
 msgstr "Rendah"
 
-#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:549
+#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:550
 msgid "Moderate"
 msgstr "Sedang"
 
-#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:550
+#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:551
 msgid "High"
 msgstr "Tinggi"
 
@@ -1322,23 +1339,23 @@ msgstr "Pengatur Angkatan"
 msgid "Target Level"
 msgstr "Target Tingkat"
 
-#: data/ui/webrtc.glade:448
+#: data/ui/webrtc.glade:449
 msgid "Maximum Gain"
 msgstr "Angkatan Maksimal"
 
-#: data/ui/webrtc.glade:521
+#: data/ui/webrtc.glade:522
 msgid "Detection Likelihood"
 msgstr "Lacak Keberadaan Vokal"
 
-#: data/ui/webrtc.glade:534
+#: data/ui/webrtc.glade:535
 msgid "Frame Size"
 msgstr "Ukuran Bingkai"
 
-#: data/ui/webrtc.glade:547
+#: data/ui/webrtc.glade:548
 msgid "Very Low"
 msgstr "Sangat Rendah"
 
-#: data/ui/webrtc.glade:584
+#: data/ui/webrtc.glade:585
 msgid "Voice Detector"
 msgstr "Pelacak Vokal"
 
@@ -1506,11 +1523,6 @@ msgstr "Equalizer, Compressor and Other Audio Effects"
 msgid "limiter;compressor;reverberation;equalizer;autovolume;"
 msgstr "limiter;compressor;reverberation;equalizer;autovolume;"
 
-#. Translators: This is an icon name, don't translate!
-#: data/com.github.wwmm.pulseeffects.desktop.in:10
-msgid "pulseeffects"
-msgstr "pulseeffects"
-
 #: data/schemas/com.github.wwmm.pulseeffects.gschema.xml:201
 msgid "\"Presets\""
 msgstr "Preset"
@@ -1535,12 +1547,12 @@ msgstr "Atur Ulang PulseEffects"
 msgid "Global bypass. 1 to enable, 2 to disable and 3 to get status"
 msgstr ""
 
-#: src/application.cpp:263
+#: src/application.cpp:250
 #, fuzzy
 msgid "Output Presets: "
 msgstr "Preset Output:"
 
-#: src/application.cpp:271
+#: src/application.cpp:258
 #, fuzzy
 msgid "Input Presets: "
 msgstr "Preset Input"
@@ -1553,27 +1565,27 @@ msgstr "Aplikasi"
 msgid "Blacklist"
 msgstr "Daftar Blokir"
 
-#: src/general_settings_ui.cpp:121
+#: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Umum"
 
-#: src/pulse_settings_ui.cpp:138
+#: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Open"
 msgstr "Buka"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Cancel"
 msgstr "Batal"
 
-#: src/app_info_ui.cpp:85
+#: src/app_info_ui.cpp:86
 msgid "paused"
 msgstr "terjeda"
 
-#: src/app_info_ui.cpp:87
+#: src/app_info_ui.cpp:88
 msgid "playing"
 msgstr "memutar"
 
@@ -1581,21 +1593,24 @@ msgstr "memutar"
 msgid "Calibration Microphone"
 msgstr "Kalibrasikan Mikrofon"
 
-#: src/convolver_ui.cpp:246
+#: src/convolver_ui.cpp:252
 msgid "Import Impulse File"
 msgstr "Muat Berkas Impuls"
 
-#: src/convolver_ui.cpp:290 src/convolver_ui.cpp:291 src/convolver_ui.cpp:293
+#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
 msgid "Failed"
 msgstr "Gagal"
 
-#: src/convolver_ui.cpp:295
+#: src/convolver_ui.cpp:302
 msgid "Could Not Load The Impulse File"
 msgstr "Tidak dapat Memuat Berkas Impuls"
 
-#: src/equalizer_ui.cpp:307 src/equalizer_ui.cpp:426
+#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
 msgid "infinity"
 msgstr "Tak Terbatas"
+
+#~ msgid "pulseeffects"
+#~ msgstr "pulseeffects"
 
 #~ msgid "PulseEffects was updated"
 #~ msgstr "PulseEffects telah dimutakhirkan"

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-28 14:03-0300\n"
+"POT-Creation-Date: 2020-05-02 00:54+0200\n"
 "PO-Revision-Date: 2019-03-28 17:38+0100\n"
 "Last-Translator: Gianluca Boiano <morf3089@gmail.com>\n"
 "Language-Team: \n"
@@ -47,7 +47,7 @@ msgstr "Aiuto"
 #: data/ui/application.glade:200 data/ui/filter.glade:204
 #: data/ui/equalizer.glade:309 data/ui/reverb.glade:284
 #: data/ui/crossfeed.glade:47 src/presets_menu_ui.cpp:115
-#: src/presets_menu_ui.cpp:274 src/presets_menu_ui.cpp:291
+#: src/presets_menu_ui.cpp:278 src/presets_menu_ui.cpp:295
 msgid "Presets"
 msgstr "Profili"
 
@@ -325,37 +325,37 @@ msgid "Weights"
 msgstr "Ampiezze"
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:718
+#: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:244 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:487
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
-#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:210
+#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
 #: data/ui/presets_menu.glade:255
 msgid "Input"
 msgstr "Ingresso"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:733
+#: data/ui/limiter.glade:380 data/ui/compressor.glade:731
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:531 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:259 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
 #: data/ui/convolver.glade:492 data/ui/crystalizer.glade:243
-#: data/ui/pitch.glade:336 data/ui/webrtc.glade:639 data/ui/delay.glade:225
+#: data/ui/pitch.glade:336 data/ui/webrtc.glade:638 data/ui/delay.glade:223
 #: data/ui/presets_menu.glade:146
 msgid "Output"
 msgstr "Uscita"
@@ -364,7 +364,7 @@ msgstr "Uscita"
 msgid "Relative"
 msgstr "Relativo"
 
-#: data/ui/autogain.glade:721 data/ui/compressor.glade:900
+#: data/ui/autogain.glade:721 data/ui/compressor.glade:897
 #: data/ui/deesser.glade:295
 msgid "Gain"
 msgstr "Guadagno"
@@ -377,6 +377,18 @@ msgstr "Loudness"
 #: data/ui/autogain.glade:840
 msgid "Range"
 msgstr "Gamma"
+
+#: data/ui/autogain.glade:892 data/ui/limiter.glade:569
+#: data/ui/compressor.glade:1039 data/ui/multiband_compressor.glade:2154
+#: data/ui/filter.glade:564 data/ui/equalizer.glade:707
+#: data/ui/reverb.glade:826 data/ui/bass_enhancer.glade:627
+#: data/ui/exciter.glade:631 data/ui/stereo_tools.glade:1001
+#: data/ui/crossfeed.glade:364 data/ui/maximizer.glade:444
+#: data/ui/loudness.glade:404 data/ui/gate.glade:691
+#: data/ui/multiband_gate.glade:2303 data/ui/deesser.glade:813
+#: data/ui/pitch.glade:517 data/ui/webrtc.glade:785 data/ui/delay.glade:404
+msgid "Provided by"
+msgstr "Fornito da"
 
 #: data/ui/limiter.glade:30 data/ui/webrtc.glade:395
 msgid "Limiter"
@@ -394,7 +406,7 @@ msgstr "Limite"
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
-#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:213
+#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
 #: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
@@ -418,7 +430,7 @@ msgid "Attenuation"
 msgstr "Attenuazione"
 
 #: data/ui/compressor.glade:30 data/ui/compressor.glade:442
-#: data/ui/webrtc.glade:482 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
+#: data/ui/webrtc.glade:483 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
 msgid "Compressor"
 msgstr "Compressore"
 
@@ -550,12 +562,12 @@ msgstr "Intermedia"
 msgid "Side"
 msgstr "Laterale"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr "Canale Sinistro"
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr "Canale Destro"
@@ -564,11 +576,11 @@ msgstr "Canale Destro"
 msgid "Source"
 msgstr "Sorgente"
 
-#: data/ui/compressor.glade:676 data/ui/compressor.glade:913
+#: data/ui/compressor.glade:676 data/ui/compressor.glade:910
 msgid "Sidechain"
 msgstr "Sidechain"
 
-#: data/ui/compressor.glade:989
+#: data/ui/compressor.glade:986
 msgid "Curve"
 msgstr "Curva"
 
@@ -966,7 +978,7 @@ msgstr "Limite inferiore"
 msgid "Exciter"
 msgstr "Exciter"
 
-#: data/ui/exciter.glade:358 data/ui/maximizer.glade:159
+#: data/ui/exciter.glade:358 data/ui/maximizer.glade:139
 msgid "Ceiling"
 msgstr "Limite Superiore"
 
@@ -1066,7 +1078,7 @@ msgstr "Taglio"
 msgid "Feed"
 msgstr "Feed"
 
-#: data/ui/crossfeed.glade:392
+#: data/ui/crossfeed.glade:432
 msgid "Crossfeed"
 msgstr "Crossfeed"
 
@@ -1174,7 +1186,7 @@ msgstr "Durata"
 msgid "Samples"
 msgstr "Campioni"
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:251
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
 msgid "Impulse Response"
 msgstr "Risposta all'Impulso"
 
@@ -1182,7 +1194,7 @@ msgstr "Risposta all'Impulso"
 msgid "Select the impulse Response File"
 msgstr "Seleziona il File di Risposta all'impulso"
 
-#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:143
+#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:145
 msgid "Spectrum"
 msgstr "Spettro"
 
@@ -1238,12 +1250,17 @@ msgstr "Ottave"
 msgid "Crispness"
 msgstr "Chiarezza"
 
+#: data/ui/pitch.glade:529
+#, fuzzy
+msgid "Rubber Band"
+msgstr "Sottobanda"
+
 #: data/ui/webrtc.glade:30
 msgid "Webrtc"
 msgstr "WebRTC"
 
 #: data/ui/webrtc.glade:137 data/ui/webrtc.glade:257 data/ui/webrtc.glade:327
-#: data/ui/webrtc.glade:496
+#: data/ui/webrtc.glade:497
 msgid "Enable"
 msgstr "Attiva"
 
@@ -1263,15 +1280,15 @@ msgstr "Filtro Passa Alto"
 msgid "Suppresion Level"
 msgstr "Livello Riduzione"
 
-#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:549
 msgid "Low"
 msgstr "Basso"
 
-#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:549
+#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:550
 msgid "Moderate"
 msgstr "Moderato"
 
-#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:550
+#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:551
 msgid "High"
 msgstr "Alto"
 
@@ -1303,23 +1320,23 @@ msgstr "Controllo Guadagno"
 msgid "Target Level"
 msgstr "Livello Soglia"
 
-#: data/ui/webrtc.glade:448
+#: data/ui/webrtc.glade:449
 msgid "Maximum Gain"
 msgstr "Guadagno Massimo"
 
-#: data/ui/webrtc.glade:521
+#: data/ui/webrtc.glade:522
 msgid "Detection Likelihood"
 msgstr "Probabilità Rilevamento"
 
-#: data/ui/webrtc.glade:534
+#: data/ui/webrtc.glade:535
 msgid "Frame Size"
 msgstr "Dimensione frame"
 
-#: data/ui/webrtc.glade:547
+#: data/ui/webrtc.glade:548
 msgid "Very Low"
 msgstr "Molto piccolo"
 
-#: data/ui/webrtc.glade:584
+#: data/ui/webrtc.glade:585
 msgid "Voice Detector"
 msgstr "Rilevatore Voce"
 
@@ -1489,11 +1506,6 @@ msgstr "Equalizzatore, Compressore e Altri Effetti Audio"
 msgid "limiter;compressor;reverberation;equalizer;autovolume;"
 msgstr "limitatore;compressore;riverbero;equalizzatore;autovolume;"
 
-#. Translators: This is an icon name, don't translate!
-#: data/com.github.wwmm.pulseeffects.desktop.in:10
-msgid "pulseeffects"
-msgstr "pulseeffects"
-
 #: data/schemas/com.github.wwmm.pulseeffects.gschema.xml:201
 msgid "\"Presets\""
 msgstr "\"Profili\""
@@ -1518,11 +1530,11 @@ msgstr "Reset PulseEffects."
 msgid "Global bypass. 1 to enable, 2 to disable and 3 to get status"
 msgstr "Bypass globale. 1 per abilitare, 2 per disabilitare e 3 per lo stato"
 
-#: src/application.cpp:263
+#: src/application.cpp:250
 msgid "Output Presets: "
 msgstr "Profili Uscita: "
 
-#: src/application.cpp:271
+#: src/application.cpp:258
 msgid "Input Presets: "
 msgstr "Profili Ingresso: "
 
@@ -1534,27 +1546,27 @@ msgstr "Applicazioni"
 msgid "Blacklist"
 msgstr "Applicazioni Escluse"
 
-#: src/general_settings_ui.cpp:121
+#: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Generale"
 
-#: src/pulse_settings_ui.cpp:138
+#: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Open"
 msgstr "Apri"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Cancel"
 msgstr "Annulla"
 
-#: src/app_info_ui.cpp:85
+#: src/app_info_ui.cpp:86
 msgid "paused"
 msgstr "pausa"
 
-#: src/app_info_ui.cpp:87
+#: src/app_info_ui.cpp:88
 msgid "playing"
 msgstr "riproduzione"
 
@@ -1562,18 +1574,21 @@ msgstr "riproduzione"
 msgid "Calibration Microphone"
 msgstr "Calibrazione Microfono"
 
-#: src/convolver_ui.cpp:246
+#: src/convolver_ui.cpp:252
 msgid "Import Impulse File"
 msgstr "Importa File Impulso"
 
-#: src/convolver_ui.cpp:290 src/convolver_ui.cpp:291 src/convolver_ui.cpp:293
+#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
 msgid "Failed"
 msgstr "Fallito"
 
-#: src/convolver_ui.cpp:295
+#: src/convolver_ui.cpp:302
 msgid "Could Not Load The Impulse File"
 msgstr "Impossibile Caricare File Impulso"
 
-#: src/equalizer_ui.cpp:307 src/equalizer_ui.cpp:426
+#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
 msgid "infinity"
 msgstr "infinito"
+
+#~ msgid "pulseeffects"
+#~ msgstr "pulseeffects"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PulseEffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-28 14:03-0300\n"
+"POT-Creation-Date: 2020-05-02 00:54+0200\n"
 "PO-Revision-Date: 2018-06-21 21:34+0200\n"
 "Last-Translator: Piotr Komur, pkomur@gmail.com\n"
 "Language-Team: \n"
@@ -46,7 +46,7 @@ msgstr ""
 #: data/ui/application.glade:200 data/ui/filter.glade:204
 #: data/ui/equalizer.glade:309 data/ui/reverb.glade:284
 #: data/ui/crossfeed.glade:47 src/presets_menu_ui.cpp:115
-#: src/presets_menu_ui.cpp:274 src/presets_menu_ui.cpp:291
+#: src/presets_menu_ui.cpp:278 src/presets_menu_ui.cpp:295
 msgid "Presets"
 msgstr "Profile"
 
@@ -342,37 +342,37 @@ msgid "Weights"
 msgstr "Wysokość"
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:718
+#: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:244 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:487
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
-#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:210
+#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
 #: data/ui/presets_menu.glade:255
 msgid "Input"
 msgstr "Wejście"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:733
+#: data/ui/limiter.glade:380 data/ui/compressor.glade:731
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:531 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:259 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
 #: data/ui/convolver.glade:492 data/ui/crystalizer.glade:243
-#: data/ui/pitch.glade:336 data/ui/webrtc.glade:639 data/ui/delay.glade:225
+#: data/ui/pitch.glade:336 data/ui/webrtc.glade:638 data/ui/delay.glade:223
 #: data/ui/presets_menu.glade:146
 msgid "Output"
 msgstr "Wyjście"
@@ -381,7 +381,7 @@ msgstr "Wyjście"
 msgid "Relative"
 msgstr ""
 
-#: data/ui/autogain.glade:721 data/ui/compressor.glade:900
+#: data/ui/autogain.glade:721 data/ui/compressor.glade:897
 #: data/ui/deesser.glade:295
 msgid "Gain"
 msgstr "Wzmocnienie"
@@ -393,6 +393,18 @@ msgstr ""
 
 #: data/ui/autogain.glade:840
 msgid "Range"
+msgstr ""
+
+#: data/ui/autogain.glade:892 data/ui/limiter.glade:569
+#: data/ui/compressor.glade:1039 data/ui/multiband_compressor.glade:2154
+#: data/ui/filter.glade:564 data/ui/equalizer.glade:707
+#: data/ui/reverb.glade:826 data/ui/bass_enhancer.glade:627
+#: data/ui/exciter.glade:631 data/ui/stereo_tools.glade:1001
+#: data/ui/crossfeed.glade:364 data/ui/maximizer.glade:444
+#: data/ui/loudness.glade:404 data/ui/gate.glade:691
+#: data/ui/multiband_gate.glade:2303 data/ui/deesser.glade:813
+#: data/ui/pitch.glade:517 data/ui/webrtc.glade:785 data/ui/delay.glade:404
+msgid "Provided by"
 msgstr ""
 
 #: data/ui/limiter.glade:30 data/ui/webrtc.glade:395
@@ -411,7 +423,7 @@ msgstr "Limit"
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
-#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:213
+#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
 #: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
@@ -437,7 +449,7 @@ msgid "Attenuation"
 msgstr "Tłumienie"
 
 #: data/ui/compressor.glade:30 data/ui/compressor.glade:442
-#: data/ui/webrtc.glade:482 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
+#: data/ui/webrtc.glade:483 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
 msgid "Compressor"
 msgstr "Kompresor"
 
@@ -578,12 +590,12 @@ msgstr "Środek"
 msgid "Side"
 msgstr "Strona"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr "Lewy"
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr "Prawy"
@@ -592,11 +604,11 @@ msgstr "Prawy"
 msgid "Source"
 msgstr "Źródło"
 
-#: data/ui/compressor.glade:676 data/ui/compressor.glade:913
+#: data/ui/compressor.glade:676 data/ui/compressor.glade:910
 msgid "Sidechain"
 msgstr "Łańcuch boczny"
 
-#: data/ui/compressor.glade:989
+#: data/ui/compressor.glade:986
 msgid "Curve"
 msgstr ""
 
@@ -1007,7 +1019,7 @@ msgstr "Podłoga"
 msgid "Exciter"
 msgstr "Exciter"
 
-#: data/ui/exciter.glade:358 data/ui/maximizer.glade:159
+#: data/ui/exciter.glade:358 data/ui/maximizer.glade:139
 msgid "Ceiling"
 msgstr "Sufit"
 
@@ -1118,7 +1130,7 @@ msgstr "Odcięcie"
 msgid "Feed"
 msgstr "Feed"
 
-#: data/ui/crossfeed.glade:392
+#: data/ui/crossfeed.glade:432
 msgid "Crossfeed"
 msgstr "Crossfeed"
 
@@ -1229,7 +1241,7 @@ msgstr "Kalibracja"
 msgid "Samples"
 msgstr "Resampler"
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:251
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
 #, fuzzy
 msgid "Impulse Response"
 msgstr "Płaska odpowiedź"
@@ -1238,7 +1250,7 @@ msgstr "Płaska odpowiedź"
 msgid "Select the impulse Response File"
 msgstr ""
 
-#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:143
+#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:145
 msgid "Spectrum"
 msgstr "Widmo"
 
@@ -1297,12 +1309,17 @@ msgstr "Oktawy"
 msgid "Crispness"
 msgstr "Czystość"
 
+#: data/ui/pitch.glade:529
+#, fuzzy
+msgid "Rubber Band"
+msgstr "Pasma"
+
 #: data/ui/webrtc.glade:30
 msgid "Webrtc"
 msgstr "WebRTC"
 
 #: data/ui/webrtc.glade:137 data/ui/webrtc.glade:257 data/ui/webrtc.glade:327
-#: data/ui/webrtc.glade:496
+#: data/ui/webrtc.glade:497
 msgid "Enable"
 msgstr "Włącz"
 
@@ -1322,15 +1339,15 @@ msgstr "Filtr górnoprzepustowy"
 msgid "Suppresion Level"
 msgstr "Poziom tłumienia"
 
-#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:549
 msgid "Low"
 msgstr "Nisko"
 
-#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:549
+#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:550
 msgid "Moderate"
 msgstr "Średni"
 
-#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:550
+#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:551
 msgid "High"
 msgstr "Wysoki"
 
@@ -1362,23 +1379,23 @@ msgstr "Kontroler wzmocnienia"
 msgid "Target Level"
 msgstr "Poziom docelowy"
 
-#: data/ui/webrtc.glade:448
+#: data/ui/webrtc.glade:449
 msgid "Maximum Gain"
 msgstr "Maksymalne wzmocnienie"
 
-#: data/ui/webrtc.glade:521
+#: data/ui/webrtc.glade:522
 msgid "Detection Likelihood"
 msgstr "Szansa wykrycia"
 
-#: data/ui/webrtc.glade:534
+#: data/ui/webrtc.glade:535
 msgid "Frame Size"
 msgstr "Rozmiar ramki"
 
-#: data/ui/webrtc.glade:547
+#: data/ui/webrtc.glade:548
 msgid "Very Low"
 msgstr "Bardzo niskie"
 
-#: data/ui/webrtc.glade:584
+#: data/ui/webrtc.glade:585
 msgid "Voice Detector"
 msgstr "Wykrywanie głosu"
 
@@ -1550,11 +1567,6 @@ msgstr "Korektor, kompresor i inne efekty audio"
 msgid "limiter;compressor;reverberation;equalizer;autovolume;"
 msgstr "limiter;kompresor;pogłos;korektor;autogłośność;"
 
-#. Translators: This is an icon name, don't translate!
-#: data/com.github.wwmm.pulseeffects.desktop.in:10
-msgid "pulseeffects"
-msgstr "pulseeffects"
-
 #: data/schemas/com.github.wwmm.pulseeffects.gschema.xml:201
 #, fuzzy
 msgid "\"Presets\""
@@ -1581,12 +1593,12 @@ msgstr "PulseEffects"
 msgid "Global bypass. 1 to enable, 2 to disable and 3 to get status"
 msgstr ""
 
-#: src/application.cpp:263
+#: src/application.cpp:250
 #, fuzzy
 msgid "Output Presets: "
 msgstr "Profile: "
 
-#: src/application.cpp:271
+#: src/application.cpp:258
 #, fuzzy
 msgid "Input Presets: "
 msgstr "Importuj profile"
@@ -1599,28 +1611,28 @@ msgstr "Programy"
 msgid "Blacklist"
 msgstr ""
 
-#: src/general_settings_ui.cpp:121
+#: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Ogólne"
 
-#: src/pulse_settings_ui.cpp:138
+#: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Open"
 msgstr ""
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 #, fuzzy
 msgid "Cancel"
 msgstr "Balans"
 
-#: src/app_info_ui.cpp:85
+#: src/app_info_ui.cpp:86
 msgid "paused"
 msgstr "zatrzymany"
 
-#: src/app_info_ui.cpp:87
+#: src/app_info_ui.cpp:88
 msgid "playing"
 msgstr "gra"
 
@@ -1628,21 +1640,24 @@ msgstr "gra"
 msgid "Calibration Microphone"
 msgstr "Kalibracja mikrofonu"
 
-#: src/convolver_ui.cpp:246
+#: src/convolver_ui.cpp:252
 msgid "Import Impulse File"
 msgstr ""
 
-#: src/convolver_ui.cpp:290 src/convolver_ui.cpp:291 src/convolver_ui.cpp:293
+#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
 msgid "Failed"
 msgstr ""
 
-#: src/convolver_ui.cpp:295
+#: src/convolver_ui.cpp:302
 msgid "Could Not Load The Impulse File"
 msgstr ""
 
-#: src/equalizer_ui.cpp:307 src/equalizer_ui.cpp:426
+#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
 msgid "infinity"
 msgstr ""
+
+#~ msgid "pulseeffects"
+#~ msgstr "pulseeffects"
 
 #, fuzzy
 #~ msgid "PulseEffects was updated"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PulseEffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-28 14:03-0300\n"
+"POT-Creation-Date: 2020-05-02 00:54+0200\n"
 "PO-Revision-Date: 2019-09-10 12:56-0300\n"
 "Last-Translator: Patrik Nilsson <translation_AT_hembas.se>\n"
 "Language-Team: Portuguese <>\n"
@@ -48,7 +48,7 @@ msgstr "Ajuda"
 #: data/ui/application.glade:200 data/ui/filter.glade:204
 #: data/ui/equalizer.glade:309 data/ui/reverb.glade:284
 #: data/ui/crossfeed.glade:47 src/presets_menu_ui.cpp:115
-#: src/presets_menu_ui.cpp:274 src/presets_menu_ui.cpp:291
+#: src/presets_menu_ui.cpp:278 src/presets_menu_ui.cpp:295
 msgid "Presets"
 msgstr "Predefinições"
 
@@ -327,37 +327,37 @@ msgid "Weights"
 msgstr "Pesos"
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:718
+#: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:244 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:487
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
-#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:210
+#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
 #: data/ui/presets_menu.glade:255
 msgid "Input"
 msgstr "Entrada"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:733
+#: data/ui/limiter.glade:380 data/ui/compressor.glade:731
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:531 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:259 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
 #: data/ui/convolver.glade:492 data/ui/crystalizer.glade:243
-#: data/ui/pitch.glade:336 data/ui/webrtc.glade:639 data/ui/delay.glade:225
+#: data/ui/pitch.glade:336 data/ui/webrtc.glade:638 data/ui/delay.glade:223
 #: data/ui/presets_menu.glade:146
 msgid "Output"
 msgstr "Saída"
@@ -366,7 +366,7 @@ msgstr "Saída"
 msgid "Relative"
 msgstr "Relativo"
 
-#: data/ui/autogain.glade:721 data/ui/compressor.glade:900
+#: data/ui/autogain.glade:721 data/ui/compressor.glade:897
 #: data/ui/deesser.glade:295
 msgid "Gain"
 msgstr "Ganho"
@@ -379,6 +379,18 @@ msgstr "Sonoridade"
 #: data/ui/autogain.glade:840
 msgid "Range"
 msgstr "Alcance"
+
+#: data/ui/autogain.glade:892 data/ui/limiter.glade:569
+#: data/ui/compressor.glade:1039 data/ui/multiband_compressor.glade:2154
+#: data/ui/filter.glade:564 data/ui/equalizer.glade:707
+#: data/ui/reverb.glade:826 data/ui/bass_enhancer.glade:627
+#: data/ui/exciter.glade:631 data/ui/stereo_tools.glade:1001
+#: data/ui/crossfeed.glade:364 data/ui/maximizer.glade:444
+#: data/ui/loudness.glade:404 data/ui/gate.glade:691
+#: data/ui/multiband_gate.glade:2303 data/ui/deesser.glade:813
+#: data/ui/pitch.glade:517 data/ui/webrtc.glade:785 data/ui/delay.glade:404
+msgid "Provided by"
+msgstr ""
 
 #: data/ui/limiter.glade:30 data/ui/webrtc.glade:395
 msgid "Limiter"
@@ -396,7 +408,7 @@ msgstr "Limite"
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
-#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:213
+#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
 #: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
@@ -420,7 +432,7 @@ msgid "Attenuation"
 msgstr "Atenuação"
 
 #: data/ui/compressor.glade:30 data/ui/compressor.glade:442
-#: data/ui/webrtc.glade:482 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
+#: data/ui/webrtc.glade:483 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
 msgid "Compressor"
 msgstr "Compressor"
 
@@ -552,12 +564,12 @@ msgstr "Meio"
 msgid "Side"
 msgstr "Lado"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr "Esquerda"
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr "Direita"
@@ -566,11 +578,11 @@ msgstr "Direita"
 msgid "Source"
 msgstr "Fonte"
 
-#: data/ui/compressor.glade:676 data/ui/compressor.glade:913
+#: data/ui/compressor.glade:676 data/ui/compressor.glade:910
 msgid "Sidechain"
 msgstr "Cadeia Lateral"
 
-#: data/ui/compressor.glade:989
+#: data/ui/compressor.glade:986
 msgid "Curve"
 msgstr "Curva"
 
@@ -968,7 +980,7 @@ msgstr "Piso"
 msgid "Exciter"
 msgstr "Excitador"
 
-#: data/ui/exciter.glade:358 data/ui/maximizer.glade:159
+#: data/ui/exciter.glade:358 data/ui/maximizer.glade:139
 msgid "Ceiling"
 msgstr "Teto"
 
@@ -1068,7 +1080,7 @@ msgstr "Corte"
 msgid "Feed"
 msgstr "Alimentação"
 
-#: data/ui/crossfeed.glade:392
+#: data/ui/crossfeed.glade:432
 msgid "Crossfeed"
 msgstr "Crossfeed"
 
@@ -1176,7 +1188,7 @@ msgstr "Duração"
 msgid "Samples"
 msgstr "Amostras"
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:251
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
 msgid "Impulse Response"
 msgstr "Resposta de Impulso"
 
@@ -1184,7 +1196,7 @@ msgstr "Resposta de Impulso"
 msgid "Select the impulse Response File"
 msgstr "Selecione o Arquivo com a Resposta de Impulso"
 
-#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:143
+#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:145
 msgid "Spectrum"
 msgstr "Espectro"
 
@@ -1240,12 +1252,17 @@ msgstr "Oitavas"
 msgid "Crispness"
 msgstr "Clareza"
 
+#: data/ui/pitch.glade:529
+#, fuzzy
+msgid "Rubber Band"
+msgstr "Banda"
+
 #: data/ui/webrtc.glade:30
 msgid "Webrtc"
 msgstr "Webrtc"
 
 #: data/ui/webrtc.glade:137 data/ui/webrtc.glade:257 data/ui/webrtc.glade:327
-#: data/ui/webrtc.glade:496
+#: data/ui/webrtc.glade:497
 msgid "Enable"
 msgstr "Habilitar"
 
@@ -1265,15 +1282,15 @@ msgstr "Filtro Passa-Alta"
 msgid "Suppresion Level"
 msgstr "Nível de Supressão"
 
-#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:549
 msgid "Low"
 msgstr "Baixo"
 
-#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:549
+#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:550
 msgid "Moderate"
 msgstr "Moderado"
 
-#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:550
+#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:551
 msgid "High"
 msgstr "Alto"
 
@@ -1305,23 +1322,23 @@ msgstr "Controlador de Ganho"
 msgid "Target Level"
 msgstr "Nível Alvo"
 
-#: data/ui/webrtc.glade:448
+#: data/ui/webrtc.glade:449
 msgid "Maximum Gain"
 msgstr "Ganho Máximo"
 
-#: data/ui/webrtc.glade:521
+#: data/ui/webrtc.glade:522
 msgid "Detection Likelihood"
 msgstr "Probabilidade de Detecção"
 
-#: data/ui/webrtc.glade:534
+#: data/ui/webrtc.glade:535
 msgid "Frame Size"
 msgstr "Tamanho do Quadro"
 
-#: data/ui/webrtc.glade:547
+#: data/ui/webrtc.glade:548
 msgid "Very Low"
 msgstr "Muito Baixo"
 
-#: data/ui/webrtc.glade:584
+#: data/ui/webrtc.glade:585
 msgid "Voice Detector"
 msgstr "Detector de Voz"
 
@@ -1493,11 +1510,6 @@ msgstr "Equalizador, Compressor e Outros Efeitos de Áudio"
 msgid "limiter;compressor;reverberation;equalizer;autovolume;"
 msgstr "limitador;compressor;reverberação;equalizador;autovolume;"
 
-#. Translators: This is an icon name, don't translate!
-#: data/com.github.wwmm.pulseeffects.desktop.in:10
-msgid "pulseeffects"
-msgstr "pulseeffects"
-
 #: data/schemas/com.github.wwmm.pulseeffects.gschema.xml:201
 msgid "\"Presets\""
 msgstr "\"Predefinições\""
@@ -1522,11 +1534,11 @@ msgstr "Redefinir o PulseEffects."
 msgid "Global bypass. 1 to enable, 2 to disable and 3 to get status"
 msgstr ""
 
-#: src/application.cpp:263
+#: src/application.cpp:250
 msgid "Output Presets: "
 msgstr "Predefinições de Saída: "
 
-#: src/application.cpp:271
+#: src/application.cpp:258
 msgid "Input Presets: "
 msgstr "Predefinições de Entrada: "
 
@@ -1538,27 +1550,27 @@ msgstr "Aplicativos"
 msgid "Blacklist"
 msgstr "Lista Negra"
 
-#: src/general_settings_ui.cpp:121
+#: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Geral"
 
-#: src/pulse_settings_ui.cpp:138
+#: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Open"
 msgstr "Abrir"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/app_info_ui.cpp:85
+#: src/app_info_ui.cpp:86
 msgid "paused"
 msgstr "pausado"
 
-#: src/app_info_ui.cpp:87
+#: src/app_info_ui.cpp:88
 msgid "playing"
 msgstr "tocando"
 
@@ -1566,21 +1578,24 @@ msgstr "tocando"
 msgid "Calibration Microphone"
 msgstr "Microfone de Calibração"
 
-#: src/convolver_ui.cpp:246
+#: src/convolver_ui.cpp:252
 msgid "Import Impulse File"
 msgstr "Importar Arquivo com a Resposta de Impulso"
 
-#: src/convolver_ui.cpp:290 src/convolver_ui.cpp:291 src/convolver_ui.cpp:293
+#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
 msgid "Failed"
 msgstr "Falhou"
 
-#: src/convolver_ui.cpp:295
+#: src/convolver_ui.cpp:302
 msgid "Could Not Load The Impulse File"
 msgstr "Não Foi Possível Carregar o Arquivo com o Impulso"
 
-#: src/equalizer_ui.cpp:307 src/equalizer_ui.cpp:426
+#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
 msgid "infinity"
 msgstr "infinito"
+
+#~ msgid "pulseeffects"
+#~ msgstr "pulseeffects"
 
 #~ msgid "PulseEffects was updated"
 #~ msgstr "PulseEffects foi atualizado"

--- a/po/pulseeffects.pot
+++ b/po/pulseeffects.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pulseeffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-28 14:03-0300\n"
+"POT-Creation-Date: 2020-05-02 00:54+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,7 +44,7 @@ msgstr ""
 #: data/ui/application.glade:200 data/ui/filter.glade:204
 #: data/ui/equalizer.glade:309 data/ui/reverb.glade:284
 #: data/ui/crossfeed.glade:47 src/presets_menu_ui.cpp:115
-#: src/presets_menu_ui.cpp:274 src/presets_menu_ui.cpp:291
+#: src/presets_menu_ui.cpp:278 src/presets_menu_ui.cpp:295
 msgid "Presets"
 msgstr ""
 
@@ -322,37 +322,37 @@ msgid "Weights"
 msgstr ""
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:718
+#: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:244 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:487
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
-#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:210
+#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
 #: data/ui/presets_menu.glade:255
 msgid "Input"
 msgstr ""
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:733
+#: data/ui/limiter.glade:380 data/ui/compressor.glade:731
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:531 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:259 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
 #: data/ui/convolver.glade:492 data/ui/crystalizer.glade:243
-#: data/ui/pitch.glade:336 data/ui/webrtc.glade:639 data/ui/delay.glade:225
+#: data/ui/pitch.glade:336 data/ui/webrtc.glade:638 data/ui/delay.glade:223
 #: data/ui/presets_menu.glade:146
 msgid "Output"
 msgstr ""
@@ -361,7 +361,7 @@ msgstr ""
 msgid "Relative"
 msgstr ""
 
-#: data/ui/autogain.glade:721 data/ui/compressor.glade:900
+#: data/ui/autogain.glade:721 data/ui/compressor.glade:897
 #: data/ui/deesser.glade:295
 msgid "Gain"
 msgstr ""
@@ -373,6 +373,18 @@ msgstr ""
 
 #: data/ui/autogain.glade:840
 msgid "Range"
+msgstr ""
+
+#: data/ui/autogain.glade:892 data/ui/limiter.glade:569
+#: data/ui/compressor.glade:1039 data/ui/multiband_compressor.glade:2154
+#: data/ui/filter.glade:564 data/ui/equalizer.glade:707
+#: data/ui/reverb.glade:826 data/ui/bass_enhancer.glade:627
+#: data/ui/exciter.glade:631 data/ui/stereo_tools.glade:1001
+#: data/ui/crossfeed.glade:364 data/ui/maximizer.glade:444
+#: data/ui/loudness.glade:404 data/ui/gate.glade:691
+#: data/ui/multiband_gate.glade:2303 data/ui/deesser.glade:813
+#: data/ui/pitch.glade:517 data/ui/webrtc.glade:785 data/ui/delay.glade:404
+msgid "Provided by"
 msgstr ""
 
 #: data/ui/limiter.glade:30 data/ui/webrtc.glade:395
@@ -391,7 +403,7 @@ msgstr ""
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
-#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:213
+#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
 #: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
@@ -415,7 +427,7 @@ msgid "Attenuation"
 msgstr ""
 
 #: data/ui/compressor.glade:30 data/ui/compressor.glade:442
-#: data/ui/webrtc.glade:482 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
+#: data/ui/webrtc.glade:483 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
 msgid "Compressor"
 msgstr ""
 
@@ -547,12 +559,12 @@ msgstr ""
 msgid "Side"
 msgstr ""
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr ""
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr ""
@@ -561,11 +573,11 @@ msgstr ""
 msgid "Source"
 msgstr ""
 
-#: data/ui/compressor.glade:676 data/ui/compressor.glade:913
+#: data/ui/compressor.glade:676 data/ui/compressor.glade:910
 msgid "Sidechain"
 msgstr ""
 
-#: data/ui/compressor.glade:989
+#: data/ui/compressor.glade:986
 msgid "Curve"
 msgstr ""
 
@@ -963,7 +975,7 @@ msgstr ""
 msgid "Exciter"
 msgstr ""
 
-#: data/ui/exciter.glade:358 data/ui/maximizer.glade:159
+#: data/ui/exciter.glade:358 data/ui/maximizer.glade:139
 msgid "Ceiling"
 msgstr ""
 
@@ -1063,7 +1075,7 @@ msgstr ""
 msgid "Feed"
 msgstr ""
 
-#: data/ui/crossfeed.glade:392
+#: data/ui/crossfeed.glade:432
 msgid "Crossfeed"
 msgstr ""
 
@@ -1171,7 +1183,7 @@ msgstr ""
 msgid "Samples"
 msgstr ""
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:251
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
 msgid "Impulse Response"
 msgstr ""
 
@@ -1179,7 +1191,7 @@ msgstr ""
 msgid "Select the impulse Response File"
 msgstr ""
 
-#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:143
+#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:145
 msgid "Spectrum"
 msgstr ""
 
@@ -1235,12 +1247,16 @@ msgstr ""
 msgid "Crispness"
 msgstr ""
 
+#: data/ui/pitch.glade:529
+msgid "Rubber Band"
+msgstr ""
+
 #: data/ui/webrtc.glade:30
 msgid "Webrtc"
 msgstr ""
 
 #: data/ui/webrtc.glade:137 data/ui/webrtc.glade:257 data/ui/webrtc.glade:327
-#: data/ui/webrtc.glade:496
+#: data/ui/webrtc.glade:497
 msgid "Enable"
 msgstr ""
 
@@ -1260,15 +1276,15 @@ msgstr ""
 msgid "Suppresion Level"
 msgstr ""
 
-#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:549
 msgid "Low"
 msgstr ""
 
-#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:549
+#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:550
 msgid "Moderate"
 msgstr ""
 
-#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:550
+#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:551
 msgid "High"
 msgstr ""
 
@@ -1300,23 +1316,23 @@ msgstr ""
 msgid "Target Level"
 msgstr ""
 
-#: data/ui/webrtc.glade:448
+#: data/ui/webrtc.glade:449
 msgid "Maximum Gain"
 msgstr ""
 
-#: data/ui/webrtc.glade:521
+#: data/ui/webrtc.glade:522
 msgid "Detection Likelihood"
 msgstr ""
 
-#: data/ui/webrtc.glade:534
+#: data/ui/webrtc.glade:535
 msgid "Frame Size"
 msgstr ""
 
-#: data/ui/webrtc.glade:547
+#: data/ui/webrtc.glade:548
 msgid "Very Low"
 msgstr ""
 
-#: data/ui/webrtc.glade:584
+#: data/ui/webrtc.glade:585
 msgid "Voice Detector"
 msgstr ""
 
@@ -1472,11 +1488,6 @@ msgstr ""
 msgid "limiter;compressor;reverberation;equalizer;autovolume;"
 msgstr ""
 
-#. Translators: This is an icon name, don't translate!
-#: data/com.github.wwmm.pulseeffects.desktop.in:10
-msgid "pulseeffects"
-msgstr ""
-
 #: data/schemas/com.github.wwmm.pulseeffects.gschema.xml:201
 msgid "\"Presets\""
 msgstr ""
@@ -1501,11 +1512,11 @@ msgstr ""
 msgid "Global bypass. 1 to enable, 2 to disable and 3 to get status"
 msgstr ""
 
-#: src/application.cpp:263
+#: src/application.cpp:250
 msgid "Output Presets: "
 msgstr ""
 
-#: src/application.cpp:271
+#: src/application.cpp:258
 msgid "Input Presets: "
 msgstr ""
 
@@ -1517,27 +1528,27 @@ msgstr ""
 msgid "Blacklist"
 msgstr ""
 
-#: src/general_settings_ui.cpp:121
+#: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr ""
 
-#: src/pulse_settings_ui.cpp:138
+#: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr ""
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Open"
 msgstr ""
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Cancel"
 msgstr ""
 
-#: src/app_info_ui.cpp:85
+#: src/app_info_ui.cpp:86
 msgid "paused"
 msgstr ""
 
-#: src/app_info_ui.cpp:87
+#: src/app_info_ui.cpp:88
 msgid "playing"
 msgstr ""
 
@@ -1545,18 +1556,18 @@ msgstr ""
 msgid "Calibration Microphone"
 msgstr ""
 
-#: src/convolver_ui.cpp:246
+#: src/convolver_ui.cpp:252
 msgid "Import Impulse File"
 msgstr ""
 
-#: src/convolver_ui.cpp:290 src/convolver_ui.cpp:291 src/convolver_ui.cpp:293
+#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
 msgid "Failed"
 msgstr ""
 
-#: src/convolver_ui.cpp:295
+#: src/convolver_ui.cpp:302
 msgid "Could Not Load The Impulse File"
 msgstr ""
 
-#: src/equalizer_ui.cpp:307 src/equalizer_ui.cpp:426
+#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
 msgid "infinity"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-28 14:03-0300\n"
+"POT-Creation-Date: 2020-05-02 00:54+0200\n"
 "PO-Revision-Date: 2018-07-18 22:14+0300\n"
 "Last-Translator: Mikhail Novosyolov <mikhailnov@dumalogiya.ru>\n"
 "Language-Team: \n"
@@ -47,7 +47,7 @@ msgstr "Справка"
 #: data/ui/application.glade:200 data/ui/filter.glade:204
 #: data/ui/equalizer.glade:309 data/ui/reverb.glade:284
 #: data/ui/crossfeed.glade:47 src/presets_menu_ui.cpp:115
-#: src/presets_menu_ui.cpp:274 src/presets_menu_ui.cpp:291
+#: src/presets_menu_ui.cpp:278 src/presets_menu_ui.cpp:295
 msgid "Presets"
 msgstr "Предустановки"
 
@@ -344,37 +344,37 @@ msgstr "Вес в расчете громкости"
 # msgstr "Влияние комплексных измерений"
 # ###############################################
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:718
+#: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:244 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:487
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
-#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:210
+#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
 #: data/ui/presets_menu.glade:255
 msgid "Input"
 msgstr "Вход"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:733
+#: data/ui/limiter.glade:380 data/ui/compressor.glade:731
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:531 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:259 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
 #: data/ui/convolver.glade:492 data/ui/crystalizer.glade:243
-#: data/ui/pitch.glade:336 data/ui/webrtc.glade:639 data/ui/delay.glade:225
+#: data/ui/pitch.glade:336 data/ui/webrtc.glade:638 data/ui/delay.glade:223
 #: data/ui/presets_menu.glade:146
 msgid "Output"
 msgstr "Выход"
@@ -383,7 +383,7 @@ msgstr "Выход"
 msgid "Relative"
 msgstr "Относительное значение"
 
-#: data/ui/autogain.glade:721 data/ui/compressor.glade:900
+#: data/ui/autogain.glade:721 data/ui/compressor.glade:897
 #: data/ui/deesser.glade:295
 msgid "Gain"
 msgstr "Усиление"
@@ -397,6 +397,18 @@ msgstr "Громкость"
 #: data/ui/autogain.glade:840
 msgid "Range"
 msgstr "Диапазон"
+
+#: data/ui/autogain.glade:892 data/ui/limiter.glade:569
+#: data/ui/compressor.glade:1039 data/ui/multiband_compressor.glade:2154
+#: data/ui/filter.glade:564 data/ui/equalizer.glade:707
+#: data/ui/reverb.glade:826 data/ui/bass_enhancer.glade:627
+#: data/ui/exciter.glade:631 data/ui/stereo_tools.glade:1001
+#: data/ui/crossfeed.glade:364 data/ui/maximizer.glade:444
+#: data/ui/loudness.glade:404 data/ui/gate.glade:691
+#: data/ui/multiband_gate.glade:2303 data/ui/deesser.glade:813
+#: data/ui/pitch.glade:517 data/ui/webrtc.glade:785 data/ui/delay.glade:404
+msgid "Provided by"
+msgstr ""
 
 #: data/ui/limiter.glade:30 data/ui/webrtc.glade:395
 msgid "Limiter"
@@ -414,7 +426,7 @@ msgstr "Ограничение"
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
-#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:213
+#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
 #: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
@@ -438,7 +450,7 @@ msgid "Attenuation"
 msgstr "Затухание"
 
 #: data/ui/compressor.glade:30 data/ui/compressor.glade:442
-#: data/ui/webrtc.glade:482 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
+#: data/ui/webrtc.glade:483 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
 msgid "Compressor"
 msgstr "Компрессор"
 
@@ -571,12 +583,12 @@ msgstr "Средний"
 msgid "Side"
 msgstr "Усиление ввода [дБ]"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr "Левый"
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr "Правый"
@@ -587,11 +599,11 @@ msgid "Source"
 msgstr "Средний источник"
 
 # #, fuzzy
-#: data/ui/compressor.glade:676 data/ui/compressor.glade:913
+#: data/ui/compressor.glade:676 data/ui/compressor.glade:910
 msgid "Sidechain"
 msgstr "Усиление ввода [дБ]"
 
-#: data/ui/compressor.glade:989
+#: data/ui/compressor.glade:986
 msgid "Curve"
 msgstr "Кривая"
 
@@ -994,7 +1006,7 @@ msgstr "Нижний порог"
 msgid "Exciter"
 msgstr "Генератор"
 
-#: data/ui/exciter.glade:358 data/ui/maximizer.glade:159
+#: data/ui/exciter.glade:358 data/ui/maximizer.glade:139
 msgid "Ceiling"
 msgstr "Верхний порог"
 
@@ -1094,7 +1106,7 @@ msgstr "Усечение"
 msgid "Feed"
 msgstr "Подача"
 
-#: data/ui/crossfeed.glade:392
+#: data/ui/crossfeed.glade:432
 msgid "Crossfeed"
 msgstr "Перекрестная подача"
 
@@ -1205,7 +1217,7 @@ msgstr "Продолжительность"
 msgid "Samples"
 msgstr "Образцы"
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:251
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
 msgid "Impulse Response"
 msgstr "Импульсная реакция"
 
@@ -1213,7 +1225,7 @@ msgstr "Импульсная реакция"
 msgid "Select the impulse Response File"
 msgstr "Выбрать файл с импульсной реакцией"
 
-#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:143
+#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:145
 msgid "Spectrum"
 msgstr "Спектр"
 
@@ -1269,12 +1281,17 @@ msgstr "Октавы"
 msgid "Crispness"
 msgstr "Чёткость"
 
+#: data/ui/pitch.glade:529
+#, fuzzy
+msgid "Rubber Band"
+msgstr "Поддиапазон"
+
 #: data/ui/webrtc.glade:30
 msgid "Webrtc"
 msgstr "Webrtc"
 
 #: data/ui/webrtc.glade:137 data/ui/webrtc.glade:257 data/ui/webrtc.glade:327
-#: data/ui/webrtc.glade:496
+#: data/ui/webrtc.glade:497
 msgid "Enable"
 msgstr "Включить"
 
@@ -1294,15 +1311,15 @@ msgstr "Высокачастотный фильтр"
 msgid "Suppresion Level"
 msgstr "Уровень подавления"
 
-#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:549
 msgid "Low"
 msgstr "Низкочастотный фильтр"
 
-#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:549
+#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:550
 msgid "Moderate"
 msgstr "Средний"
 
-#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:550
+#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:551
 msgid "High"
 msgstr "Высокий"
 
@@ -1335,24 +1352,24 @@ msgstr "Автоконтроль усиления (AGC)"
 msgid "Target Level"
 msgstr "Целевой результат"
 
-#: data/ui/webrtc.glade:448
+#: data/ui/webrtc.glade:449
 msgid "Maximum Gain"
 msgstr "Максимальное увеличение"
 
-#: data/ui/webrtc.glade:521
+#: data/ui/webrtc.glade:522
 msgid "Detection Likelihood"
 msgstr "Вероятность обнаружения"
 
 # Taking lingual shortcuts to squeeze it in the text box
-#: data/ui/webrtc.glade:534
+#: data/ui/webrtc.glade:535
 msgid "Frame Size"
 msgstr "Размер кадра"
 
-#: data/ui/webrtc.glade:547
+#: data/ui/webrtc.glade:548
 msgid "Very Low"
 msgstr "Очень низкий"
 
-#: data/ui/webrtc.glade:584
+#: data/ui/webrtc.glade:585
 msgid "Voice Detector"
 msgstr "Обнаруживатель голоса"
 
@@ -1524,11 +1541,6 @@ msgstr "Эквалайзер, Компрессор и другие аудиоэ�
 msgid "limiter;compressor;reverberation;equalizer;autovolume;"
 msgstr "лимитер;компрессор;ребербатор;эквалайзер;автогромкость;"
 
-#. Translators: This is an icon name, don't translate!
-#: data/com.github.wwmm.pulseeffects.desktop.in:10
-msgid "pulseeffects"
-msgstr ""
-
 #: data/schemas/com.github.wwmm.pulseeffects.gschema.xml:201
 msgid "\"Presets\""
 msgstr "\"Предустановки\""
@@ -1553,11 +1565,11 @@ msgstr "Сбросить настройки PulseEffects"
 msgid "Global bypass. 1 to enable, 2 to disable and 3 to get status"
 msgstr ""
 
-#: src/application.cpp:263
+#: src/application.cpp:250
 msgid "Output Presets: "
 msgstr "Выходные предустановки: "
 
-#: src/application.cpp:271
+#: src/application.cpp:258
 msgid "Input Presets: "
 msgstr "Входные предустановки: "
 
@@ -1569,27 +1581,27 @@ msgstr "Приложения"
 msgid "Blacklist"
 msgstr "Черный список"
 
-#: src/general_settings_ui.cpp:121
+#: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Общие"
 
-#: src/pulse_settings_ui.cpp:138
+#: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr ""
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Open"
 msgstr "Открыть"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Cancel"
 msgstr "Отмена"
 
-#: src/app_info_ui.cpp:85
+#: src/app_info_ui.cpp:86
 msgid "paused"
 msgstr "на паузе"
 
-#: src/app_info_ui.cpp:87
+#: src/app_info_ui.cpp:88
 msgid "playing"
 msgstr "воспроизводится"
 
@@ -1597,19 +1609,19 @@ msgstr "воспроизводится"
 msgid "Calibration Microphone"
 msgstr "Калибровка корректировки микрофона"
 
-#: src/convolver_ui.cpp:246
+#: src/convolver_ui.cpp:252
 msgid "Import Impulse File"
 msgstr "Импортировать импульс"
 
-#: src/convolver_ui.cpp:290 src/convolver_ui.cpp:291 src/convolver_ui.cpp:293
+#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
 msgid "Failed"
 msgstr "Не получилось"
 
-#: src/convolver_ui.cpp:295
+#: src/convolver_ui.cpp:302
 msgid "Could Not Load The Impulse File"
 msgstr "Не смогли загрузить файл с импульсными реакциями"
 
-#: src/equalizer_ui.cpp:307 src/equalizer_ui.cpp:426
+#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
 msgid "infinity"
 msgstr ""
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-28 14:03-0300\n"
+"POT-Creation-Date: 2020-05-02 00:54+0200\n"
 "PO-Revision-Date: 2019-09-07 22:19+0200\n"
 "Last-Translator: Mlocik97\n"
 "Language-Team: \n"
@@ -47,7 +47,7 @@ msgstr "Nápoveda"
 #: data/ui/application.glade:200 data/ui/filter.glade:204
 #: data/ui/equalizer.glade:309 data/ui/reverb.glade:284
 #: data/ui/crossfeed.glade:47 src/presets_menu_ui.cpp:115
-#: src/presets_menu_ui.cpp:274 src/presets_menu_ui.cpp:291
+#: src/presets_menu_ui.cpp:278 src/presets_menu_ui.cpp:295
 msgid "Presets"
 msgstr "Predvoľby"
 
@@ -343,37 +343,37 @@ msgid "Weights"
 msgstr "Váhy"
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:718
+#: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:244 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:487
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
-#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:210
+#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
 #: data/ui/presets_menu.glade:255
 msgid "Input"
 msgstr "Vstup"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:733
+#: data/ui/limiter.glade:380 data/ui/compressor.glade:731
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:531 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:259 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
 #: data/ui/convolver.glade:492 data/ui/crystalizer.glade:243
-#: data/ui/pitch.glade:336 data/ui/webrtc.glade:639 data/ui/delay.glade:225
+#: data/ui/pitch.glade:336 data/ui/webrtc.glade:638 data/ui/delay.glade:223
 #: data/ui/presets_menu.glade:146
 msgid "Output"
 msgstr "Výstup"
@@ -382,7 +382,7 @@ msgstr "Výstup"
 msgid "Relative"
 msgstr "Relatívna"
 
-#: data/ui/autogain.glade:721 data/ui/compressor.glade:900
+#: data/ui/autogain.glade:721 data/ui/compressor.glade:897
 #: data/ui/deesser.glade:295
 #, fuzzy
 msgid "Gain"
@@ -396,6 +396,18 @@ msgstr "Hlasitosť"
 #: data/ui/autogain.glade:840
 msgid "Range"
 msgstr "Rozsah"
+
+#: data/ui/autogain.glade:892 data/ui/limiter.glade:569
+#: data/ui/compressor.glade:1039 data/ui/multiband_compressor.glade:2154
+#: data/ui/filter.glade:564 data/ui/equalizer.glade:707
+#: data/ui/reverb.glade:826 data/ui/bass_enhancer.glade:627
+#: data/ui/exciter.glade:631 data/ui/stereo_tools.glade:1001
+#: data/ui/crossfeed.glade:364 data/ui/maximizer.glade:444
+#: data/ui/loudness.glade:404 data/ui/gate.glade:691
+#: data/ui/multiband_gate.glade:2303 data/ui/deesser.glade:813
+#: data/ui/pitch.glade:517 data/ui/webrtc.glade:785 data/ui/delay.glade:404
+msgid "Provided by"
+msgstr ""
 
 #: data/ui/limiter.glade:30 data/ui/webrtc.glade:395
 #, fuzzy
@@ -416,7 +428,7 @@ msgstr "Obmedzenie"
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
-#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:213
+#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
 #: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
@@ -441,7 +453,7 @@ msgid "Attenuation"
 msgstr "Zoslabenie"
 
 #: data/ui/compressor.glade:30 data/ui/compressor.glade:442
-#: data/ui/webrtc.glade:482 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
+#: data/ui/webrtc.glade:483 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
 msgid "Compressor"
 msgstr "Kompresor"
 
@@ -583,12 +595,12 @@ msgstr "Stredný"
 msgid "Side"
 msgstr "Postranný"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr "Ľavý"
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr "Pravý"
@@ -597,11 +609,11 @@ msgstr "Pravý"
 msgid "Source"
 msgstr "Zdroj"
 
-#: data/ui/compressor.glade:676 data/ui/compressor.glade:913
+#: data/ui/compressor.glade:676 data/ui/compressor.glade:910
 msgid "Sidechain"
 msgstr ""
 
-#: data/ui/compressor.glade:989
+#: data/ui/compressor.glade:986
 msgid "Curve"
 msgstr "Krivka"
 
@@ -1014,7 +1026,7 @@ msgstr ""
 msgid "Exciter"
 msgstr ""
 
-#: data/ui/exciter.glade:358 data/ui/maximizer.glade:159
+#: data/ui/exciter.glade:358 data/ui/maximizer.glade:139
 #, fuzzy
 msgid "Ceiling"
 msgstr "Obmedzenie [dB]"
@@ -1122,7 +1134,7 @@ msgstr "Zrezanie [Hz]"
 msgid "Feed"
 msgstr "Koleno [dB]"
 
-#: data/ui/crossfeed.glade:392
+#: data/ui/crossfeed.glade:432
 msgid "Crossfeed"
 msgstr ""
 
@@ -1236,7 +1248,7 @@ msgstr "Zoslabenie"
 msgid "Samples"
 msgstr "Vzorky"
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:251
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
 msgid "Impulse Response"
 msgstr ""
 
@@ -1244,7 +1256,7 @@ msgstr ""
 msgid "Select the impulse Response File"
 msgstr "Zvolte Súbor impulse"
 
-#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:143
+#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:145
 #, fuzzy
 msgid "Spectrum"
 msgstr "Zobraziť spektrum"
@@ -1303,12 +1315,17 @@ msgstr ""
 msgid "Crispness"
 msgstr ""
 
+#: data/ui/pitch.glade:529
+#, fuzzy
+msgid "Rubber Band"
+msgstr "Spodné Pásmo"
+
 #: data/ui/webrtc.glade:30
 msgid "Webrtc"
 msgstr ""
 
 #: data/ui/webrtc.glade:137 data/ui/webrtc.glade:257 data/ui/webrtc.glade:327
-#: data/ui/webrtc.glade:496
+#: data/ui/webrtc.glade:497
 msgid "Enable"
 msgstr "Povolené"
 
@@ -1330,15 +1347,15 @@ msgstr "Horný prechod"
 msgid "Suppresion Level"
 msgstr "Redukcia zosilnenia"
 
-#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:549
 msgid "Low"
 msgstr ""
 
-#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:549
+#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:550
 msgid "Moderate"
 msgstr ""
 
-#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:550
+#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:551
 #, fuzzy
 msgid "High"
 msgstr "Horný prechod"
@@ -1374,25 +1391,25 @@ msgstr ""
 msgid "Target Level"
 msgstr "Prah [dB]"
 
-#: data/ui/webrtc.glade:448
+#: data/ui/webrtc.glade:449
 msgid "Maximum Gain"
 msgstr "Maximálny Zisk"
 
-#: data/ui/webrtc.glade:521
+#: data/ui/webrtc.glade:522
 #, fuzzy
 msgid "Detection Likelihood"
 msgstr "Zoslabenie"
 
-#: data/ui/webrtc.glade:534
+#: data/ui/webrtc.glade:535
 #, fuzzy
 msgid "Frame Size"
 msgstr "Veľkosť miestnosti"
 
-#: data/ui/webrtc.glade:547
+#: data/ui/webrtc.glade:548
 msgid "Very Low"
 msgstr ""
 
-#: data/ui/webrtc.glade:584
+#: data/ui/webrtc.glade:585
 #, fuzzy
 msgid "Voice Detector"
 msgstr "Zoslabenie"
@@ -1553,11 +1570,6 @@ msgstr "Ekvalizér, Kompresor a Ďalšie Audio Efekty"
 msgid "limiter;compressor;reverberation;equalizer;autovolume;"
 msgstr ""
 
-#. Translators: This is an icon name, don't translate!
-#: data/com.github.wwmm.pulseeffects.desktop.in:10
-msgid "pulseeffects"
-msgstr ""
-
 #: data/schemas/com.github.wwmm.pulseeffects.gschema.xml:201
 #, fuzzy
 msgid "\"Presets\""
@@ -1583,12 +1595,12 @@ msgstr "Resetnúť PulseEffects"
 msgid "Global bypass. 1 to enable, 2 to disable and 3 to get status"
 msgstr ""
 
-#: src/application.cpp:263
+#: src/application.cpp:250
 #, fuzzy
 msgid "Output Presets: "
 msgstr "Predvoľby"
 
-#: src/application.cpp:271
+#: src/application.cpp:258
 #, fuzzy
 msgid "Input Presets: "
 msgstr "Načítať predvoľbu"
@@ -1601,27 +1613,27 @@ msgstr "Aplikácie"
 msgid "Blacklist"
 msgstr "Čierny List"
 
-#: src/general_settings_ui.cpp:121
+#: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Všeobecné"
 
-#: src/pulse_settings_ui.cpp:138
+#: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Open"
 msgstr "Otvoriť"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: src/app_info_ui.cpp:85
+#: src/app_info_ui.cpp:86
 msgid "paused"
 msgstr "pozastavené"
 
-#: src/app_info_ui.cpp:87
+#: src/app_info_ui.cpp:88
 msgid "playing"
 msgstr "hrá"
 
@@ -1629,20 +1641,20 @@ msgstr "hrá"
 msgid "Calibration Microphone"
 msgstr "Kalibrovať Mikrofón"
 
-#: src/convolver_ui.cpp:246
+#: src/convolver_ui.cpp:252
 #, fuzzy
 msgid "Import Impulse File"
 msgstr "Načítať predvoľbu"
 
-#: src/convolver_ui.cpp:290 src/convolver_ui.cpp:291 src/convolver_ui.cpp:293
+#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
 msgid "Failed"
 msgstr "Zlyhalo"
 
-#: src/convolver_ui.cpp:295
+#: src/convolver_ui.cpp:302
 msgid "Could Not Load The Impulse File"
 msgstr "Nie Je Možné Načítať Impulse súbor"
 
-#: src/equalizer_ui.cpp:307 src/equalizer_ui.cpp:426
+#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
 msgid "infinity"
 msgstr "Nekonečno"
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-28 14:03-0300\n"
+"POT-Creation-Date: 2020-05-02 00:54+0200\n"
 "PO-Revision-Date: 2017-10-14 10:20+0200\n"
 "Last-Translator: Patrik Nilsson <translation_AT_hembas.se>\n"
 "Language-Team: \n"
@@ -45,7 +45,7 @@ msgstr ""
 #: data/ui/application.glade:200 data/ui/filter.glade:204
 #: data/ui/equalizer.glade:309 data/ui/reverb.glade:284
 #: data/ui/crossfeed.glade:47 src/presets_menu_ui.cpp:115
-#: src/presets_menu_ui.cpp:274 src/presets_menu_ui.cpp:291
+#: src/presets_menu_ui.cpp:278 src/presets_menu_ui.cpp:295
 msgid "Presets"
 msgstr "Profiler"
 
@@ -342,37 +342,37 @@ msgid "Weights"
 msgstr ""
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:718
+#: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:244 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:487
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
-#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:210
+#: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
 #: data/ui/presets_menu.glade:255
 msgid "Input"
 msgstr "Ingång"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:733
+#: data/ui/limiter.glade:380 data/ui/compressor.glade:731
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:531 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:259 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
 #: data/ui/convolver.glade:492 data/ui/crystalizer.glade:243
-#: data/ui/pitch.glade:336 data/ui/webrtc.glade:639 data/ui/delay.glade:225
+#: data/ui/pitch.glade:336 data/ui/webrtc.glade:638 data/ui/delay.glade:223
 #: data/ui/presets_menu.glade:146
 msgid "Output"
 msgstr "Utgång"
@@ -381,7 +381,7 @@ msgstr "Utgång"
 msgid "Relative"
 msgstr ""
 
-#: data/ui/autogain.glade:721 data/ui/compressor.glade:900
+#: data/ui/autogain.glade:721 data/ui/compressor.glade:897
 #: data/ui/deesser.glade:295
 #, fuzzy
 msgid "Gain"
@@ -394,6 +394,18 @@ msgstr ""
 
 #: data/ui/autogain.glade:840
 msgid "Range"
+msgstr ""
+
+#: data/ui/autogain.glade:892 data/ui/limiter.glade:569
+#: data/ui/compressor.glade:1039 data/ui/multiband_compressor.glade:2154
+#: data/ui/filter.glade:564 data/ui/equalizer.glade:707
+#: data/ui/reverb.glade:826 data/ui/bass_enhancer.glade:627
+#: data/ui/exciter.glade:631 data/ui/stereo_tools.glade:1001
+#: data/ui/crossfeed.glade:364 data/ui/maximizer.glade:444
+#: data/ui/loudness.glade:404 data/ui/gate.glade:691
+#: data/ui/multiband_gate.glade:2303 data/ui/deesser.glade:813
+#: data/ui/pitch.glade:517 data/ui/webrtc.glade:785 data/ui/delay.glade:404
+msgid "Provided by"
 msgstr ""
 
 #: data/ui/limiter.glade:30 data/ui/webrtc.glade:395
@@ -415,7 +427,7 @@ msgstr "Gränsvärde (dB)"
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
-#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:213
+#: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
 #: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
@@ -440,7 +452,7 @@ msgid "Attenuation"
 msgstr "Försvagning"
 
 #: data/ui/compressor.glade:30 data/ui/compressor.glade:442
-#: data/ui/webrtc.glade:482 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
+#: data/ui/webrtc.glade:483 data/com.github.wwmm.pulseeffects.appdata.xml.in:52
 msgid "Compressor"
 msgstr "Kompressor"
 
@@ -583,12 +595,12 @@ msgstr "Nivå"
 msgid "Side"
 msgstr "Ingångsförstärkning (dB)"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr ""
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr ""
@@ -597,12 +609,12 @@ msgstr ""
 msgid "Source"
 msgstr ""
 
-#: data/ui/compressor.glade:676 data/ui/compressor.glade:913
+#: data/ui/compressor.glade:676 data/ui/compressor.glade:910
 #, fuzzy
 msgid "Sidechain"
 msgstr "Ingångsförstärkning (dB)"
 
-#: data/ui/compressor.glade:989
+#: data/ui/compressor.glade:986
 msgid "Curve"
 msgstr ""
 
@@ -1018,7 +1030,7 @@ msgstr ""
 msgid "Exciter"
 msgstr ""
 
-#: data/ui/exciter.glade:358 data/ui/maximizer.glade:159
+#: data/ui/exciter.glade:358 data/ui/maximizer.glade:139
 #, fuzzy
 msgid "Ceiling"
 msgstr "Gränsvärde (dB)"
@@ -1134,7 +1146,7 @@ msgstr "Cut-off (Hz)"
 msgid "Feed"
 msgstr "Knee-värde (dB)"
 
-#: data/ui/crossfeed.glade:392
+#: data/ui/crossfeed.glade:432
 msgid "Crossfeed"
 msgstr ""
 
@@ -1251,7 +1263,7 @@ msgstr "Kalibrering"
 msgid "Samples"
 msgstr "Resampler"
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:251
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
 #, fuzzy
 msgid "Impulse Response"
 msgstr "Platt respons"
@@ -1261,7 +1273,7 @@ msgstr "Platt respons"
 msgid "Select the impulse Response File"
 msgstr "Platt respons"
 
-#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:143
+#: data/ui/convolver.glade:382 src/spectrum_settings_ui.cpp:145
 msgid "Spectrum"
 msgstr "Spektrum"
 
@@ -1320,12 +1332,17 @@ msgstr ""
 msgid "Crispness"
 msgstr ""
 
+#: data/ui/pitch.glade:529
+#, fuzzy
+msgid "Rubber Band"
+msgstr "Ljudstyrka (dB) (in)"
+
 #: data/ui/webrtc.glade:30
 msgid "Webrtc"
 msgstr ""
 
 #: data/ui/webrtc.glade:137 data/ui/webrtc.glade:257 data/ui/webrtc.glade:327
-#: data/ui/webrtc.glade:496
+#: data/ui/webrtc.glade:497
 #, fuzzy
 msgid "Enable"
 msgstr "Sinustabell"
@@ -1348,15 +1365,15 @@ msgstr "Högpass"
 msgid "Suppresion Level"
 msgstr "Förstärkningsreducering"
 
-#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:225 data/ui/webrtc.glade:293 data/ui/webrtc.glade:549
 msgid "Low"
 msgstr ""
 
-#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:549
+#: data/ui/webrtc.glade:226 data/ui/webrtc.glade:294 data/ui/webrtc.glade:550
 msgid "Moderate"
 msgstr ""
 
-#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:550
+#: data/ui/webrtc.glade:227 data/ui/webrtc.glade:295 data/ui/webrtc.glade:551
 #, fuzzy
 msgid "High"
 msgstr "Högpass"
@@ -1393,25 +1410,25 @@ msgstr ""
 msgid "Target Level"
 msgstr "Målvärde (dB)"
 
-#: data/ui/webrtc.glade:448
+#: data/ui/webrtc.glade:449
 msgid "Maximum Gain"
 msgstr ""
 
-#: data/ui/webrtc.glade:521
+#: data/ui/webrtc.glade:522
 #, fuzzy
 msgid "Detection Likelihood"
 msgstr "Försvagning"
 
-#: data/ui/webrtc.glade:534
+#: data/ui/webrtc.glade:535
 #, fuzzy
 msgid "Frame Size"
 msgstr "Rumsstorlek"
 
-#: data/ui/webrtc.glade:547
+#: data/ui/webrtc.glade:548
 msgid "Very Low"
 msgstr ""
 
-#: data/ui/webrtc.glade:584
+#: data/ui/webrtc.glade:585
 #, fuzzy
 msgid "Voice Detector"
 msgstr "Försvagning"
@@ -1588,11 +1605,6 @@ msgid "limiter;compressor;reverberation;equalizer;autovolume;"
 msgstr ""
 "limiter;begränsare;kompressor;eko;efterklang;equalizer;utjämnare;auto;volym;"
 
-#. Translators: This is an icon name, don't translate!
-#: data/com.github.wwmm.pulseeffects.desktop.in:10
-msgid "pulseeffects"
-msgstr "pulseeffects"
-
 #: data/schemas/com.github.wwmm.pulseeffects.gschema.xml:201
 #, fuzzy
 msgid "\"Presets\""
@@ -1619,12 +1631,12 @@ msgstr "PulseEffects"
 msgid "Global bypass. 1 to enable, 2 to disable and 3 to get status"
 msgstr ""
 
-#: src/application.cpp:263
+#: src/application.cpp:250
 #, fuzzy
 msgid "Output Presets: "
 msgstr "Profiler"
 
-#: src/application.cpp:271
+#: src/application.cpp:258
 #, fuzzy
 msgid "Input Presets: "
 msgstr "Öppna förinställning"
@@ -1637,28 +1649,28 @@ msgstr "Program"
 msgid "Blacklist"
 msgstr ""
 
-#: src/general_settings_ui.cpp:121
+#: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Allmänt"
 
-#: src/pulse_settings_ui.cpp:138
+#: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr ""
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 msgid "Open"
 msgstr ""
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:247
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
 #, fuzzy
 msgid "Cancel"
 msgstr "Ljudförstärkare"
 
-#: src/app_info_ui.cpp:85
+#: src/app_info_ui.cpp:86
 msgid "paused"
 msgstr ""
 
-#: src/app_info_ui.cpp:87
+#: src/app_info_ui.cpp:88
 msgid "playing"
 msgstr ""
 
@@ -1667,22 +1679,25 @@ msgstr ""
 msgid "Calibration Microphone"
 msgstr "Kalibrering och mikrofon korrigering"
 
-#: src/convolver_ui.cpp:246
+#: src/convolver_ui.cpp:252
 #, fuzzy
 msgid "Import Impulse File"
 msgstr "Platt respons"
 
-#: src/convolver_ui.cpp:290 src/convolver_ui.cpp:291 src/convolver_ui.cpp:293
+#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
 msgid "Failed"
 msgstr ""
 
-#: src/convolver_ui.cpp:295
+#: src/convolver_ui.cpp:302
 msgid "Could Not Load The Impulse File"
 msgstr ""
 
-#: src/equalizer_ui.cpp:307 src/equalizer_ui.cpp:426
+#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
 msgid "infinity"
 msgstr ""
+
+#~ msgid "pulseeffects"
+#~ msgstr "pulseeffects"
 
 #, fuzzy
 #~ msgid "PulseEffects was updated"


### PR DESCRIPTION
Added a line in the UI as credit to the original author of the plugins, except Crystalizer and Convolver provided by PulseEffects. 

Related to #578. This can help users to figure out which package to install if the plugin is disabled.

Translated in Italian, need to be translated in other languages.

Successfully compiled and tested. 