### PR TITLE
Reset a single plugin individually

### DIFF
--- a/data/ui/autogain.glade
+++ b/data/ui/autogain.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkImage" id="image1">
@@ -926,11 +926,47 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/data/ui/bass_enhancer.glade
+++ b/data/ui/bass_enhancer.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="amount">
@@ -22,11 +22,11 @@
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="harmonics">
-    <property name="lower">0.10000000000000001</property>
+    <property name="lower">0.1</property>
     <property name="upper">10</property>
     <property name="value">8.5</property>
-    <property name="step_increment">0.10000000000000001</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="step_increment">0.1</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkImage" id="image1">
     <property name="visible">True</property>
@@ -636,7 +636,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="no">Calf Studio Gears</property>
+                <property name="label">Calf Studio Gears</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -661,11 +661,47 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/data/ui/compressor.glade
+++ b/data/ui/compressor.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="attack">
@@ -93,7 +93,7 @@
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="knee">
-    <property name="lower">-23.800000000000001</property>
+    <property name="lower">-23.80</property>
     <property name="value">-6</property>
     <property name="step_increment">0.01</property>
     <property name="page_increment">1</property>
@@ -102,7 +102,7 @@
   <object class="GtkAdjustment" id="lookahead">
     <property name="upper">20</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="page_increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="makeup">
     <property name="lower">-60</property>
@@ -120,20 +120,20 @@
   <object class="GtkAdjustment" id="preamp">
     <property name="upper">40</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="page_increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="ratio">
     <property name="lower">1</property>
     <property name="upper">100</property>
     <property name="value">4</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="page_increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="reactivity">
     <property name="upper">250</property>
     <property name="value">10</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="page_increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="release">
     <property name="upper">5000</property>
@@ -1048,7 +1048,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="no">Linux Studio Plugins</property>
+                <property name="label">Linux Studio Plugins</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -1073,11 +1073,47 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/data/ui/convolver.glade
+++ b/data/ui/convolver.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkImage" id="image1">
@@ -667,11 +667,47 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/data/ui/crossfeed.glade
+++ b/data/ui/crossfeed.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="fcut">
@@ -12,8 +12,8 @@
   <object class="GtkAdjustment" id="feed">
     <property name="lower">1</property>
     <property name="upper">15</property>
-    <property name="value">4.5</property>
-    <property name="step_increment">0.10000000000000001</property>
+    <property name="value">4.50</property>
+    <property name="step_increment">0.10</property>
     <property name="page_increment">1</property>
     <signal name="value-changed" handler="on_feed_value_changed" swapped="no"/>
   </object>
@@ -373,7 +373,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="no">bs2b</property>
+                <property name="label">bs2b</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -398,11 +398,47 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/data/ui/crystalizer.glade
+++ b/data/ui/crystalizer.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="freq1">
@@ -530,11 +530,47 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/data/ui/deesser.glade
+++ b/data/ui/deesser.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="f1_freq">
@@ -33,10 +33,10 @@
     <signal name="value-changed" handler="on_f2_level_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="f2_q">
-    <property name="lower">0.10000000000000001</property>
+    <property name="lower">0.10</property>
     <property name="upper">100</property>
     <property name="value">1</property>
-    <property name="step_increment">0.10000000000000001</property>
+    <property name="step_increment">0.10</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkImage" id="image1">
@@ -822,7 +822,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="no">Calf Studio Gears</property>
+                <property name="label">Calf Studio Gears</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -847,11 +847,47 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/data/ui/delay.glade
+++ b/data/ui/delay.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkImage" id="image1">
@@ -413,7 +413,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="no">Linux Studio Plugins</property>
+                <property name="label">Linux Studio Plugins</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -438,11 +438,47 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/data/ui/equalizer.glade
+++ b/data/ui/equalizer.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkImage" id="image1">
@@ -331,6 +331,12 @@
         </child>
       </object>
     </child>
+  </object>
+  <object class="GtkAdjustment" id="output_gain">
+    <property name="lower">-20</property>
+    <property name="upper">20</property>
+    <property name="step_increment">0.01</property>
+    <property name="page_increment">0.01</property>
   </object>
   <object class="GtkGrid" id="widgets_grid">
     <property name="visible">True</property>
@@ -716,7 +722,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="no">Linux Studio Plugins</property>
+                <property name="label">Linux Studio Plugins</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -741,22 +747,52 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>
         <property name="top_attach">0</property>
       </packing>
     </child>
-  </object>
-  <object class="GtkAdjustment" id="output_gain">
-    <property name="lower">-20</property>
-    <property name="upper">20</property>
-    <property name="step_increment">0.01</property>
-    <property name="page_increment">0.01</property>
   </object>
 </interface>

--- a/data/ui/exciter.glade
+++ b/data/ui/exciter.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="amount">
@@ -22,11 +22,11 @@
     <property name="page_increment">1000</property>
   </object>
   <object class="GtkAdjustment" id="harmonics">
-    <property name="lower">0.10000000000000001</property>
+    <property name="lower">0.10</property>
     <property name="upper">10</property>
-    <property name="value">8.5</property>
-    <property name="step_increment">0.10000000000000001</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="value">8.50</property>
+    <property name="step_increment">0.10</property>
+    <property name="page_increment">0.10</property>
   </object>
   <object class="GtkImage" id="image1">
     <property name="visible">True</property>
@@ -640,7 +640,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="no">Calf Studio Gears</property>
+                <property name="label">Calf Studio Gears</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -665,11 +665,47 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/data/ui/filter.glade
+++ b/data/ui/filter.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="frequency">
@@ -173,8 +173,8 @@
     <property name="lower">-3</property>
     <property name="upper">30</property>
     <property name="value">-3</property>
-    <property name="step_increment">0.10000000000000001</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="step_increment">0.10</property>
+    <property name="page_increment">0.10</property>
   </object>
   <object class="GtkGrid" id="widgets_grid">
     <property name="visible">True</property>
@@ -573,7 +573,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="no">Calf Studio Gears</property>
+                <property name="label">Calf Studio Gears</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -598,11 +598,47 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/data/ui/gate.glade
+++ b/data/ui/gate.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="attack">
@@ -700,7 +700,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="no">Calf Studio Gears</property>
+                <property name="label">Calf Studio Gears</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -725,11 +725,47 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/data/ui/limiter.glade
+++ b/data/ui/limiter.glade
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="asc_level">
     <property name="upper">1</property>
-    <property name="value">0.5</property>
+    <property name="value">0.50</property>
     <property name="step_increment">0.01</property>
     <property name="page_increment">0.01</property>
   </object>
@@ -100,11 +100,11 @@
     <signal name="value-changed" handler="on_limit_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="lookahead">
-    <property name="lower">0.10000000000000001</property>
+    <property name="lower">0.10</property>
     <property name="upper">10</property>
     <property name="value">5</property>
-    <property name="step_increment">0.10000000000000001</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="step_increment">0.10</property>
+    <property name="page_increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="oversampling">
     <property name="lower">1</property>
@@ -269,7 +269,7 @@
                 <property name="digits">2</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
-                <property name="value">0.5</property>
+                <property name="value">0.50</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
@@ -315,7 +315,7 @@
                 <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="width_chars">10</property>
-                <property name="text">1,00</property>
+                <property name="text">1.00</property>
                 <property name="input_purpose">number</property>
                 <property name="orientation">vertical</property>
                 <property name="adjustment">asc_level</property>
@@ -578,7 +578,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="no">Calf Studio Gears</property>
+                <property name="label">Calf Studio Gears</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -603,12 +603,48 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
-        <signal name="state-set" handler="on_limiter_enable_state_set" swapped="no"/>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+            <signal name="state-set" handler="on_limiter_enable_state_set" swapped="no"/>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/data/ui/loudness.glade
+++ b/data/ui/loudness.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkImage" id="image1">
@@ -82,13 +82,13 @@
   </object>
   <object class="GtkAdjustment" id="link">
     <property name="lower">-100</property>
-    <property name="value">-9.0999999999999996</property>
+    <property name="value">-9.10</property>
     <property name="step_increment">0.01</property>
     <property name="page_increment">0.01</property>
   </object>
   <object class="GtkAdjustment" id="loudness">
     <property name="lower">-100</property>
-    <property name="value">-3.1000000000000001</property>
+    <property name="value">-3.10</property>
     <property name="step_increment">0.01</property>
     <property name="page_increment">0.01</property>
   </object>
@@ -215,7 +215,7 @@
                 <property name="digits">2</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
-                <property name="value">4.5</property>
+                <property name="value">4.50</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
@@ -413,7 +413,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="no">MDA VST LV2</property>
+                <property name="label">MDA VST LV2</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -438,11 +438,47 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/data/ui/maximizer.glade
+++ b/data/ui/maximizer.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="ceiling">
@@ -88,7 +88,7 @@
   <object class="GtkAdjustment" id="release">
     <property name="lower">1</property>
     <property name="upper">100</property>
-    <property name="value">3.1600000000000001</property>
+    <property name="value">3.16</property>
     <property name="step_increment">0.01</property>
     <property name="page_increment">1</property>
   </object>
@@ -453,7 +453,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="no">ZamAudio</property>
+                <property name="label">ZamAudio</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -478,11 +478,47 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/data/ui/multiband_compressor.glade
+++ b/data/ui/multiband_compressor.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="attack0">
@@ -186,25 +186,25 @@
     <property name="upper">20</property>
     <property name="value">2</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="page_increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="ratio1">
     <property name="lower">1</property>
     <property name="upper">20</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="page_increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="ratio2">
     <property name="lower">1</property>
     <property name="upper">20</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="page_increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="ratio3">
     <property name="lower">1</property>
     <property name="upper">20</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="page_increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="release0">
     <property name="lower">0.01</property>
@@ -2163,7 +2163,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="no">Calf Studio Gears</property>
+                <property name="label">Calf Studio Gears</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -2188,11 +2188,47 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/data/ui/multiband_gate.glade
+++ b/data/ui/multiband_gate.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="attack0">
@@ -206,25 +206,25 @@
     <property name="upper">20</property>
     <property name="value">2</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="page_increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="ratio1">
     <property name="lower">1</property>
     <property name="upper">20</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="page_increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="ratio2">
     <property name="lower">1</property>
     <property name="upper">20</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="page_increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="ratio3">
     <property name="lower">1</property>
     <property name="upper">20</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="page_increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="release0">
     <property name="lower">0.01</property>
@@ -2312,7 +2312,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="no">Calf Studio Gears</property>
+                <property name="label">Calf Studio Gears</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -2337,11 +2337,47 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/data/ui/pitch.glade
+++ b/data/ui/pitch.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="cents">
@@ -551,11 +551,47 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/data/ui/reverb.glade
+++ b/data/ui/reverb.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="amount">
@@ -17,17 +17,17 @@
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="decay_time">
-    <property name="lower">0.40000000000000002</property>
+    <property name="lower">0.4</property>
     <property name="upper">15</property>
     <property name="value">1.5</property>
-    <property name="step_increment">0.10000000000000001</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="step_increment">0.1</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkAdjustment" id="diffusion">
     <property name="upper">1</property>
-    <property name="value">0.5</property>
+    <property name="value">0.50</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="page_increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="dry">
     <property name="lower">-100</property>
@@ -835,7 +835,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="no">Calf Studio Gears</property>
+                <property name="label">Calf Studio Gears</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -860,11 +860,47 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/data/ui/stereo_tools.glade
+++ b/data/ui/stereo_tools.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="balance_in">
@@ -1010,7 +1010,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="no">Calf Studio Gears</property>
+                <property name="label">Calf Studio Gears</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -1035,11 +1035,47 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/data/ui/webrtc.glade
+++ b/data/ui/webrtc.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="compression_gain_db">
@@ -794,7 +794,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="no">WebRTC</property>
+                <property name="label">WebRTC</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -819,11 +819,47 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="enable">
+      <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
+        <property name="can_focus">False</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkSwitch" id="enable">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="plugin_reset">
+            <property name="label" translatable="yes">Reset</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="image_position">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="left_attach">0</property>

--- a/help/de/de.po
+++ b/help/de/de.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2019-11-28 14:06-0300\n"
+"POT-Creation-Date: 2020-05-13 20:02+0200\n"
 "PO-Revision-Date: 2020-01-12 17:48+0100\n"
+"Last-Translator: \n"
 "Language-Team: \n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.2.4\n"
-"Last-Translator: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: de\n"
 
 #. Put one translator per line, in the form NAME <EMAIL>, YEAR1, YEAR2
 msgctxt "_"
@@ -427,8 +427,7 @@ msgstr ""
 "Ausschläge."
 
 #. (itstool) path: item/p
-#: C/deesser.page:28 C/gate.page:40 C/multibandcompressor.page:40
-#: C/multibandgate.page:48
+#: C/deesser.page:28 C/multibandcompressor.page:40 C/multibandgate.page:48
 msgid "If a signal rises above this level it will affect the gain reduction."
 msgstr ""
 "Übersteigt ein Signal diesen Wert, wird die Amplitudenreduktion beeinflusst."
@@ -641,22 +640,31 @@ msgid "PulseEffects uses the gate developed by Calf Studio."
 msgstr "PulseEffects verwendet das von Calf Studio entwickelte Gate."
 
 #. (itstool) path: item/p
-#: C/gate.page:22 C/multibandcompressor.page:22 C/multibandgate.page:22
+#: C/gate.page:22
+#, fuzzy
 msgid ""
 "Amount of milliseconds the signal has to rise above the threshold before "
-"gain reduction starts."
+"gain reduction stops."
 msgstr ""
 "Anzahl der Millisekunden, die das Signal über die Schwelle steigen muss, "
 "bevor die Amplitudenreduktion beginnt."
 
 #. (itstool) path: item/p
-#: C/gate.page:31 C/multibandcompressor.page:31 C/multibandgate.page:31
+#: C/gate.page:31
+#, fuzzy
 msgid ""
 "Amount of milliseconds the signal has to fall below the threshold before the "
-"reduction is decreased again."
+"reduction is increased again."
 msgstr ""
 "Anzahl der Millisekunden, die das Signal unter die Schwelle fallen muss, "
 "bevor die Reduktion wieder verringert wird."
+
+#. (itstool) path: item/p
+#: C/gate.page:40
+#, fuzzy
+msgid "If a signal rises above this level the gain reduction is released."
+msgstr ""
+"Übersteigt ein Signal diesen Wert, wird die Amplitudenreduktion beeinflusst."
 
 #. (itstool) path: title/em
 #: C/gate.page:70
@@ -939,6 +947,24 @@ msgstr ""
 #: C/multibandcompressor.page:14
 msgid "PulseEffects uses the multiband compressor developed by Calf Studio."
 msgstr "PulseEffects verwendet den Multibandkompressor von Calf Studio."
+
+#. (itstool) path: item/p
+#: C/multibandcompressor.page:22 C/multibandgate.page:22
+msgid ""
+"Amount of milliseconds the signal has to rise above the threshold before "
+"gain reduction starts."
+msgstr ""
+"Anzahl der Millisekunden, die das Signal über die Schwelle steigen muss, "
+"bevor die Amplitudenreduktion beginnt."
+
+#. (itstool) path: item/p
+#: C/multibandcompressor.page:31 C/multibandgate.page:31
+msgid ""
+"Amount of milliseconds the signal has to fall below the threshold before the "
+"reduction is decreased again."
+msgstr ""
+"Anzahl der Millisekunden, die das Signal unter die Schwelle fallen muss, "
+"bevor die Reduktion wieder verringert wird."
 
 #. (itstool) path: title/em
 #: C/multibandcompressor.page:70 C/multibandgate.page:78 C/crystalizer.page:37

--- a/help/it_IT/it_IT.po
+++ b/help/it_IT/it_IT.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: pulseeffects\n"
-"POT-Creation-Date: 2019-11-28 14:06-0300\n"
+"POT-Creation-Date: 2020-05-13 20:02+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Gianluca Boiano <morf3089@gmail.com>\n"
 "Language-Team: \n"
@@ -40,8 +40,7 @@ msgstr ""
 #. (itstool) path: page/p
 #: C/bassenhancer.page:16
 msgid "PulseEffects uses the bass enhancer developed by Calf Studio."
-msgstr ""
-"PulseEffects usa il plugin di Enfasi Bassi sviluppato da Calf Studio."
+msgstr "PulseEffects usa il plugin di Enfasi Bassi sviluppato da Calf Studio."
 
 #. (itstool) path: title/em
 #: C/bassenhancer.page:22 C/exciter.page:21 C/reverb.page:40
@@ -345,8 +344,8 @@ msgid ""
 "<em style=\"strong\">Middle</em> - Middle part of signal is used for "
 "sidechain processing."
 msgstr ""
-"<em style=\"strong\">Intermedia</em> - La parte intermedia del segnale è usata "
-"per l'elaborazione in sidechain."
+"<em style=\"strong\">Intermedia</em> - La parte intermedia del segnale è "
+"usata per l'elaborazione in sidechain."
 
 #. (itstool) path: item/p
 #: C/compressor.page:165
@@ -435,8 +434,7 @@ msgstr ""
 "molto brevi."
 
 #. (itstool) path: item/p
-#: C/deesser.page:28 C/gate.page:40 C/multibandcompressor.page:40
-#: C/multibandgate.page:48
+#: C/deesser.page:28 C/multibandcompressor.page:40 C/multibandgate.page:48
 msgid "If a signal rises above this level it will affect the gain reduction."
 msgstr ""
 "Se il segnale supera il valore specificato, verrà applicata la compressione."
@@ -653,22 +651,31 @@ msgid "PulseEffects uses the gate developed by Calf Studio."
 msgstr "PulseEffects usa il Gate sviluppato da Calf Studio."
 
 #. (itstool) path: item/p
-#: C/gate.page:22 C/multibandcompressor.page:22 C/multibandgate.page:22
+#: C/gate.page:22
+#, fuzzy
 msgid ""
 "Amount of milliseconds the signal has to rise above the threshold before "
-"gain reduction starts."
+"gain reduction stops."
 msgstr ""
 "Valore in millisecondi per cui il segnale deve rimanere oltre la soglia "
 "affinchè la compressione venga applicata interamente."
 
 #. (itstool) path: item/p
-#: C/gate.page:31 C/multibandcompressor.page:31 C/multibandgate.page:31
+#: C/gate.page:31
+#, fuzzy
 msgid ""
 "Amount of milliseconds the signal has to fall below the threshold before the "
-"reduction is decreased again."
+"reduction is increased again."
 msgstr ""
 "Valore in millisecondi per cui il segnale deve rimanere sotto la soglia "
 "affinchè la compressione venga terminata."
+
+#. (itstool) path: item/p
+#: C/gate.page:40
+#, fuzzy
+msgid "If a signal rises above this level the gain reduction is released."
+msgstr ""
+"Se il segnale supera il valore specificato, verrà applicata la compressione."
 
 #. (itstool) path: title/em
 #: C/gate.page:70
@@ -951,6 +958,24 @@ msgstr ""
 msgid "PulseEffects uses the multiband compressor developed by Calf Studio."
 msgstr "PulseEffects usa il Compressore Multibanda sviluppato da Calf Studio."
 
+#. (itstool) path: item/p
+#: C/multibandcompressor.page:22 C/multibandgate.page:22
+msgid ""
+"Amount of milliseconds the signal has to rise above the threshold before "
+"gain reduction starts."
+msgstr ""
+"Valore in millisecondi per cui il segnale deve rimanere oltre la soglia "
+"affinchè la compressione venga applicata interamente."
+
+#. (itstool) path: item/p
+#: C/multibandcompressor.page:31 C/multibandgate.page:31
+msgid ""
+"Amount of milliseconds the signal has to fall below the threshold before the "
+"reduction is decreased again."
+msgstr ""
+"Valore in millisecondi per cui il segnale deve rimanere sotto la soglia "
+"affinchè la compressione venga terminata."
+
 #. (itstool) path: title/em
 #: C/multibandcompressor.page:70 C/multibandgate.page:78 C/crystalizer.page:37
 msgid "Bypass"
@@ -1185,12 +1210,12 @@ msgstr ""
 #. (itstool) path: page/title
 #: C/stereotools.page:9
 msgid "Stereo Tools"
-msgstr "Plugin Stereo"
+msgstr "Strumenti Stereo"
 
 #. (itstool) path: page/p
 #: C/stereotools.page:10
 msgid "PulseEffects uses the stereo tools developed by Calf Studio."
-msgstr "PulseEffects usa il Plugin Stereo sviluppato da Calf Studio."
+msgstr "PulseEffects usa il plugin Strumenti Stereo sviluppato da Calf Studio."
 
 #. (itstool) path: title/em
 #: C/stereotools.page:16
@@ -2772,9 +2797,9 @@ msgid ""
 msgstr ""
 "I sistemi operativi commerciali offrono software specifici per migliorare "
 "l'audio su questi tipi di notebook. Su Linux si può ottenere un risultato "
-"simile con PulseEffects, anche se il procedimento non è immediato e "
-"richiede un lungo intervento manuale, a meno che in futuro la community non "
-"realizzi un database con le impostazioni per i modelli più comuni."
+"simile con PulseEffects, anche se il procedimento non è immediato e richiede "
+"un lungo intervento manuale, a meno che in futuro la community non realizzi "
+"un database con le impostazioni per i modelli più comuni."
 
 #. (itstool) path: section/p
 #: C/guide_1.page:11
@@ -2882,8 +2907,8 @@ msgid ""
 msgstr ""
 "<em style=\"strong\">Medio-Bassi</em>: Colpisci una scatola di cartone da "
 "0.5m3 e capirai cosa sono. L'energia di un suono è localizzata in questo "
-"intervallo. Anche il rullo di tamburi e le chitarre elettriche. Nei film, "
-"il rombo dei motori e i colpi d'arma da fuoco. Siamo tra i ~250Hz e ~750Hz."
+"intervallo. Anche il rullo di tamburi e le chitarre elettriche. Nei film, il "
+"rombo dei motori e i colpi d'arma da fuoco. Siamo tra i ~250Hz e ~750Hz."
 
 #. (itstool) path: item/p
 #: C/guide_1.page:41
@@ -3025,8 +3050,8 @@ msgid ""
 "high-mid and height is quite out-of-bounds. This needs correction, although "
 "I promised a tutorial without EQ."
 msgstr ""
-"Rappresenta la differenza tra i vari intervalli di frequenza: basso, "
-"medio-basso, medio-alto e alto. Sui notebook può essere molto marcata e va "
+"Rappresenta la differenza tra i vari intervalli di frequenza: basso, medio-"
+"basso, medio-alto e alto. Sui notebook può essere molto marcata e va "
 "corretta, anche se non ricorreremo a un equalizzatore."
 
 #. (itstool) path: item/title
@@ -3312,10 +3337,10 @@ msgstr ""
 "200Hz/300Hz/400Hz/600Hz/800Hz/900Hz/... al variare e al ridursi dei livelli "
 "(in base alle Armoniche impostate). Questo comporta un incremento "
 "nell'intervallo basso affinché si abbia qualcosa che suoni meglio sul nostro "
-"particolare sistema. Non aggiunge, né aumenta, i "
-"<em style=\"strong\">reali</em> fondamentali del suono originale (dunque il "
-"tuo notebook non comincerà a sobbalzare), ma rende più udibili i segnali che "
-"l'hardware inizialmente non riusciva a riprodurre correttamente."
+"particolare sistema. Non aggiunge, né aumenta, i <em style=\"strong\">reali</"
+"em> fondamentali del suono originale (dunque il tuo notebook non comincerà a "
+"sobbalzare), ma rende più udibili i segnali che l'hardware inizialmente non "
+"riusciva a riprodurre correttamente."
 
 #. (itstool) path: item/p
 #: C/guide_1.page:154
@@ -3373,9 +3398,9 @@ msgid ""
 "to the problems instead of solving anything."
 msgstr ""
 "Il Compressore Multibanda ci aiuterà a risolvere diversi aspetti. Taglierà "
-"delle frequenze troppo forti, ridurrà l'intervallo dinamico e armonizzerà "
-"la risposta in frequenza. La maggior parte delle persone prova a migliorare "
-"la risposta in frequenza attraverso gli equalizzatori, ma questi ultimi non "
+"delle frequenze troppo forti, ridurrà l'intervallo dinamico e armonizzerà la "
+"risposta in frequenza. La maggior parte delle persone prova a migliorare la "
+"risposta in frequenza attraverso gli equalizzatori, ma questi ultimi non "
 "sono dinamici, per cui tendono ad aumentare i problemi piuttosto che "
 "risolverli."
 
@@ -3385,8 +3410,8 @@ msgid ""
 "Drag the Multiband Compressor to the third position, after the Bass Enhancer "
 "and before the Limiter."
 msgstr ""
-"Trascina il plugin Compressore Multibanda alla terza posizione, dopo l'Enfasi "
-"Bassi e prima del Limitatore."
+"Trascina il plugin Compressore Multibanda alla terza posizione, dopo "
+"l'Enfasi Bassi e prima del Limitatore."
 
 #. (itstool) path: item/p
 #: C/guide_1.page:164
@@ -3612,7 +3637,7 @@ msgstr ""
 #. (itstool) path: item/title
 #: C/guide_1.page:294
 msgid "<em style=\"strong\">Stereo Tools</em>"
-msgstr "<em style=\"strong\">Plugin Stereo</em>"
+msgstr "<em style=\"strong\">Strumenti Stereo</em>"
 
 #. (itstool) path: item/p
 #: C/guide_1.page:297
@@ -3627,10 +3652,10 @@ msgid ""
 "single parameter. Switch to the last tab \"Output\" and set the parameter "
 "stereo base to 0.25. That's it."
 msgstr ""
-"Trascina il Plugin Stereo alla quarta posizione, dopo il Compressore "
-"Multibanda e prima del Limitatore. Questo processo ha un sacco di "
-"funzionalità, ma a noi ne interessa soltanto una. Clicca su Output e imposta "
-"il parametro Base Stereo su 0.25. Ecco fatto."
+"Trascina il plugin Strumenti Stereo alla quarta posizione, dopo il "
+"Compressore Multibanda e prima del Limitatore. Questo processo ha un sacco "
+"di funzionalità, ma a noi ne interessa soltanto una. Clicca su Output e "
+"imposta il parametro Base Stereo su 0.25. Ecco fatto."
 
 #. (itstool) path: item/p
 #: C/guide_1.page:299
@@ -3677,10 +3702,10 @@ msgid ""
 "comparable set of signal processors set up in the presumably same way as "
 "this tutorial explained."
 msgstr ""
-"Fortunatamente sono riuscito a ottenere una qualità del suono <em "
-"style=\"strong\">migliore</em> di quella iniziale. Questa catena di plugin "
-"sarebbe in grado di rovinare l'esperienza acustica se non impostata nel "
-"modo corretto, ma coi giusti passi può anche rendere il suono paragonabile a "
+"Fortunatamente sono riuscito a ottenere una qualità del suono <em style="
+"\"strong\">migliore</em> di quella iniziale. Questa catena di plugin sarebbe "
+"in grado di rovinare l'esperienza acustica se non impostata nel modo "
+"corretto, ma coi giusti passi può anche rendere il suono paragonabile a "
 "quello di notebook con altoparlanti di buona fattura. Tutti i produttori "
 "forniscono dei driver audio con dei preset per migliorare l'acustica, che "
 "più o meno funzionano alla stessa maniera di come ho spiegato in questa "

--- a/help/pt_BR/pt_BR.po
+++ b/help/pt_BR/pt_BR.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: pulseeffects\n"
-"POT-Creation-Date: 2019-11-28 14:06-0300\n"
+"POT-Creation-Date: 2020-05-13 20:02+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -419,8 +419,7 @@ msgstr ""
 "A reação do deesser. Valores maiores não afetarão picos realmente curtos."
 
 #. (itstool) path: item/p
-#: C/deesser.page:28 C/gate.page:40 C/multibandcompressor.page:40
-#: C/multibandgate.page:48
+#: C/deesser.page:28 C/multibandcompressor.page:40 C/multibandgate.page:48
 msgid "If a signal rises above this level it will affect the gain reduction."
 msgstr "Se um sinal subir acima deste nível ele afetará a redução de ganho."
 
@@ -633,22 +632,30 @@ msgid "PulseEffects uses the gate developed by Calf Studio."
 msgstr "PulseEffects usa o gate desenvolvido por Calf Studio."
 
 #. (itstool) path: item/p
-#: C/gate.page:22 C/multibandcompressor.page:22 C/multibandgate.page:22
+#: C/gate.page:22
+#, fuzzy
 msgid ""
 "Amount of milliseconds the signal has to rise above the threshold before "
-"gain reduction starts."
+"gain reduction stops."
 msgstr ""
 "Quantidade de milissegundos que o sinal deve passar acima do limiar para que "
 "a redução de ganho comece."
 
 #. (itstool) path: item/p
-#: C/gate.page:31 C/multibandcompressor.page:31 C/multibandgate.page:31
+#: C/gate.page:31
+#, fuzzy
 msgid ""
 "Amount of milliseconds the signal has to fall below the threshold before the "
-"reduction is decreased again."
+"reduction is increased again."
 msgstr ""
 "Quantidade de milissegundos que o sinal tem que passar abaixo do limar antes "
 "que a magnitude da redução seja novamente diminuída."
+
+#. (itstool) path: item/p
+#: C/gate.page:40
+#, fuzzy
+msgid "If a signal rises above this level the gain reduction is released."
+msgstr "Se um sinal subir acima deste nível ele afetará a redução de ganho."
 
 #. (itstool) path: title/em
 #: C/gate.page:70
@@ -926,6 +933,24 @@ msgstr ""
 msgid "PulseEffects uses the multiband compressor developed by Calf Studio."
 msgstr ""
 "PulseEffects usa o compressor multi bandas desenvolvido por Calf Studio."
+
+#. (itstool) path: item/p
+#: C/multibandcompressor.page:22 C/multibandgate.page:22
+msgid ""
+"Amount of milliseconds the signal has to rise above the threshold before "
+"gain reduction starts."
+msgstr ""
+"Quantidade de milissegundos que o sinal deve passar acima do limiar para que "
+"a redução de ganho comece."
+
+#. (itstool) path: item/p
+#: C/multibandcompressor.page:31 C/multibandgate.page:31
+msgid ""
+"Amount of milliseconds the signal has to fall below the threshold before the "
+"reduction is decreased again."
+msgstr ""
+"Quantidade de milissegundos que o sinal tem que passar abaixo do limar antes "
+"que a magnitude da redução seja novamente diminuída."
 
 #. (itstool) path: title/em
 #: C/multibandcompressor.page:70 C/multibandgate.page:78 C/crystalizer.page:37

--- a/help/pulseeffects.pot
+++ b/help/pulseeffects.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-11-28 14:06-0300\n"
+"POT-Creation-Date: 2020-05-13 20:02+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -398,7 +398,6 @@ msgstr ""
 
 #. (itstool) path: item/p
 #: C/deesser.page:28
-#: C/gate.page:40
 #: C/multibandcompressor.page:40
 #: C/multibandgate.page:48
 msgid "If a signal rises above this level it will affect the gain reduction."
@@ -571,16 +570,17 @@ msgstr ""
 
 #. (itstool) path: item/p
 #: C/gate.page:22
-#: C/multibandcompressor.page:22
-#: C/multibandgate.page:22
-msgid "Amount of milliseconds the signal has to rise above the threshold before gain reduction starts."
+msgid "Amount of milliseconds the signal has to rise above the threshold before gain reduction stops."
 msgstr ""
 
 #. (itstool) path: item/p
 #: C/gate.page:31
-#: C/multibandcompressor.page:31
-#: C/multibandgate.page:31
-msgid "Amount of milliseconds the signal has to fall below the threshold before the reduction is decreased again."
+msgid "Amount of milliseconds the signal has to fall below the threshold before the reduction is increased again."
+msgstr ""
+
+#. (itstool) path: item/p
+#: C/gate.page:40
+msgid "If a signal rises above this level the gain reduction is released."
 msgstr ""
 
 #. (itstool) path: title/em
@@ -797,6 +797,18 @@ msgstr ""
 #. (itstool) path: page/p
 #: C/multibandcompressor.page:14
 msgid "PulseEffects uses the multiband compressor developed by Calf Studio."
+msgstr ""
+
+#. (itstool) path: item/p
+#: C/multibandcompressor.page:22
+#: C/multibandgate.page:22
+msgid "Amount of milliseconds the signal has to rise above the threshold before gain reduction starts."
+msgstr ""
+
+#. (itstool) path: item/p
+#: C/multibandcompressor.page:31
+#: C/multibandgate.page:31
+msgid "Amount of milliseconds the signal has to fall below the threshold before the reduction is decreased again."
 msgstr ""
 
 #. (itstool) path: title/em

--- a/help/ru/ru.po
+++ b/help/ru/ru.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-11-28 14:06-0300\n"
+"POT-Creation-Date: 2020-05-13 20:02+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Mikhail Novosyolov <mikhailnov@dumalogiya.ru>\n"
 "MIME-Version: 1.0\n"
@@ -404,8 +404,7 @@ msgstr ""
 "сигнала."
 
 #. (itstool) path: item/p
-#: C/deesser.page:28 C/gate.page:40 C/multibandcompressor.page:40
-#: C/multibandgate.page:48
+#: C/deesser.page:28 C/multibandcompressor.page:40 C/multibandgate.page:48
 msgid "If a signal rises above this level it will affect the gain reduction."
 msgstr ""
 "Уровень сигнала, выше которого «Компрессор» уменьшает уровень сигнала на "
@@ -612,23 +611,33 @@ msgstr ""
 "PulseEffects использует плагин для усиления басов, разработанный Calf Studio."
 
 #. (itstool) path: item/p
-#: C/gate.page:22 C/multibandcompressor.page:22 C/multibandgate.page:22
+#: C/gate.page:22
+#, fuzzy
 msgid ""
 "Amount of milliseconds the signal has to rise above the threshold before "
-"gain reduction starts."
+"gain reduction stops."
 msgstr ""
 "Время (в миллисекундах), в течение которого «Компрессор» не уменьшает "
 "уровень сигнала после достижения сигналом уровнявыше «Порога срабатывания»."
 
 #. (itstool) path: item/p
-#: C/gate.page:31 C/multibandcompressor.page:31 C/multibandgate.page:31
+#: C/gate.page:31
+#, fuzzy
 msgid ""
 "Amount of milliseconds the signal has to fall below the threshold before the "
-"reduction is decreased again."
+"reduction is increased again."
 msgstr ""
 "Время (в миллисекундах), в течение которого «Компрессор» продолжает "
 "уменьшать уровень сигнала после достижения сигналом уровняниже «Порога "
 "срабатывания»."
+
+#. (itstool) path: item/p
+#: C/gate.page:40
+#, fuzzy
+msgid "If a signal rises above this level the gain reduction is released."
+msgstr ""
+"Уровень сигнала, выше которого «Компрессор» уменьшает уровень сигнала на "
+"заданный пользователем коэффициент («Степень сжатия»)."
 
 #. (itstool) path: title/em
 #: C/gate.page:70
@@ -876,6 +885,25 @@ msgstr ""
 msgid "PulseEffects uses the multiband compressor developed by Calf Studio."
 msgstr ""
 "PulseEffects использует плагин для усиления басов, разработанный Calf Studio."
+
+#. (itstool) path: item/p
+#: C/multibandcompressor.page:22 C/multibandgate.page:22
+msgid ""
+"Amount of milliseconds the signal has to rise above the threshold before "
+"gain reduction starts."
+msgstr ""
+"Время (в миллисекундах), в течение которого «Компрессор» не уменьшает "
+"уровень сигнала после достижения сигналом уровнявыше «Порога срабатывания»."
+
+#. (itstool) path: item/p
+#: C/multibandcompressor.page:31 C/multibandgate.page:31
+msgid ""
+"Amount of milliseconds the signal has to fall below the threshold before the "
+"reduction is decreased again."
+msgstr ""
+"Время (в миллисекундах), в течение которого «Компрессор» продолжает "
+"уменьшать уровень сигнала после достижения сигналом уровняниже «Порога "
+"срабатывания»."
 
 #. (itstool) path: title/em
 #: C/multibandcompressor.page:70 C/multibandgate.page:78 C/crystalizer.page:37

--- a/include/autogain_ui.hpp
+++ b/include/autogain_ui.hpp
@@ -23,6 +23,8 @@ class AutoGainUi : public Gtk::Grid, public PluginUiBase {
   void on_new_range(const float& value);
   void on_new_gain(const float& value);
 
+  void reset() override;
+
  private:
   Glib::RefPtr<Gtk::Adjustment> input_gain, output_gain, target, weight_m, weight_s, weight_i;
 
@@ -32,7 +34,7 @@ class AutoGainUi : public Gtk::Grid, public PluginUiBase {
   Gtk::Label *m_label = nullptr, *s_label = nullptr, *i_label = nullptr, *r_label = nullptr, *g_label = nullptr,
              *l_label = nullptr, *lra_label = nullptr;
 
-  Gtk::Button* reset = nullptr;
+  Gtk::Button* reset_history = nullptr;
 
   Gtk::ToggleButton *detect_silence = nullptr, *use_geometric_mean = nullptr;
 

--- a/include/bass_enhancer_ui.hpp
+++ b/include/bass_enhancer_ui.hpp
@@ -16,6 +16,8 @@ class BassEnhancerUi : public Gtk::Grid, public PluginUiBase {
 
   void on_new_harmonics_level(double value);
 
+  void reset() override;
+
  private:
   Glib::RefPtr<Gtk::Adjustment> amount, blend, floorv, harmonics, input_gain, output_gain, scope;
 

--- a/include/compressor_ui.hpp
+++ b/include/compressor_ui.hpp
@@ -21,6 +21,8 @@ class CompressorUi : public Gtk::Grid, public PluginUiBase {
 
   void on_new_curve(double value);
 
+  void reset() override;
+
  private:
   Glib::RefPtr<Gtk::Adjustment> attack, release, threshold, knee, ratio, makeup, preamp, reactivity, lookahead,
       input_gain, output_gain;

--- a/include/convolver_ui.hpp
+++ b/include/convolver_ui.hpp
@@ -23,6 +23,8 @@ class ConvolverUi : public Gtk::Grid, public PluginUiBase {
   auto operator=(const ConvolverUi &&) -> ConvolverUi& = delete;
   ~ConvolverUi() override;
 
+  void reset() override;
+
  private:
   std::string log_tag = "convolver_ui: ";
 

--- a/include/crossfeed_ui.hpp
+++ b/include/crossfeed_ui.hpp
@@ -14,6 +14,8 @@ class CrossfeedUi : public Gtk::Grid, public PluginUiBase {
   auto operator=(const CrossfeedUi &&) -> CrossfeedUi& = delete;
   ~CrossfeedUi() override;
 
+  void reset() override;
+
  private:
   Glib::RefPtr<Gtk::Adjustment> fcut, feed;
 

--- a/include/crystalizer_ui.hpp
+++ b/include/crystalizer_ui.hpp
@@ -18,6 +18,8 @@ class CrystalizerUi : public Gtk::Grid, public PluginUiBase {
 
   void on_new_range_after(double value);
 
+  void reset() override;
+
  private:
   Gtk::Grid* bands_grid = nullptr;
 

--- a/include/deesser_ui.hpp
+++ b/include/deesser_ui.hpp
@@ -18,6 +18,8 @@ class DeesserUi : public Gtk::Grid, public PluginUiBase {
   void on_new_compression(double value);
   void on_new_detected(double value);
 
+  void reset() override;
+
  private:
   Glib::RefPtr<Gtk::Adjustment> threshold, ratio, makeup, f1_freq, f2_freq, f1_level, f2_level, f2_q;
 

--- a/include/delay_ui.hpp
+++ b/include/delay_ui.hpp
@@ -13,6 +13,8 @@ class DelayUi : public Gtk::Grid, public PluginUiBase {
   auto operator=(const DelayUi &&) -> DelayUi& = delete;
   ~DelayUi() override;
 
+  void reset() override;
+
  private:
   Glib::RefPtr<Gtk::Adjustment> input_gain, output_gain, time_l, time_r;
 };

--- a/include/equalizer_ui.hpp
+++ b/include/equalizer_ui.hpp
@@ -23,7 +23,7 @@ class EqualizerUi : public Gtk::Grid, public PluginUiBase {
   auto operator=(const EqualizerUi &&) -> EqualizerUi& = delete;
   ~EqualizerUi() override;
 
-  void reset();
+  void reset() override;
 
  private:
   Glib::RefPtr<Gio::Settings> settings_left, settings_right;

--- a/include/exciter_ui.hpp
+++ b/include/exciter_ui.hpp
@@ -16,6 +16,8 @@ class ExciterUi : public Gtk::Grid, public PluginUiBase {
 
   void on_new_harmonics_level(double value);
 
+  void reset() override;
+
  private:
   Glib::RefPtr<Gtk::Adjustment> amount, blend, ceilv, harmonics, input_gain, output_gain, scope;
 

--- a/include/filter_ui.hpp
+++ b/include/filter_ui.hpp
@@ -15,6 +15,8 @@ class FilterUi : public Gtk::Grid, public PluginUiBase {
   auto operator=(const FilterUi &&) -> FilterUi& = delete;
   ~FilterUi() override;
 
+  void reset() override;
+
  private:
   Glib::RefPtr<Gtk::Adjustment> input_gain, output_gain, frequency, resonance, inertia;
 

--- a/include/gate_ui.hpp
+++ b/include/gate_ui.hpp
@@ -16,6 +16,8 @@ class GateUi : public Gtk::Grid, public PluginUiBase {
 
   void on_new_gating(double value);
 
+  void reset() override;
+
  private:
   Glib::RefPtr<Gtk::Adjustment> attack, release, threshold, knee, ratio, range, makeup;
   Gtk::LevelBar* gating = nullptr;

--- a/include/limiter_ui.hpp
+++ b/include/limiter_ui.hpp
@@ -16,6 +16,8 @@ class LimiterUi : public Gtk::Grid, public PluginUiBase {
 
   void on_new_attenuation(double value);
 
+  void reset() override;
+
  private:
   Glib::RefPtr<Gtk::Adjustment> input_gain, limit, lookahead, release, oversampling;
   Gtk::ToggleButton* asc = nullptr;

--- a/include/loudness_ui.hpp
+++ b/include/loudness_ui.hpp
@@ -14,6 +14,8 @@ class LoudnessUi : public Gtk::Grid, public PluginUiBase {
   auto operator=(const LoudnessUi &&) -> LoudnessUi& = delete;
   ~LoudnessUi() override;
 
+  void reset() override;
+
  private:
   Glib::RefPtr<Gtk::Adjustment> loudness, output, link;
 };

--- a/include/maximizer_ui.hpp
+++ b/include/maximizer_ui.hpp
@@ -15,6 +15,8 @@ class MaximizerUi : public Gtk::Grid, public PluginUiBase {
 
   void on_new_reduction(double value);
 
+  void reset() override;
+
  private:
   Glib::RefPtr<Gtk::Adjustment> release, threshold, ceiling;
   Gtk::LevelBar* reduction = nullptr;

--- a/include/multiband_compressor_ui.hpp
+++ b/include/multiband_compressor_ui.hpp
@@ -28,6 +28,8 @@ class MultibandCompressorUi : public Gtk::Grid, public PluginUiBase {
   void on_new_compression2(double value);
   void on_new_compression3(double value);
 
+  void reset() override;
+
  private:
   Glib::RefPtr<Gtk::Adjustment> freq0, freq1, freq2, input_gain, output_gain;
   Glib::RefPtr<Gtk::Adjustment> attack0, release0, threshold0, knee0, ratio0, makeup0;

--- a/include/multiband_gate_ui.hpp
+++ b/include/multiband_gate_ui.hpp
@@ -26,6 +26,8 @@ class MultibandGateUi : public Gtk::Grid, public PluginUiBase {
   void on_new_gating2(double value);
   void on_new_gating3(double value);
 
+  void reset() override;
+
  private:
   Glib::RefPtr<Gtk::Adjustment> freq0, freq1, freq2, input_gain, output_gain;
   Glib::RefPtr<Gtk::Adjustment> range0, attack0, release0, threshold0, knee0, ratio0, makeup0;

--- a/include/pitch_ui.hpp
+++ b/include/pitch_ui.hpp
@@ -14,6 +14,8 @@ class PitchUi : public Gtk::Grid, public PluginUiBase {
   auto operator=(const PitchUi &&) -> PitchUi& = delete;
   ~PitchUi() override;
 
+  void reset() override;
+
  private:
   Gtk::ToggleButton *faster = nullptr, *formant_preserving = nullptr;
 

--- a/include/reverb_ui.hpp
+++ b/include/reverb_ui.hpp
@@ -15,6 +15,8 @@ class ReverbUi : public Gtk::Grid, public PluginUiBase {
   auto operator=(const ReverbUi &&) -> ReverbUi& = delete;
   ~ReverbUi() override;
 
+  void reset() override;
+
  private:
   Glib::RefPtr<Gtk::Adjustment> input_gain, output_gain, predelay, decay_time, diffusion, amount, dry, hf_damp,
       bass_cut, treble_cut;

--- a/include/sink_input_effects_ui.hpp
+++ b/include/sink_input_effects_ui.hpp
@@ -20,6 +20,7 @@
 #include "multiband_compressor_ui.hpp"
 #include "multiband_gate_ui.hpp"
 #include "pitch_ui.hpp"
+#include "preset_type.hpp"
 #include "reverb_ui.hpp"
 #include "sink_input_effects.hpp"
 #include "stereo_tools_ui.hpp"

--- a/include/source_output_effects_ui.hpp
+++ b/include/source_output_effects_ui.hpp
@@ -11,6 +11,7 @@
 #include "multiband_compressor_ui.hpp"
 #include "multiband_gate_ui.hpp"
 #include "pitch_ui.hpp"
+#include "preset_type.hpp"
 #include "reverb_ui.hpp"
 #include "source_output_effects.hpp"
 #include "webrtc_ui.hpp"

--- a/include/stereo_tools_ui.hpp
+++ b/include/stereo_tools_ui.hpp
@@ -16,6 +16,8 @@ class StereoToolsUi : public Gtk::Grid, public PluginUiBase {
   auto operator=(const StereoToolsUi &&) -> StereoToolsUi& = delete;
   ~StereoToolsUi() override;
 
+  void reset() override;
+
  private:
   Glib::RefPtr<Gtk::Adjustment> input_gain, output_gain, balance_in, balance_out, slev, sbal, mlev, mpan, stereo_base,
       delay, sc_level, stereo_phase;

--- a/include/webrtc_ui.hpp
+++ b/include/webrtc_ui.hpp
@@ -15,6 +15,8 @@ class WebrtcUi : public Gtk::Grid, public PluginUiBase {
   auto operator=(const WebrtcUi &&) -> WebrtcUi& = delete;
   ~WebrtcUi() override;
 
+  void reset() override;
+
  private:
   Glib::RefPtr<Gtk::Adjustment> compression_gain_db, target_level_dbfs, voice_detection_frame_size;
 

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -988,7 +988,7 @@ msgstr "Limite Superiore"
 
 #: data/ui/stereo_tools.glade:42
 msgid "Stereo Tools"
-msgstr "Plugin Stereo"
+msgstr "Strumenti Stereo"
 
 #: data/ui/stereo_tools.glade:207
 msgid "Softclip"

--- a/src/autogain_ui.cpp
+++ b/src/autogain_ui.cpp
@@ -24,10 +24,12 @@ AutoGainUi::AutoGainUi(BaseObjectType* cobject,
   builder->get_widget("l_label", l_label);
   builder->get_widget("lra_label", lra_label);
 
-  builder->get_widget("reset", reset);
+  builder->get_widget("reset", reset_history);
   builder->get_widget("detect_silence", detect_silence);
   builder->get_widget("use_geometric_mean", use_geometric_mean);
   builder->get_widget("weights_grid", weights_grid);
+
+  builder->get_widget("plugin_reset", reset_button);
 
   get_object(builder, "input_gain", input_gain);
   builder->get_widget("l_label", l_label);
@@ -53,11 +55,40 @@ AutoGainUi::AutoGainUi(BaseObjectType* cobject,
   settings->bind("use-geometric-mean", weights_grid, "visible",
                  Gio::SettingsBindFlags::SETTINGS_BIND_GET | Gio::SettingsBindFlags::SETTINGS_BIND_INVERT_BOOLEAN);
 
-  reset->signal_clicked().connect([=]() { settings->set_boolean("reset", true); });
+  reset_history->signal_clicked().connect([=]() { settings->set_boolean("reset", true); });
+
+  // reset plugin
+  reset_button->signal_clicked().connect([=]() { reset(); });
 }
 
 AutoGainUi::~AutoGainUi() {
   util::debug(name + " ui destroyed");
+}
+
+void AutoGainUi::reset() {
+  try {
+    std::string section = (preset_type == PresetType::output) ? "output" : "input";
+
+    update_default_key<bool>(settings, "detect-silence", section + ".autogain.detect-silence");
+
+    update_default_key<bool>(settings, "use-geometric-mean", section + ".autogain.use-geometric-mean");
+
+    update_default_key<double>(settings, "input-gain", section + ".autogain.input-gain");
+
+    update_default_key<double>(settings, "output-gain", section + ".autogain.output-gain");
+
+    update_default_key<double>(settings, "target", section + ".autogain.target");
+
+    update_default_key<int>(settings, "weight-m", section + ".autogain.weight-m");
+
+    update_default_key<int>(settings, "weight-s", section + ".autogain.weight-s");
+
+    update_default_key<int>(settings, "weight-i", section + ".autogain.weight-i");
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
+  }
 }
 
 void AutoGainUi::on_new_momentary(const float& value) {

--- a/src/bass_enhancer_ui.cpp
+++ b/src/bass_enhancer_ui.cpp
@@ -12,6 +12,7 @@ BassEnhancerUi::BassEnhancerUi(BaseObjectType* cobject,
   builder->get_widget("harmonics_levelbar_label", harmonics_levelbar_label);
   builder->get_widget("floor_active", floor_active);
   builder->get_widget("listen", listen);
+  builder->get_widget("plugin_reset", reset_button);
 
   get_object(builder, "amount", amount);
   get_object(builder, "blend", blend);
@@ -35,10 +36,41 @@ BassEnhancerUi::BassEnhancerUi(BaseObjectType* cobject,
   settings->bind("output-gain", output_gain.get(), "value", flag);
   settings->bind("listen", listen, "active", flag);
   settings->bind("floor-active", floor_active, "active", flag);
+
+  // reset plugin
+  reset_button->signal_clicked().connect([=]() { reset(); });
 }
 
 BassEnhancerUi::~BassEnhancerUi() {
   util::debug(name + " ui destroyed");
+}
+
+void BassEnhancerUi::reset() {
+  try {
+    std::string section = (preset_type == PresetType::output) ? "output" : "input";
+
+    update_default_key<double>(settings, "input-gain", section + ".bass_enhancer.input-gain");
+
+    update_default_key<double>(settings, "output-gain", section + ".bass_enhancer.output-gain");
+
+    update_default_key<double>(settings, "amount", section + ".bass_enhancer.amount");
+
+    update_default_key<double>(settings, "harmonics", section + ".bass_enhancer.harmonics");
+
+    update_default_key<double>(settings, "scope", section + ".bass_enhancer.scope");
+
+    update_default_key<double>(settings, "floor", section + ".bass_enhancer.floor");
+
+    update_default_key<double>(settings, "blend", section + ".bass_enhancer.blend");
+
+    update_default_key<bool>(settings, "floor-active", section + ".bass_enhancer.floor-active");
+
+    update_default_key<bool>(settings, "listen", section + ".bass_enhancer.listen");
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
+  }
 }
 
 void BassEnhancerUi::on_new_harmonics_level(double value) {

--- a/src/compressor_ui.cpp
+++ b/src/compressor_ui.cpp
@@ -138,6 +138,7 @@ CompressorUi::CompressorUi(BaseObjectType* cobject,
   builder->get_widget("sidechain_label", sidechain_label);
   builder->get_widget("curve", curve);
   builder->get_widget("curve_label", curve_label);
+  builder->get_widget("plugin_reset", reset_button);
 
   get_object(builder, "attack", attack);
   get_object(builder, "knee", knee);
@@ -183,10 +184,55 @@ CompressorUi::CompressorUi(BaseObjectType* cobject,
   g_settings_bind_with_mapping(settings->gobj(), "sidechain-source", sidechain_source->gobj(), "active",
                                G_SETTINGS_BIND_DEFAULT, sidechain_source_enum_to_int, int_to_sidechain_source_enum,
                                nullptr, nullptr);
+
+  // reset plugin
+  reset_button->signal_clicked().connect([=]() { reset(); });
 }
 
 CompressorUi::~CompressorUi() {
   util::debug(name + " ui destroyed");
+}
+
+void CompressorUi::reset() {
+  try {
+    std::string section = (preset_type == PresetType::output) ? "output" : "input";
+
+    update_default_key<double>(settings, "input-gain", section + ".compressor.input-gain");
+
+    update_default_key<double>(settings, "output-gain", section + ".compressor.output-gain");
+
+    update_default_string_key(settings, "mode", section + ".compressor.mode");
+
+    update_default_key<double>(settings, "attack", section + ".compressor.attack");
+
+    update_default_key<double>(settings, "release", section + ".compressor.release");
+
+    update_default_key<double>(settings, "threshold", section + ".compressor.threshold");
+
+    update_default_key<double>(settings, "ratio", section + ".compressor.ratio");
+
+    update_default_key<double>(settings, "knee", section + ".compressor.knee");
+
+    update_default_key<double>(settings, "makeup", section + ".compressor.makeup");
+
+    update_default_key<bool>(settings, "sidechain-listen", section + ".compressor.sidechain.listen");
+
+    update_default_string_key(settings, "sidechain-type", section + ".compressor.sidechain.type");
+
+    update_default_string_key(settings, "sidechain-mode", section + ".compressor.sidechain.mode");
+
+    update_default_string_key(settings, "sidechain-source", section + ".compressor.sidechain.source");
+
+    update_default_key<double>(settings, "sidechain-preamp", section + ".compressor.sidechain.preamp");
+
+    update_default_key<double>(settings, "sidechain-reactivity", section + ".compressor.sidechain.reactivity");
+
+    update_default_key<double>(settings, "sidechain-lookahead", section + ".compressor.sidechain.lookahead");
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
+  }
 }
 
 void CompressorUi::on_new_reduction(double value) {

--- a/src/convolver_ui.cpp
+++ b/src/convolver_ui.cpp
@@ -28,6 +28,7 @@ ConvolverUi::ConvolverUi(BaseObjectType* cobject,
   builder->get_widget("samples", label_samples);
   builder->get_widget("duration", label_duration);
   builder->get_widget("show_fft", show_fft);
+  builder->get_widget("plugin_reset", reset_button);
 
   get_object(builder, "input_gain", input_gain);
   get_object(builder, "output_gain", output_gain);
@@ -75,6 +76,9 @@ ConvolverUi::ConvolverUi(BaseObjectType* cobject,
 
   settings->set_boolean("post-messages", true);
 
+  // reset plugin
+  reset_button->signal_clicked().connect([=]() { reset(); });
+
   // irs dir
 
   auto dir_exists = boost::filesystem::is_directory(irs_dir);
@@ -120,6 +124,26 @@ ConvolverUi::~ConvolverUi() {
   futures.clear();
 
   util::debug(name + " ui destroyed");
+}
+
+void ConvolverUi::reset() {
+  try {
+    std::string section = (preset_type == PresetType::output) ? "output" : "input";
+
+    update_default_key<bool>(settings, "state", section + ".convolver.state");
+
+    update_default_key<double>(settings, "input-gain", section + ".convolver.input-gain");
+
+    update_default_key<double>(settings, "output-gain", section + ".convolver.output-gain");
+
+    update_default_string_key(settings, "kernel-path", section + ".convolver.kernel-path");
+
+    update_default_key<int>(settings, "ir-width", section + ".convolver.ir-width");
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
+  }
 }
 
 auto ConvolverUi::get_irs_names() -> std::vector<std::string> {

--- a/src/crossfeed_ui.cpp
+++ b/src/crossfeed_ui.cpp
@@ -11,6 +11,7 @@ CrossfeedUi::CrossfeedUi(BaseObjectType* cobject,
   builder->get_widget("preset_cmoy", preset_cmoy);
   builder->get_widget("preset_default", preset_default);
   builder->get_widget("preset_jmeier", preset_jmeier);
+  builder->get_widget("plugin_reset", reset_button);
 
   get_object(builder, "fcut", fcut);
   get_object(builder, "feed", feed);
@@ -23,11 +24,28 @@ CrossfeedUi::CrossfeedUi(BaseObjectType* cobject,
   settings->bind("fcut", fcut.get(), "value", flag);
   settings->bind("feed", feed.get(), "value", flag);
 
+  // reset plugin
+  reset_button->signal_clicked().connect([=]() { reset(); });
+
   init_presets_buttons();
 }
 
 CrossfeedUi::~CrossfeedUi() {
   util::debug(name + " ui destroyed");
+}
+
+void CrossfeedUi::reset() {
+  try {
+    std::string section = (preset_type == PresetType::output) ? "output" : "input";
+
+    update_default_key<int>(settings, "fcut", section + ".crossfeed.fcut");
+
+    update_default_key<double>(settings, "feed", section + ".crossfeed.feed");
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
+  }
 }
 
 void CrossfeedUi::init_presets_buttons() {

--- a/src/crystalizer_ui.cpp
+++ b/src/crystalizer_ui.cpp
@@ -16,6 +16,7 @@ CrystalizerUi::CrystalizerUi(BaseObjectType* cobject,
   builder->get_widget("range_before_label", range_before_label);
   builder->get_widget("range_after_label", range_after_label);
   builder->get_widget("aggressive", aggressive);
+  builder->get_widget("plugin_reset", reset_button);
 
   get_object(builder, "input_gain", input_gain);
   get_object(builder, "output_gain", output_gain);
@@ -31,10 +32,40 @@ CrystalizerUi::CrystalizerUi(BaseObjectType* cobject,
   settings->bind("aggressive", aggressive, "active", flag);
 
   build_bands(13);
+
+  // reset plugin
+  reset_button->signal_clicked().connect([=]() { reset(); });
 }
 
 CrystalizerUi::~CrystalizerUi() {
   util::debug(name + " ui destroyed");
+}
+
+void CrystalizerUi::reset() {
+  try {
+    std::string section = (preset_type == PresetType::output) ? "output" : "input";
+
+    update_default_key<bool>(settings, "aggressive", section + ".crystalizer.aggressive");
+
+    update_default_key<double>(settings, "input-gain", section + ".crystalizer.input-gain");
+
+    update_default_key<double>(settings, "output-gain", section + ".crystalizer.output-gain");
+
+    for (int n = 0; n < 13; n++) {
+      update_default_key<double>(settings, "intensity-band" + std::to_string(n),
+                         section + ".crystalizer.band" + std::to_string(n) + ".intensity");
+
+      update_default_key<bool>(settings, "mute-band" + std::to_string(n),
+                       section + ".crystalizer.band" + std::to_string(n) + ".mute");
+
+      update_default_key<bool>(settings, "bypass-band" + std::to_string(n),
+                       section + ".crystalizer.band" + std::to_string(n) + ".bypass");
+    }
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
+  }
 }
 
 void CrystalizerUi::build_bands(const int& nbands) {

--- a/src/deesser_ui.cpp
+++ b/src/deesser_ui.cpp
@@ -64,6 +64,7 @@ DeesserUi::DeesserUi(BaseObjectType* cobject,
   builder->get_widget("detected", detected);
   builder->get_widget("detected_label", detected_label);
   builder->get_widget("sc_listen", sc_listen);
+  builder->get_widget("plugin_reset", reset_button);
 
   get_object(builder, "makeup", makeup);
   get_object(builder, "ratio", ratio);
@@ -94,10 +95,47 @@ DeesserUi::DeesserUi(BaseObjectType* cobject,
 
   g_settings_bind_with_mapping(settings->gobj(), "mode", mode->gobj(), "active", G_SETTINGS_BIND_DEFAULT,
                                mode_enum_to_int, int_to_mode_enum, nullptr, nullptr);
+
+  // reset plugin
+  reset_button->signal_clicked().connect([=]() { reset(); });
 }
 
 DeesserUi::~DeesserUi() {
   util::debug(name + " ui destroyed");
+}
+
+void DeesserUi::reset() {
+  try {
+    std::string section = (preset_type == PresetType::output) ? "output" : "input";
+
+    update_default_string_key(settings, "detection", section + ".deesser.detection");
+
+    update_default_string_key(settings, "mode", section + ".deesser.mode");
+
+    update_default_key<double>(settings, "threshold", section + ".deesser.threshold");
+
+    update_default_key<double>(settings, "ratio", section + ".deesser.ratio");
+
+    update_default_key<int>(settings, "laxity", section + ".deesser.laxity");
+
+    update_default_key<double>(settings, "makeup", section + ".deesser.makeup");
+
+    update_default_key<double>(settings, "f1-freq", section + ".deesser.f1-freq");
+
+    update_default_key<double>(settings, "f2-freq", section + ".deesser.f2-freq");
+
+    update_default_key<double>(settings, "f1-level", section + ".deesser.f1-level");
+
+    update_default_key<double>(settings, "f2-level", section + ".deesser.f2-level");
+
+    update_default_key<double>(settings, "f2-q", section + ".deesser.f2-q");
+
+    update_default_key<bool>(settings, "sc-listen", section + ".deesser.sc-listen");
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
+  }
 }
 
 void DeesserUi::on_new_compression(double value) {

--- a/src/delay_ui.cpp
+++ b/src/delay_ui.cpp
@@ -6,6 +6,8 @@ DelayUi::DelayUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& buil
 
   // loading glade widgets
 
+  builder->get_widget("plugin_reset", reset_button);
+
   get_object(builder, "time_l", time_l);
   get_object(builder, "time_r", time_r);
   get_object(builder, "input_gain", input_gain);
@@ -20,8 +22,29 @@ DelayUi::DelayUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& buil
   settings->bind("output-gain", output_gain.get(), "value", flag);
   settings->bind("time-l", time_l.get(), "value", flag);
   settings->bind("time-r", time_r.get(), "value", flag);
+
+  // reset plugin
+  reset_button->signal_clicked().connect([=]() { reset(); });
 }
 
 DelayUi::~DelayUi() {
   util::debug(name + " ui destroyed");
+}
+
+void DelayUi::reset() {
+  try {
+    std::string section = (preset_type == PresetType::output) ? "output" : "input";
+
+    update_default_key<double>(settings, "input-gain", section + ".delay.input-gain");
+
+    update_default_key<double>(settings, "output-gain", section + ".delay.output-gain");
+
+    update_default_key<double>(settings, "time-l", section + ".delay.time-l");
+
+    update_default_key<double>(settings, "time-r", section + ".delay.time-r");
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
+  }
 }

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -206,6 +206,7 @@ EqualizerUi::EqualizerUi(BaseObjectType* cobject,
   builder->get_widget("stack", stack);
   builder->get_widget("stack_switcher", stack_switcher);
   builder->get_widget("mode", mode);
+  builder->get_widget("plugin_reset", reset_button);
 
   get_object(builder, "nbands", nbands);
   get_object(builder, "input_gain", input_gain);
@@ -215,7 +216,9 @@ EqualizerUi::EqualizerUi(BaseObjectType* cobject,
 
   nbands->signal_value_changed().connect(sigc::mem_fun(*this, &EqualizerUi::on_nbands_changed));
 
+  // reset equalizer
   reset_eq->signal_clicked().connect(sigc::mem_fun(*this, &EqualizerUi::reset));
+  reset_button->signal_clicked().connect(sigc::mem_fun(*this, &EqualizerUi::reset));
 
   flat_response->signal_clicked().connect(sigc::mem_fun(*this, &EqualizerUi::on_flat_response));
 
@@ -747,34 +750,40 @@ void EqualizerUi::populate_presets_listbox() {
 }
 
 void EqualizerUi::reset() {
-  settings->reset("state");
-  settings->reset("mode");
-  settings->reset("num-bands");
-  settings->reset("split-channels");
-  settings->reset("input-gain");
-  settings->reset("output-gain");
+  try {
+    settings->reset("state");
+    settings->reset("mode");
+    settings->reset("num-bands");
+    settings->reset("split-channels");
+    settings->reset("input-gain");
+    settings->reset("output-gain");
 
-  for (int n = 0; n < 30; n++) {
-    // left channel
+    for (int n = 0; n < 30; n++) {
+      // left channel
 
-    settings_left->reset(std::string("band" + std::to_string(n) + "-gain"));
-    settings_left->reset(std::string("band" + std::to_string(n) + "-frequency"));
-    settings_left->reset(std::string("band" + std::to_string(n) + "-q"));
-    settings_left->reset(std::string("band" + std::to_string(n) + "-type"));
-    settings_left->reset(std::string("band" + std::to_string(n) + "-mode"));
-    settings_left->reset(std::string("band" + std::to_string(n) + "-slope"));
-    settings_left->reset(std::string("band" + std::to_string(n) + "-solo"));
-    settings_left->reset(std::string("band" + std::to_string(n) + "-mute"));
+      settings_left->reset(std::string("band" + std::to_string(n) + "-gain"));
+      settings_left->reset(std::string("band" + std::to_string(n) + "-frequency"));
+      settings_left->reset(std::string("band" + std::to_string(n) + "-q"));
+      settings_left->reset(std::string("band" + std::to_string(n) + "-type"));
+      settings_left->reset(std::string("band" + std::to_string(n) + "-mode"));
+      settings_left->reset(std::string("band" + std::to_string(n) + "-slope"));
+      settings_left->reset(std::string("band" + std::to_string(n) + "-solo"));
+      settings_left->reset(std::string("band" + std::to_string(n) + "-mute"));
 
-    // right channel
+      // right channel
 
-    settings_right->reset(std::string("band" + std::to_string(n) + "-gain"));
-    settings_right->reset(std::string("band" + std::to_string(n) + "-frequency"));
-    settings_right->reset(std::string("band" + std::to_string(n) + "-q"));
-    settings_right->reset(std::string("band" + std::to_string(n) + "-type"));
-    settings_right->reset(std::string("band" + std::to_string(n) + "-mode"));
-    settings_right->reset(std::string("band" + std::to_string(n) + "-slope"));
-    settings_right->reset(std::string("band" + std::to_string(n) + "-solo"));
-    settings_right->reset(std::string("band" + std::to_string(n) + "-mute"));
+      settings_right->reset(std::string("band" + std::to_string(n) + "-gain"));
+      settings_right->reset(std::string("band" + std::to_string(n) + "-frequency"));
+      settings_right->reset(std::string("band" + std::to_string(n) + "-q"));
+      settings_right->reset(std::string("band" + std::to_string(n) + "-type"));
+      settings_right->reset(std::string("band" + std::to_string(n) + "-mode"));
+      settings_right->reset(std::string("band" + std::to_string(n) + "-slope"));
+      settings_right->reset(std::string("band" + std::to_string(n) + "-solo"));
+      settings_right->reset(std::string("band" + std::to_string(n) + "-mute"));
+    }
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
   }
 }

--- a/src/exciter_ui.cpp
+++ b/src/exciter_ui.cpp
@@ -12,6 +12,7 @@ ExciterUi::ExciterUi(BaseObjectType* cobject,
   builder->get_widget("harmonics_levelbar_label", harmonics_levelbar_label);
   builder->get_widget("ceil_active", ceil_active);
   builder->get_widget("listen", listen);
+  builder->get_widget("plugin_reset", reset_button);
 
   get_object(builder, "amount", amount);
   get_object(builder, "blend", blend);
@@ -35,10 +36,41 @@ ExciterUi::ExciterUi(BaseObjectType* cobject,
   settings->bind("output-gain", output_gain.get(), "value", flag);
   settings->bind("listen", listen, "active", flag);
   settings->bind("ceil-active", ceil_active, "active", flag);
+
+  // reset plugin
+  reset_button->signal_clicked().connect([=]() { reset(); });
 }
 
 ExciterUi::~ExciterUi() {
   util::debug(name + " ui destroyed");
+}
+
+void ExciterUi::reset() {
+  try {
+    std::string section = (preset_type == PresetType::output) ? "output" : "input";
+
+    update_default_key<double>(settings, "input-gain", section + ".exciter.input-gain");
+
+    update_default_key<double>(settings, "output-gain", section + ".exciter.output-gain");
+
+    update_default_key<double>(settings, "amount", section + ".exciter.amount");
+
+    update_default_key<double>(settings, "harmonics", section + ".exciter.harmonics");
+
+    update_default_key<double>(settings, "scope", section + ".exciter.scope");
+
+    update_default_key<double>(settings, "ceil", section + ".exciter.ceil");
+
+    update_default_key<double>(settings, "blend", section + ".exciter.blend");
+
+    update_default_key<bool>(settings, "ceil-active", section + ".exciter.ceil-active");
+
+    update_default_key<bool>(settings, "listen", section + ".exciter.listen");
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
+  }
 }
 
 void ExciterUi::on_new_harmonics_level(double value) {

--- a/src/filter_ui.cpp
+++ b/src/filter_ui.cpp
@@ -98,6 +98,7 @@ FilterUi::FilterUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& bu
   builder->get_widget("preset_disco", preset_disco);
   builder->get_widget("preset_distant_headphones", preset_distant_headphones);
   builder->get_widget("preset_default", preset_default);
+  builder->get_widget("plugin_reset", reset_button);
 
   get_object(builder, "input_gain", input_gain);
   get_object(builder, "output_gain", output_gain);
@@ -120,10 +121,35 @@ FilterUi::FilterUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& bu
                                filter_enum_to_int, int_to_filter_enum, nullptr, nullptr);
 
   init_presets_buttons();
+
+  // reset plugin
+  reset_button->signal_clicked().connect([=]() { reset(); });
 }
 
 FilterUi::~FilterUi() {
   util::debug(name + " ui destroyed");
+}
+
+void FilterUi::reset() {
+  try {
+    std::string section = (preset_type == PresetType::output) ? "output" : "input";
+
+    update_default_key<double>(settings, "input-gain", section + ".filter.input-gain");
+
+    update_default_key<double>(settings, "output-gain", section + ".filter.output-gain");
+
+    update_default_key<double>(settings, "frequency", section + ".filter.frequency");
+
+    update_default_key<double>(settings, "resonance", section + ".filter.resonance");
+
+    update_default_string_key(settings, "mode", section + ".filter.mode");
+
+    update_default_key<double>(settings, "inertia", section + ".filter.inertia");
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
+  }
 }
 
 void FilterUi::init_presets_buttons() {

--- a/src/gate_ui.cpp
+++ b/src/gate_ui.cpp
@@ -59,6 +59,7 @@ GateUi::GateUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& builde
   builder->get_widget("stereo_link", stereo_link);
   builder->get_widget("gating", gating);
   builder->get_widget("gating_label", gating_label);
+  builder->get_widget("plugin_reset", reset_button);
 
   get_object(builder, "attack", attack);
   get_object(builder, "knee", knee);
@@ -86,10 +87,41 @@ GateUi::GateUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& builde
 
   g_settings_bind_with_mapping(settings->gobj(), "stereo-link", stereo_link->gobj(), "active", G_SETTINGS_BIND_DEFAULT,
                                stereo_link_enum_to_int, int_to_stereo_link_enum, nullptr, nullptr);
+
+  // reset plugin
+  reset_button->signal_clicked().connect([=]() { reset(); });
 }
 
 GateUi::~GateUi() {
   util::debug(name + " ui destroyed");
+}
+
+void GateUi::reset() {
+  try {
+    std::string section = (preset_type == PresetType::output) ? "output" : "input";
+
+    update_default_string_key(settings, "detection", section + ".gate.detection");
+
+    update_default_string_key(settings, "stereo-link", section + ".gate.stereo-link");
+
+    update_default_key<double>(settings, "range", section + ".gate.range");
+
+    update_default_key<double>(settings, "attack", section + ".gate.attack");
+
+    update_default_key<double>(settings, "release", section + ".gate.release");
+
+    update_default_key<double>(settings, "threshold", section + ".gate.threshold");
+
+    update_default_key<double>(settings, "ratio", section + ".gate.ratio");
+
+    update_default_key<double>(settings, "knee", section + ".gate.knee");
+
+    update_default_key<double>(settings, "makeup", section + ".gate.makeup");
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
+  }
 }
 
 void GateUi::on_new_gating(double value) {

--- a/src/limiter_ui.cpp
+++ b/src/limiter_ui.cpp
@@ -11,6 +11,7 @@ LimiterUi::LimiterUi(BaseObjectType* cobject,
   builder->get_widget("asc", asc);
   builder->get_widget("attenuation", attenuation);
   builder->get_widget("attenuation_label", attenuation_label);
+  builder->get_widget("plugin_reset", reset_button);
 
   get_object(builder, "input_gain", input_gain);
   get_object(builder, "limit", limit);
@@ -32,10 +33,37 @@ LimiterUi::LimiterUi(BaseObjectType* cobject,
   settings->bind("oversampling", oversampling.get(), "value", flag);
   settings->bind("asc", asc, "active", flag);
   settings->bind("asc-level", asc_level.get(), "value", flag);
+
+  // reset plugin
+  reset_button->signal_clicked().connect([=]() { reset(); });
 }
 
 LimiterUi::~LimiterUi() {
   util::debug(name + " ui destroyed");
+}
+
+void LimiterUi::reset() {
+  try {
+    std::string section = (preset_type == PresetType::output) ? "output" : "input";
+
+    update_default_key<double>(settings, "input-gain", section + ".limiter.input-gain");
+
+    update_default_key<double>(settings, "limit", section + ".limiter.limit");
+
+    update_default_key<double>(settings, "lookahead", section + ".limiter.lookahead");
+
+    update_default_key<double>(settings, "release", section + ".limiter.release");
+
+    update_default_key<bool>(settings, "asc", section + ".limiter.asc");
+
+    update_default_key<double>(settings, "asc-level", section + ".limiter.asc-level");
+
+    update_default_key<int>(settings, "oversampling", section + ".limiter.oversampling");
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
+  }
 }
 
 void LimiterUi::on_new_attenuation(double value) {

--- a/src/loudness_ui.cpp
+++ b/src/loudness_ui.cpp
@@ -8,6 +8,8 @@ LoudnessUi::LoudnessUi(BaseObjectType* cobject,
 
   // loading glade widgets
 
+  builder->get_widget("plugin_reset", reset_button);
+
   get_object(builder, "loudness", loudness);
   get_object(builder, "output", output);
   get_object(builder, "link", link);
@@ -20,8 +22,27 @@ LoudnessUi::LoudnessUi(BaseObjectType* cobject,
   settings->bind("loudness", loudness.get(), "value", flag);
   settings->bind("output", output.get(), "value", flag);
   settings->bind("link", link.get(), "value", flag);
+
+  // reset plugin
+  reset_button->signal_clicked().connect([=]() { reset(); });
 }
 
 LoudnessUi::~LoudnessUi() {
   util::debug(name + " ui destroyed");
+}
+
+void LoudnessUi::reset() {
+  try {
+    std::string section = (preset_type == PresetType::output) ? "output" : "input";
+
+    update_default_key<double>(settings, "loudness", section + ".loudness.loudness");
+
+    update_default_key<double>(settings, "output", section + ".loudness.output");
+
+    update_default_key<double>(settings, "link", section + ".loudness.link");
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
+  }
 }

--- a/src/maximizer_ui.cpp
+++ b/src/maximizer_ui.cpp
@@ -10,6 +10,7 @@ MaximizerUi::MaximizerUi(BaseObjectType* cobject,
 
   builder->get_widget("reduction", reduction);
   builder->get_widget("reduction_label", reduction_label);
+  builder->get_widget("plugin_reset", reset_button);
 
   get_object(builder, "ceiling", ceiling);
   get_object(builder, "release", release);
@@ -23,10 +24,29 @@ MaximizerUi::MaximizerUi(BaseObjectType* cobject,
   settings->bind("ceiling", ceiling.get(), "value", flag);
   settings->bind("release", release.get(), "value", flag);
   settings->bind("threshold", threshold.get(), "value", flag);
+
+  // reset plugin
+  reset_button->signal_clicked().connect([=]() { reset(); });
 }
 
 MaximizerUi::~MaximizerUi() {
   util::debug(name + " ui destroyed");
+}
+
+void MaximizerUi::reset() {
+  try {
+    std::string section = (preset_type == PresetType::output) ? "output" : "input";
+
+    update_default_key<double>(settings, "release", section + "maximizer.release");
+
+    update_default_key<double>(settings, "ceiling", section + "maximizer.ceiling");
+    
+    update_default_key<double>(settings, "threshold", section + "maximizer.threshold");
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
+  }
 }
 
 void MaximizerUi::on_new_reduction(double value) {

--- a/src/multiband_compressor_ui.cpp
+++ b/src/multiband_compressor_ui.cpp
@@ -86,6 +86,7 @@ MultibandCompressorUi::MultibandCompressorUi(BaseObjectType* cobject,
   builder->get_widget("compression2_label", compression2_label);
   builder->get_widget("compression3", compression3);
   builder->get_widget("compression3_label", compression3_label);
+  builder->get_widget("plugin_reset", reset_button);
 
   get_object(builder, "input_gain", input_gain);
   get_object(builder, "output_gain", output_gain);
@@ -176,10 +177,115 @@ MultibandCompressorUi::MultibandCompressorUi(BaseObjectType* cobject,
 
   g_settings_bind_with_mapping(settings->gobj(), "detection3", detection3->gobj(), "active", G_SETTINGS_BIND_DEFAULT,
                                detection_enum_to_int, int_to_detection_enum, nullptr, nullptr);
+
+  // reset plugin
+  reset_button->signal_clicked().connect([=]() { reset(); });
 }
 
 MultibandCompressorUi::~MultibandCompressorUi() {
   util::debug(name + " ui destroyed");
+}
+
+void MultibandCompressorUi::reset() {
+  try {
+    std::string section = (preset_type == PresetType::output) ? "output" : "input";
+
+    update_default_key<double>(settings, "input-gain", section + ".multiband_compressor.input-gain");
+
+    update_default_key<double>(settings, "output-gain", section + ".multiband_compressor.output-gain");
+
+    update_default_key<double>(settings, "freq0", section + ".multiband_compressor.freq0");
+
+    update_default_key<double>(settings, "freq1", section + ".multiband_compressor.freq1");
+
+    update_default_key<double>(settings, "freq2", section + ".multiband_compressor.freq2");
+
+    update_default_string_key(settings, "mode", section + ".multiband_compressor.mode");
+
+    // sub band
+
+    update_default_key<double>(settings, "threshold0", section + ".multiband_compressor.subband.threshold");
+
+    update_default_key<double>(settings, "ratio0", section + ".multiband_compressor.subband.ratio");
+
+    update_default_key<double>(settings, "attack0", section + ".multiband_compressor.subband.attack");
+
+    update_default_key<double>(settings, "release0", section + ".multiband_compressor.subband.release");
+
+    update_default_key<double>(settings, "makeup0", section + ".multiband_compressor.subband.makeup");
+
+    update_default_key<double>(settings, "knee0", section + ".multiband_compressor.subband.knee");
+
+    update_default_string_key(settings, "detection0", section + ".multiband_compressor.subband.detection");
+
+    update_default_key<bool>(settings, "bypass0", section + ".multiband_compressor.subband.bypass");
+
+    update_default_key<bool>(settings, "solo0", section + ".multiband_compressor.subband.solo");
+
+    // low band
+
+    update_default_key<double>(settings, "threshold1", section + ".multiband_compressor.lowband.threshold");
+
+    update_default_key<double>(settings, "ratio1", section + ".multiband_compressor.lowband.ratio");
+
+    update_default_key<double>(settings, "attack1", section + ".multiband_compressor.lowband.attack");
+
+    update_default_key<double>(settings, "release1", section + ".multiband_compressor.lowband.release");
+
+    update_default_key<double>(settings, "makeup1", section + ".multiband_compressor.lowband.makeup");
+
+    update_default_key<double>(settings, "knee1", section + ".multiband_compressor.lowband.knee");
+
+    update_default_string_key(settings, "detection1", section + ".multiband_compressor.lowband.detection");
+
+    update_default_key<bool>(settings, "bypass1", section + ".multiband_compressor.lowband.bypass");
+
+    update_default_key<bool>(settings, "solo1", section + ".multiband_compressor.lowband.solo");
+
+    // mid band
+
+    update_default_key<double>(settings, "threshold2", section + ".multiband_compressor.midband.threshold");
+
+    update_default_key<double>(settings, "ratio2", section + ".multiband_compressor.midband.ratio");
+
+    update_default_key<double>(settings, "attack2", section + ".multiband_compressor.midband.attack");
+
+    update_default_key<double>(settings, "release2", section + ".multiband_compressor.midband.release");
+
+    update_default_key<double>(settings, "makeup2", section + ".multiband_compressor.midband.makeup");
+
+    update_default_key<double>(settings, "knee2", section + ".multiband_compressor.midband.knee");
+
+    update_default_string_key(settings, "detection2", section + ".multiband_compressor.midband.detection");
+
+    update_default_key<bool>(settings, "bypass2", section + ".multiband_compressor.midband.bypass");
+
+    update_default_key<bool>(settings, "solo2", section + ".multiband_compressor.midband.solo");
+
+    // high band
+
+    update_default_key<double>(settings, "threshold3", section + ".multiband_compressor.highband.threshold");
+
+    update_default_key<double>(settings, "ratio3", section + ".multiband_compressor.highband.ratio");
+
+    update_default_key<double>(settings, "attack3", section + ".multiband_compressor.highband.attack");
+
+    update_default_key<double>(settings, "release3", section + ".multiband_compressor.highband.release");
+
+    update_default_key<double>(settings, "makeup3", section + ".multiband_compressor.highband.makeup");
+
+    update_default_key<double>(settings, "knee3", section + ".multiband_compressor.highband.knee");
+
+    update_default_string_key(settings, "detection3", section + ".multiband_compressor.highband.detection");
+
+    update_default_key<bool>(settings, "bypass3", section + ".multiband_compressor.highband.bypass");
+
+    update_default_key<bool>(settings, "solo3", section + ".multiband_compressor.highband.solo");
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
+  }
 }
 
 void MultibandCompressorUi::on_new_output0(double value) {

--- a/src/multiband_gate_ui.cpp
+++ b/src/multiband_gate_ui.cpp
@@ -86,6 +86,7 @@ MultibandGateUi::MultibandGateUi(BaseObjectType* cobject,
   builder->get_widget("gating2_label", gating2_label);
   builder->get_widget("gating3", gating3);
   builder->get_widget("gating3_label", gating3_label);
+  builder->get_widget("plugin_reset", reset_button);
 
   get_object(builder, "input_gain", input_gain);
   get_object(builder, "output_gain", output_gain);
@@ -184,10 +185,123 @@ MultibandGateUi::MultibandGateUi(BaseObjectType* cobject,
 
   g_settings_bind_with_mapping(settings->gobj(), "detection3", detection3->gobj(), "active", G_SETTINGS_BIND_DEFAULT,
                                detection_enum_to_int, int_to_detection_enum, nullptr, nullptr);
+
+  // reset plugin
+  reset_button->signal_clicked().connect([=]() { reset(); });
 }
 
 MultibandGateUi::~MultibandGateUi() {
   util::debug(name + " ui destroyed");
+}
+
+void MultibandGateUi::reset() {
+  try {
+    std::string section = (preset_type == PresetType::output) ? "output" : "input";
+
+    update_default_key<double>(settings, "input-gain", section + ".multiband_gate.input-gain");
+
+    update_default_key<double>(settings, "output-gain", section + ".multiband_gate.output-gain");
+
+    update_default_key<double>(settings, "freq0", section + ".multiband_gate.freq0");
+
+    update_default_key<double>(settings, "freq1", section + ".multiband_gate.freq1");
+
+    update_default_key<double>(settings, "freq2", section + ".multiband_gate.freq2");
+
+    update_default_string_key(settings, "mode", section + ".multiband_gate.mode");
+
+    // sub band
+
+    update_default_key<double>(settings, "range0", section + ".multiband_gate.subband.reduction");
+
+    update_default_key<double>(settings, "threshold0", section + ".multiband_gate.subband.threshold");
+
+    update_default_key<double>(settings, "ratio0", section + ".multiband_gate.subband.ratio");
+
+    update_default_key<double>(settings, "attack0", section + ".multiband_gate.subband.attack");
+
+    update_default_key<double>(settings, "release0", section + ".multiband_gate.subband.release");
+
+    update_default_key<double>(settings, "makeup0", section + ".multiband_gate.subband.makeup");
+
+    update_default_key<double>(settings, "knee0", section + ".multiband_gate.subband.knee");
+
+    update_default_string_key(settings, "detection0", section + ".multiband_gate.subband.detection");
+
+    update_default_key<bool>(settings, "bypass0", section + ".multiband_gate.subband.bypass");
+
+    update_default_key<bool>(settings, "solo0", section + ".multiband_gate.subband.solo");
+
+    // low band
+
+    update_default_key<double>(settings, "range1", section + ".multiband_gate.lowband.reduction");
+
+    update_default_key<double>(settings, "threshold1", section + ".multiband_gate.lowband.threshold");
+
+    update_default_key<double>(settings, "ratio1", section + ".multiband_gate.lowband.ratio");
+
+    update_default_key<double>(settings, "attack1", section + ".multiband_gate.lowband.attack");
+
+    update_default_key<double>(settings, "release1", section + ".multiband_gate.lowband.release");
+
+    update_default_key<double>(settings, "makeup1", section + ".multiband_gate.lowband.makeup");
+
+    update_default_key<double>(settings, "knee1", section + ".multiband_gate.lowband.knee");
+
+    update_default_string_key(settings, "detection1", section + ".multiband_gate.lowband.detection");
+
+    update_default_key<bool>(settings, "bypass1", section + ".multiband_gate.lowband.bypass");
+
+    update_default_key<bool>(settings, "solo1", section + ".multiband_gate.lowband.solo");
+
+    // mid band
+
+    update_default_key<double>(settings, "range2", section + ".multiband_gate.midband.reduction");
+
+    update_default_key<double>(settings, "threshold2", section + ".multiband_gate.midband.threshold");
+
+    update_default_key<double>(settings, "ratio2", section + ".multiband_gate.midband.ratio");
+
+    update_default_key<double>(settings, "attack2", section + ".multiband_gate.midband.attack");
+
+    update_default_key<double>(settings, "release2", section + ".multiband_gate.midband.release");
+
+    update_default_key<double>(settings, "makeup2", section + ".multiband_gate.midband.makeup");
+
+    update_default_key<double>(settings, "knee2", section + ".multiband_gate.midband.knee");
+
+    update_default_string_key(settings, "detection2", section + ".multiband_gate.midband.detection");
+
+    update_default_key<bool>(settings, "bypass2", section + ".multiband_gate.midband.bypass");
+
+    update_default_key<bool>(settings, "solo2", section + ".multiband_gate.midband.solo");
+
+    // high band
+
+    update_default_key<double>(settings, "range3", section + ".multiband_gate.highband.reduction");
+
+    update_default_key<double>(settings, "threshold3", section + ".multiband_gate.highband.threshold");
+
+    update_default_key<double>(settings, "ratio3", section + ".multiband_gate.highband.ratio");
+
+    update_default_key<double>(settings, "attack3", section + ".multiband_gate.highband.attack");
+
+    update_default_key<double>(settings, "release3", section + ".multiband_gate.highband.release");
+
+    update_default_key<double>(settings, "makeup3", section + ".multiband_gate.highband.makeup");
+
+    update_default_key<double>(settings, "knee3", section + ".multiband_gate.highband.knee");
+
+    update_default_string_key(settings, "detection3", section + ".multiband_gate.highband.detection");
+
+    update_default_key<bool>(settings, "bypass3", section + ".multiband_gate.highband.bypass");
+
+    update_default_key<bool>(settings, "solo3", section + ".multiband_gate.highband.solo");
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
+  }
 }
 
 void MultibandGateUi::on_new_output0(double value) {

--- a/src/pitch_ui.cpp
+++ b/src/pitch_ui.cpp
@@ -8,6 +8,7 @@ PitchUi::PitchUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& buil
 
   builder->get_widget("faster", faster);
   builder->get_widget("formant_preserving", formant_preserving);
+  builder->get_widget("plugin_reset", reset_button);
 
   get_object(builder, "cents", cents);
   get_object(builder, "crispness", crispness);
@@ -29,8 +30,37 @@ PitchUi::PitchUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& buil
   settings->bind("formant-preserving", formant_preserving, "active", flag);
   settings->bind("input-gain", input_gain.get(), "value", flag);
   settings->bind("output-gain", output_gain.get(), "value", flag);
+
+  // reset plugin
+  reset_button->signal_clicked().connect([=]() { reset(); });
 }
 
 PitchUi::~PitchUi() {
   util::debug(name + " ui destroyed");
+}
+
+void PitchUi::reset() {
+  try {
+    std::string section = (preset_type == PresetType::output) ? "output" : "input";
+
+    update_default_key<double>(settings, "input-gain", section + ".pitch.input-gain");
+
+    update_default_key<double>(settings, "output-gain", section + ".pitch.output-gain");
+
+    update_default_key<double>(settings, "cents", section + ".pitch.cents");
+
+    update_default_key<int>(settings, "semitones", section + ".pitch.semitones");
+
+    update_default_key<int>(settings, "octaves", section + ".pitch.octaves");
+
+    update_default_key<int>(settings, "crispness", section + ".pitch.crispness");
+
+    update_default_key<bool>(settings, "formant-preserving", section + ".pitch.formant-preserving");
+
+    update_default_key<bool>(settings, "faster", section + ".pitch.faster");
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
+  }
 }

--- a/src/reverb_ui.cpp
+++ b/src/reverb_ui.cpp
@@ -66,6 +66,7 @@ ReverbUi::ReverbUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& bu
   builder->get_widget("preset_disco", preset_disco);
   builder->get_widget("preset_large_occupied_hall", preset_large_occupied_hall);
   builder->get_widget("preset_default", preset_default);
+  builder->get_widget("plugin_reset", reset_button);
 
   get_object(builder, "input_gain", input_gain);
   get_object(builder, "output_gain", output_gain);
@@ -98,10 +99,45 @@ ReverbUi::ReverbUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& bu
                                room_size_enum_to_int, int_to_room_size_enum, nullptr, nullptr);
 
   init_presets_buttons();
+
+  // reset plugin
+  reset_button->signal_clicked().connect([=]() { reset(); });
 }
 
 ReverbUi::~ReverbUi() {
   util::debug(name + " ui destroyed");
+}
+
+void ReverbUi::reset() {
+  try {
+    std::string section = (preset_type == PresetType::output) ? "output" : "input";
+
+    update_default_key<double>(settings, "input-gain", section + ".reverb.input-gain");
+
+    update_default_key<double>(settings, "output-gain", section + ".reverb.output-gain");
+
+    update_default_string_key(settings, "room-size", section + ".reverb.room-size");
+
+    update_default_key<double>(settings, "decay-time", section + ".reverb.decay-time");
+
+    update_default_key<double>(settings, "hf-damp", section + ".reverb.hf-damp");
+
+    update_default_key<double>(settings, "diffusion", section + ".reverb.diffusion");
+
+    update_default_key<double>(settings, "amount", section + ".reverb.amount");
+
+    update_default_key<double>(settings, "dry", section + ".reverb.dry");
+
+    update_default_key<double>(settings, "predelay", section + ".reverb.predelay");
+
+    update_default_key<double>(settings, "bass-cut", section + ".reverb.bass-cut");
+
+    update_default_key<double>(settings, "treble-cut", section + ".reverb.treble-cut");
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
+  }
 }
 
 void ReverbUi::init_presets_buttons() {

--- a/src/sink_input_effects_ui.cpp
+++ b/src/sink_input_effects_ui.cpp
@@ -57,6 +57,10 @@ SinkInputEffectsUi::SinkInputEffectsUi(BaseObjectType* cobject,
   b_autogain->get_widget_derived("widgets_grid", autogain_ui, "com.github.wwmm.pulseeffects.sinkinputs.autogain");
   b_delay->get_widget_derived("widgets_grid", delay_ui, "com.github.wwmm.pulseeffects.sinkinputs.delay");
 
+  // preset_type inside user interfaces already initialized to "output"; nothing to be done
+
+  // add to stack
+
   stack->add(*limiter_ui, limiter_ui->name);
   stack->add(*compressor_ui, compressor_ui->name);
   stack->add(*filter_ui, filter_ui->name);

--- a/src/source_output_effects_ui.cpp
+++ b/src/source_output_effects_ui.cpp
@@ -37,6 +37,22 @@ SourceOutputEffectsUi::SourceOutputEffectsUi(BaseObjectType* cobject,
   b_multiband_gate->get_widget_derived("widgets_grid", multiband_gate_ui,
                                        "com.github.wwmm.pulseeffects.sourceoutputs.multibandgate");
 
+  // set preset type property inside user interfaces to be intepreted as "input"
+
+  limiter_ui->preset_type = PresetType::input;
+  compressor_ui->preset_type = PresetType::input;
+  filter_ui->preset_type = PresetType::input;
+  equalizer_ui->preset_type = PresetType::input;
+  reverb_ui->preset_type = PresetType::input;
+  gate_ui->preset_type = PresetType::input;
+  deesser_ui->preset_type = PresetType::input;
+  pitch_ui->preset_type = PresetType::input;
+  webrtc_ui->preset_type = PresetType::input;
+  multiband_compressor_ui->preset_type = PresetType::input;
+  multiband_gate_ui->preset_type = PresetType::input;
+
+  // add to stack
+
   stack->add(*limiter_ui, limiter_ui->name);
   stack->add(*compressor_ui, compressor_ui->name);
   stack->add(*filter_ui, filter_ui->name);

--- a/src/stereo_tools_ui.cpp
+++ b/src/stereo_tools_ui.cpp
@@ -71,6 +71,7 @@ StereoToolsUi::StereoToolsUi(BaseObjectType* cobject,
   builder->get_widget("phasel", phasel);
   builder->get_widget("phaser", phaser);
   builder->get_widget("mode", mode);
+  builder->get_widget("plugin_reset", reset_button);
 
   get_object(builder, "input_gain", input_gain);
   get_object(builder, "output_gain", output_gain);
@@ -111,8 +112,57 @@ StereoToolsUi::StereoToolsUi(BaseObjectType* cobject,
 
   g_settings_bind_with_mapping(settings->gobj(), "mode", mode->gobj(), "active", G_SETTINGS_BIND_DEFAULT,
                                stereo_tools_enum_to_int, int_to_stereo_tools_enum, nullptr, nullptr);
+
+  // reset plugin
+  reset_button->signal_clicked().connect([=]() { reset(); });
 }
 
 StereoToolsUi::~StereoToolsUi() {
   util::debug(name + " ui destroyed");
+}
+
+void StereoToolsUi::reset() {
+  try {
+    std::string section = (preset_type == PresetType::output) ? "output" : "input";
+
+    update_default_key<double>(settings, "input-gain", section + ".stereo_tools.input-gain");
+
+    update_default_key<double>(settings, "output-gain", section + ".stereo_tools.output-gain");
+
+    update_default_key<double>(settings, "balance-in", section + ".stereo_tools.balance-in");
+
+    update_default_key<double>(settings, "balance-out", section + ".stereo_tools.balance-out");
+
+    update_default_key<bool>(settings, "softclip", section + ".stereo_tools.softclip");
+
+    update_default_key<bool>(settings, "mutel", section + ".stereo_tools.mutel");
+
+    update_default_key<bool>(settings, "muter", section + ".stereo_tools.muter");
+
+    update_default_key<bool>(settings, "phasel", section + ".stereo_tools.phasel");
+
+    update_default_key<bool>(settings, "phaser", section + ".stereo_tools.phaser");
+
+    update_default_string_key(settings, "mode", section + ".stereo_tools.mode");
+
+    update_default_key<double>(settings, "slev", section + ".stereo_tools.side-level");
+
+    update_default_key<double>(settings, "sbal", section + ".stereo_tools.side-balance");
+
+    update_default_key<double>(settings, "mlev", section + ".stereo_tools.middle-level");
+
+    update_default_key<double>(settings, "mpan", section + ".stereo_tools.middle-panorama");
+
+    update_default_key<double>(settings, "stereo-base", section + ".stereo_tools.stereo-base");
+
+    update_default_key<double>(settings, "delay", section + ".stereo_tools.delay");
+
+    update_default_key<double>(settings, "sc-level", section + ".stereo_tools.sc-level");
+
+    update_default_key<double>(settings, "stereo-phase", section + ".stereo_tools.stereo-phase");
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
+  }
 }

--- a/src/webrtc_ui.cpp
+++ b/src/webrtc_ui.cpp
@@ -144,6 +144,7 @@ WebrtcUi::WebrtcUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& bu
   builder->get_widget("noise_suppression_level", noise_suppression_level);
   builder->get_widget("gain_control_mode", gain_control_mode);
   builder->get_widget("voice_detection_likelihood", voice_detection_likelihood);
+  builder->get_widget("plugin_reset", reset_button);
 
   get_object(builder, "compression_gain_db", compression_gain_db);
   get_object(builder, "target_level_dbfs", target_level_dbfs);
@@ -182,8 +183,51 @@ WebrtcUi::WebrtcUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& bu
   g_settings_bind_with_mapping(settings->gobj(), "voice-detection-likelihood", voice_detection_likelihood->gobj(),
                                "active", G_SETTINGS_BIND_DEFAULT, voice_detection_likelihood_to_int,
                                int_to_voice_detection_likelihood, nullptr, nullptr);
+
+  // reset plugin
+  reset_button->signal_clicked().connect([=]() { reset(); });
 }
 
 WebrtcUi::~WebrtcUi() {
   util::debug(name + " ui destroyed");
+}
+
+void WebrtcUi::reset() {
+  try {
+    std::string section = (preset_type == PresetType::output) ? "output" : "input";
+
+    update_default_key<bool>(settings, "high-pass-filter", section + ".webrtc.high-pass-filter");
+
+    update_default_key<bool>(settings, "echo-cancel", section + ".webrtc.echo-cancel");
+
+    update_default_string_key(settings, "echo-suppression-level", section + ".webrtc.echo-suppression-level");
+
+    update_default_key<bool>(settings, "noise-suppression", section + ".webrtc.noise-suppression");
+
+    update_default_string_key(settings, "noise-suppression-level", section + ".webrtc.noise-suppression-level");
+
+    update_default_key<bool>(settings, "gain-control", section + ".webrtc.gain-control");
+
+    update_default_key<bool>(settings, "extended-filter", section + ".webrtc.extended-filter");
+
+    update_default_key<bool>(settings, "delay-agnostic", section + ".webrtc.delay-agnostic");
+
+    update_default_key<int>(settings, "target-level-dbfs", section + ".webrtc.target-level-dbfs");
+
+    update_default_key<int>(settings, "compression-gain-db", section + ".webrtc.compression-gain-db");
+
+    update_default_key<bool>(settings, "limiter", section + ".webrtc.limiter");
+
+    update_default_string_key(settings, "gain-control-mode", section + ".webrtc.gain-control-mode");
+
+    update_default_key<bool>(settings, "voice-detection", section + ".webrtc.voice-detection");
+
+    update_default_key<int>(settings, "voice-detection-frame-size-ms", section + ".webrtc.voice-detection-frame-size-ms");
+
+    update_default_string_key(settings, "voice-detection-likelihood", section + ".webrtc.voice-detection-likelihood");
+
+    util::debug(name + " plugin: successfully reset");
+  } catch (std::exception& e) {
+    util::debug(name + " plugin: an error occurred during reset process");
+  }
 }


### PR DESCRIPTION
This pull request implements #560 

Some templates in plugin_preset_base have been rewritten and added inside plugin_ui_base to apply default settings. A reset button has been added to each plugin UI.

A reset method has been added to each plugin UI class, except equalizer that already had one. UI classes didn't know which pipeline they belong to, so in order to apply the correct default preset, a PresetType property has been added to plugin_ui_base. In reset method this property is read to get the proper section.

The PresetType is initialized to "output" and inherited from plugin_ui_base, so it is set to "input" for all UI inside soe_ui.

Successfully compiled and tested on my system. A single plugin is reset properly to its default settings. Each plugin can be reset even if it is disabled.

I don't know if this was the simplest way to do this. I know you @wwmm don't have time implement these features, so at least I tried.

Testing this I found a weird issue. Laxity key inside Deesser is not updating. If I reset the plugin or everytime a preset is applied from the menu, laxity option stays always the previous value. This issue in not related to my modifications, I discovered it's happening in Arch upstream repository version too. Maybe it's something wrong with the plugin. Please check it out.