### PR TITLE
Update boost version requirement in meson.build

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -106,7 +106,7 @@ pulseeffects_deps = [
 	dependency('gstreamer-fft-1.0'),
 	dependency('lilv-0', version: '>=0.22', required: false),
 	dependency('libbs2b', required: false),
-	dependency('boost', version: '>=1.65', modules:['system','filesystem']),
+	dependency('boost', version: '>=1.72', modules:['system','filesystem']),
 	dependency('sndfile'),
 	dependency('threads')
 ]


### PR DESCRIPTION
So it is consistent with the the actual requirement, and with the README.

This prevents builds that failed even after meson could configure the project successfully - without detecting the insufficient Boost version.