### PR TITLE
Blacklist button to app entry inside applications list tab

### DIFF
--- a/data/ui/app_info.glade
+++ b/data/ui/app_info.glade
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkImage" id="blacklist_icon">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">action-unavailable</property>
+  </object>
   <object class="GtkImage" id="mute_icon">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -15,8 +20,6 @@
   <object class="GtkGrid" id="widgets_grid">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="margin_left">12</property>
-    <property name="margin_right">12</property>
     <property name="margin_top">12</property>
     <property name="margin_bottom">12</property>
     <property name="row_spacing">18</property>
@@ -280,24 +283,10 @@
       <object class="GtkGrid">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="margin_start">12</property>
+        <property name="margin_end">12</property>
         <property name="hexpand">True</property>
         <property name="column_spacing">6</property>
-        <child>
-          <object class="GtkScale" id="volume">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="valign">center</property>
-            <property name="hexpand">True</property>
-            <property name="adjustment">volume_adjustment</property>
-            <property name="round_digits">1</property>
-            <property name="digits">0</property>
-            <property name="value_pos">right</property>
-          </object>
-          <packing>
-            <property name="left_attach">1</property>
-            <property name="top_attach">0</property>
-          </packing>
-        </child>
         <child>
           <object class="GtkToggleButton" id="mute">
             <property name="visible">True</property>
@@ -309,6 +298,39 @@
           </object>
           <packing>
             <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkScale" id="volume">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="valign">center</property>
+            <property name="margin_end">10</property>
+            <property name="hexpand">True</property>
+            <property name="adjustment">volume_adjustment</property>
+            <property name="round_digits">0</property>
+            <property name="digits">0</property>
+            <property name="value_pos">right</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkToggleButton" id="blacklist">
+            <property name="label" translatable="yes">Blacklist</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="halign">start</property>
+            <property name="valign">center</property>
+            <property name="image">blacklist_icon</property>
+            <property name="always_show_image">True</property>
+          </object>
+          <packing>
+            <property name="left_attach">2</property>
             <property name="top_attach">0</property>
           </packing>
         </child>

--- a/data/ui/blacklist_settings.glade
+++ b/data/ui/blacklist_settings.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkImage" id="image_add_blacklist_in">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -124,6 +124,19 @@
                 <property name="width">2</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_bottom">2</property>
+                <property name="label" translatable="yes">Reconnect the microphone to apply new changes made to the blacklist</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+                <property name="width">2</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="name">blacklist_in</property>
@@ -215,6 +228,19 @@
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">1</property>
+                <property name="width">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_bottom">2</property>
+                <property name="label" translatable="yes">Restart the player to apply new changes made to the blacklist</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
                 <property name="width">2</property>
               </packing>
             </child>

--- a/include/app_info_ui.hpp
+++ b/include/app_info_ui.hpp
@@ -27,6 +27,7 @@ class AppInfoUi : public Gtk::Grid {
   Gtk::Label* app_name = nullptr;
   Gtk::Scale* volume = nullptr;
   Gtk::ToggleButton* mute = nullptr;
+  Gtk::ToggleButton* blacklist = nullptr;
   Gtk::Image* mute_icon = nullptr;
   Gtk::Label* format = nullptr;
   Gtk::Label* rate = nullptr;
@@ -48,6 +49,7 @@ class AppInfoUi : public Gtk::Grid {
   sigc::connection enable_connection;
   sigc::connection volume_connection;
   sigc::connection mute_connection;
+  sigc::connection blacklist_connection;
   sigc::connection timeout_connection;
 
   PulseManager* pm = nullptr;

--- a/include/blacklist_settings_ui.hpp
+++ b/include/blacklist_settings_ui.hpp
@@ -11,6 +11,8 @@
 #include <gtkmm/scrolledwindow.h>
 #include <gtkmm/stack.h>
 
+#include "preset_type.hpp"
+
 class BlacklistSettingsUi : public Gtk::Grid {
  public:
   BlacklistSettingsUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& builder);
@@ -21,6 +23,8 @@ class BlacklistSettingsUi : public Gtk::Grid {
   ~BlacklistSettingsUi() override;
 
   static void add_to_stack(Gtk::Stack* stack);
+  static bool add_new_entry(Glib::RefPtr<Gio::Settings> settings, const std::string& name, PresetType preset_type);
+  static void remove_entry(Glib::RefPtr<Gio::Settings> settings, const std::string& name, PresetType preset_type);
 
  private:
   std::string log_tag = "blacklist_settings_ui: ";

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -1548,7 +1548,7 @@ msgstr "Applicazioni"
 
 #: src/blacklist_settings_ui.cpp:71
 msgid "Blacklist"
-msgstr "Applicazioni Escluse"
+msgstr "Blacklist"
 
 #: src/general_settings_ui.cpp:124
 msgid "General"

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -37,13 +37,13 @@ PresetsManager::PresetsManager()
       spectrum(std::make_unique<SpectrumPreset>()) {
   // system presets directories provided by Glib
   for (auto& scd : Glib::get_system_config_dirs()) {
-    system_input_dirs.push_back(scd + "/PulseEffects/input");
-    system_output_dirs.push_back(scd + "/PulseEffects/output");
+    system_input_dirs.emplace_back(scd + "/PulseEffects/input");
+    system_output_dirs.emplace_back(scd + "/PulseEffects/output");
   }
 
   // add "/etc" to system config folders array and remove duplicates
-  system_input_dirs.push_back("/etc/PulseEffects/input");
-  system_output_dirs.push_back("/etc/PulseEffects/output");
+  system_input_dirs.emplace_back("/etc/PulseEffects/input");
+  system_output_dirs.emplace_back("/etc/PulseEffects/output");
   std::sort(system_input_dirs.begin(), system_input_dirs.end());
   std::sort(system_output_dirs.begin(), system_output_dirs.end());
   system_input_dirs.erase(std::unique(system_input_dirs.begin(), system_input_dirs.end()), system_input_dirs.end());
@@ -125,7 +125,7 @@ auto PresetsManager::search_names(boost::filesystem::directory_iterator& it) -> 
     while (it != boost::filesystem::directory_iterator{}) {
       if (boost::filesystem::is_regular_file(it->status())) {
         if (it->path().extension().string() == ".json") {
-          names.push_back(it->path().stem().string());
+          names.emplace_back(it->path().stem().string());
         }
       }
 
@@ -139,7 +139,7 @@ auto PresetsManager::search_names(boost::filesystem::directory_iterator& it) -> 
 
 void PresetsManager::add(PresetType preset_type, const std::string& name) {
   for (const auto& p : get_names(preset_type)) {
-    if (p == name) {
+    if (p.compare(name) == 0) {
       return;
     }
   }
@@ -184,7 +184,7 @@ void PresetsManager::load_blacklist(PresetType preset_type, boost::property_tree
   if (preset_type == PresetType::output) {
     try {
       for (auto& p : root.get_child("input.blacklist")) {
-        blacklist.push_back(p.second.data());
+        blacklist.emplace_back(p.second.data());
       }
 
       settings->set_string_array("blacklist-in", blacklist);
@@ -194,7 +194,7 @@ void PresetsManager::load_blacklist(PresetType preset_type, boost::property_tree
   } else {
     try {
       for (auto& p : root.get_child("output.blacklist")) {
-        blacklist.push_back(p.second.data());
+        blacklist.emplace_back(p.second.data());
       }
 
       settings->set_string_array("blacklist-out", blacklist);
@@ -291,7 +291,7 @@ void PresetsManager::load(PresetType preset_type, const std::string& name) {
   bool preset_found = false;
 
   if (preset_type == PresetType::output) {
-    conf_dirs.push_back(user_output_dir);
+    conf_dirs.emplace_back(user_output_dir);
     conf_dirs.insert(conf_dirs.end(), system_output_dirs.begin(), system_output_dirs.end());
 
     for (auto& dir : conf_dirs) {
@@ -337,7 +337,7 @@ void PresetsManager::load(PresetType preset_type, const std::string& name) {
       util::debug("can't found the preset " + name + " on the filesystem");
     }
   } else {
-    conf_dirs.push_back(user_input_dir);
+    conf_dirs.emplace_back(user_input_dir);
     conf_dirs.insert(conf_dirs.end(), system_input_dirs.begin(), system_input_dirs.end());
 
     for (auto& dir : conf_dirs) {
@@ -496,7 +496,7 @@ auto PresetsManager::preset_file_exists(PresetType preset_type, const std::strin
   std::vector<boost::filesystem::path> conf_dirs;
 
   if (preset_type == PresetType::output) {
-    conf_dirs.push_back(user_output_dir);
+    conf_dirs.emplace_back(user_output_dir);
     conf_dirs.insert(conf_dirs.end(), system_output_dirs.begin(), system_output_dirs.end());
 
     for (auto& dir : conf_dirs) {
@@ -506,7 +506,7 @@ auto PresetsManager::preset_file_exists(PresetType preset_type, const std::strin
       }
     }
   } else {
-    conf_dirs.push_back(user_input_dir);
+    conf_dirs.emplace_back(user_input_dir);
     conf_dirs.insert(conf_dirs.end(), system_input_dirs.begin(), system_input_dirs.end());
 
     for (auto& dir : conf_dirs) {


### PR DESCRIPTION
Added a blacklist button as the title says. Related to #626 

Parts of code for adding/removing entries to/from blacklist are made unique as static method.

Right after blacklisting by the button, the application is removed from pipeline so pulseaudio can remember the last sink and apply it when the app is started and it's already in the blacklist.

@wwmm as you said, actions inside blacklist config ui can't be effective immediately, so my idea has been to left a message to inform the user that he/she has to restart/reconnect the player/microphone. I'd leave that ui so the user can see which apps are in the blacklist, otherwise he/she can't remember or can't remove one already added.  

Successfully compiled and tested for output stream, please @wwmm test for input one, I don't have a mic at the moment.