### PR TITLE
Modified load button, switch to emplace_back and Italian translation

### DIFF
--- a/data/ui/app_info.glade
+++ b/data/ui/app_info.glade
@@ -5,7 +5,7 @@
   <object class="GtkImage" id="blacklist_icon">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">action-unavailable</property>
+    <property name="icon_name">action-unavailable-symbolic</property>
   </object>
   <object class="GtkImage" id="mute_icon">
     <property name="visible">True</property>

--- a/data/ui/preset_row.glade
+++ b/data/ui/preset_row.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkImage" id="image_autoload">
@@ -48,7 +48,7 @@
         </child>
         <child>
           <object class="GtkButton" id="apply">
-            <property name="label" translatable="yes">Apply</property>
+            <property name="label" translatable="yes">Load</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>

--- a/include/effects_base_ui.hpp
+++ b/include/effects_base_ui.hpp
@@ -54,7 +54,7 @@ class EffectsBaseUi {
 
     auto entry = Gtk::TargetEntry("Gtk::ListBoxRow", Gtk::TARGET_SAME_APP, 0);
 
-    listTargets.push_back(entry);
+    listTargets.emplace_back(entry);
 
     eventBox->drag_source_set(listTargets, Gdk::MODIFIER_MASK, Gdk::ACTION_MOVE);
 

--- a/include/pipeline_common.hpp
+++ b/include/pipeline_common.hpp
@@ -60,7 +60,7 @@ auto check_update(gpointer user_data) -> bool {
   l->plugins_order.clear();
 
   while (g_variant_iter_next(iter, "s", &name)) {
-    l->plugins_order.push_back(name);
+    l->plugins_order.emplace_back(name);
     g_free(name);
   }
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-02 17:20+0200\n"
+"POT-Creation-Date: 2020-05-28 22:40+0200\n"
 "PO-Revision-Date: 2019-08-25 21:29+0200\n"
 "Last-Translator: Pavel Fric <pavelfric@seznam.cz>\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
@@ -127,13 +127,13 @@ msgstr ""
 
 #: data/ui/pulse_settings.glade:210 data/ui/pulse_settings.glade:301
 #: data/ui/pulse_settings.glade:500 data/ui/pulse_settings.glade:591
-#: data/ui/app_info.glade:159
+#: data/ui/app_info.glade:162
 msgid "Buffer"
 msgstr "Vyrovnávací paměť"
 
 #: data/ui/pulse_settings.glade:243 data/ui/pulse_settings.glade:334
 #: data/ui/pulse_settings.glade:513 data/ui/pulse_settings.glade:604
-#: data/ui/app_info.glade:186
+#: data/ui/app_info.glade:189
 msgid "Latency"
 msgstr "Prodleva"
 
@@ -142,24 +142,32 @@ msgstr "Prodleva"
 msgid "Pipeline Output"
 msgstr "Ekvalizér - výstup"
 
-#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:130
+#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:143
 msgid "Input Effects"
 msgstr "Vstupní efekty"
 
-#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:224
+#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:250
 msgid "Output Effects"
 msgstr "Výstupní efekty"
 
-#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:147
+#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:160
 #: data/ui/presets_menu.glade:68 data/ui/presets_menu.glade:177
 msgid "Create Preset"
 msgstr "Vytvořit přednastavení"
 
-#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:166
+#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:179
 #: data/ui/pulse_info.glade:49 data/ui/presets_menu.glade:55
 #: data/ui/presets_menu.glade:164
 msgid "Name"
 msgstr "Název"
+
+#: data/ui/blacklist_settings.glade:132
+msgid "Reconnect the microphone to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:239
+msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
 
 #: data/ui/general_settings.glade:31
 msgid "Start Service at Login"
@@ -173,8 +181,18 @@ msgstr "Zpracovat všechny výstupy"
 msgid "Use Dark Theme"
 msgstr "Použít tmavý vzhled"
 
-#: data/ui/general_settings.glade:116 data/ui/equalizer_band.glade:183
-#: data/ui/equalizer_band.glade:229
+#: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
+#: data/ui/limiter.glade:635 data/ui/compressor.glade:1104
+#: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
+#: data/ui/equalizer.glade:778 data/ui/equalizer_band.glade:183
+#: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
+#: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
+#: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
+#: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
+#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/deesser.glade:878 data/ui/convolver.glade:698
+#: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
+#: data/ui/webrtc.glade:850 data/ui/delay.glade:469
 msgid "Reset"
 msgstr "Vrátit na výchozí"
 
@@ -210,26 +228,30 @@ msgstr "Přednost"
 msgid "Audio effects for PulseAudio applications"
 msgstr "Zvukové efekty pro programy PulseAudio"
 
-#: data/ui/app_info.glade:51
+#: data/ui/app_info.glade:54
 msgid "Format"
 msgstr "Formát"
 
-#: data/ui/app_info.glade:78 data/ui/convolver.glade:257
+#: data/ui/app_info.glade:81 data/ui/convolver.glade:257
 msgid "Rate"
 msgstr "Kmitočet"
 
-#: data/ui/app_info.glade:105 data/ui/pulse_info.glade:238
+#: data/ui/app_info.glade:108 data/ui/pulse_info.glade:238
 #: data/ui/stereo_tools.glade:629
 msgid "Channels"
 msgstr "Kanály"
 
-#: data/ui/app_info.glade:132
+#: data/ui/app_info.glade:135
 msgid "Resampler"
 msgstr "Převzorkovač"
 
-#: data/ui/app_info.glade:213
+#: data/ui/app_info.glade:216
 msgid "State"
 msgstr "Stav"
+
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+msgid "Blacklist"
+msgstr "Černá listina"
 
 #: data/ui/pulse_info.glade:76
 msgid "Version"
@@ -329,7 +351,7 @@ msgstr "Váhy"
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
 #: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
@@ -348,7 +370,7 @@ msgstr "Vstup"
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:530 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
@@ -425,7 +447,7 @@ msgstr "Tlumení"
 
 #: data/ui/limiter.glade:569 data/ui/compressor.glade:1039
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
-#: data/ui/equalizer.glade:707 data/ui/reverb.glade:826
+#: data/ui/equalizer.glade:713 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
@@ -568,12 +590,12 @@ msgstr "Střední"
 msgid "Side"
 msgstr "Postranní"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr "Levý"
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr "Pravý"
@@ -862,7 +884,6 @@ msgid "Mute"
 msgstr "Ztlumit"
 
 #: data/ui/equalizer_preset_row.glade:37 data/ui/irs_row.glade:59
-#: data/ui/preset_row.glade:51
 msgid "Apply"
 msgstr "Použít"
 
@@ -1084,7 +1105,7 @@ msgstr "Useknutí"
 msgid "Feed"
 msgstr "Kanál"
 
-#: data/ui/crossfeed.glade:432
+#: data/ui/crossfeed.glade:468
 msgid "Crossfeed"
 msgstr "Prolínání kanálů"
 
@@ -1192,7 +1213,7 @@ msgstr "Doba trvání"
 msgid "Samples"
 msgstr "Vzorky"
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:281
 msgid "Impulse Response"
 msgstr "Odpověď impulsu"
 
@@ -1349,6 +1370,10 @@ msgstr "Zjišťovatel hlasu"
 #: data/ui/delay.glade:24
 msgid "Delay"
 msgstr "Zpoždění"
+
+#: data/ui/preset_row.glade:51
+msgid "Load"
+msgstr ""
 
 #: data/ui/preset_row.glade:68
 msgid "Save current settings to this preset file"
@@ -1548,10 +1573,6 @@ msgstr "Vstupní přednastavení:"
 msgid "Applications"
 msgstr "Programy"
 
-#: src/blacklist_settings_ui.cpp:71
-msgid "Blacklist"
-msgstr "Černá listina"
-
 #: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Obecné"
@@ -1560,19 +1581,19 @@ msgstr "Obecné"
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Open"
 msgstr "Otevřít"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: src/app_info_ui.cpp:86
+#: src/app_info_ui.cpp:89
 msgid "paused"
 msgstr "Pozastaveno"
 
-#: src/app_info_ui.cpp:88
+#: src/app_info_ui.cpp:91
 msgid "playing"
 msgstr "Přehrává se"
 
@@ -1580,19 +1601,19 @@ msgstr "Přehrává se"
 msgid "Calibration Microphone"
 msgstr "Kalibrace mikrofonu"
 
-#: src/convolver_ui.cpp:252
+#: src/convolver_ui.cpp:276
 msgid "Import Impulse File"
 msgstr "Zavést soubor s impulsem"
 
-#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
+#: src/convolver_ui.cpp:321 src/convolver_ui.cpp:322 src/convolver_ui.cpp:324
 msgid "Failed"
 msgstr "Nepodařilo se"
 
-#: src/convolver_ui.cpp:302
+#: src/convolver_ui.cpp:326
 msgid "Could Not Load The Impulse File"
 msgstr "Nepodařilo se nahrát soubor s impulsem"
 
-#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
+#: src/equalizer_ui.cpp:344 src/equalizer_ui.cpp:468
 msgid "infinity"
 msgstr "nekonečno"
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PulseEffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-02 17:20+0200\n"
+"POT-Creation-Date: 2020-05-28 22:40+0200\n"
 "PO-Revision-Date: 2020-01-12 17:49+0100\n"
 "Last-Translator: David Keller <blobcodes@protonmail.com>\n"
 "Language-Team: \n"
@@ -127,13 +127,13 @@ msgstr "Pipeline-Eingang"
 
 #: data/ui/pulse_settings.glade:210 data/ui/pulse_settings.glade:301
 #: data/ui/pulse_settings.glade:500 data/ui/pulse_settings.glade:591
-#: data/ui/app_info.glade:159
+#: data/ui/app_info.glade:162
 msgid "Buffer"
 msgstr "Puffer"
 
 #: data/ui/pulse_settings.glade:243 data/ui/pulse_settings.glade:334
 #: data/ui/pulse_settings.glade:513 data/ui/pulse_settings.glade:604
-#: data/ui/app_info.glade:186
+#: data/ui/app_info.glade:189
 msgid "Latency"
 msgstr "Latenz"
 
@@ -141,24 +141,32 @@ msgstr "Latenz"
 msgid "Pipeline Output"
 msgstr "Pipeline-Ausgang"
 
-#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:130
+#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:143
 msgid "Input Effects"
 msgstr "Eingangseffekte"
 
-#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:224
+#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:250
 msgid "Output Effects"
 msgstr "Ausgabeeffekte"
 
-#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:147
+#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:160
 #: data/ui/presets_menu.glade:68 data/ui/presets_menu.glade:177
 msgid "Create Preset"
 msgstr "Preset erstellen"
 
-#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:166
+#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:179
 #: data/ui/pulse_info.glade:49 data/ui/presets_menu.glade:55
 #: data/ui/presets_menu.glade:164
 msgid "Name"
 msgstr "Name"
+
+#: data/ui/blacklist_settings.glade:132
+msgid "Reconnect the microphone to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:239
+msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
 
 #: data/ui/general_settings.glade:31
 msgid "Start Service at Login"
@@ -172,8 +180,18 @@ msgstr "Alle Ausgänge verarbeiten"
 msgid "Use Dark Theme"
 msgstr "Benutze dunkles Thema"
 
-#: data/ui/general_settings.glade:116 data/ui/equalizer_band.glade:183
-#: data/ui/equalizer_band.glade:229
+#: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
+#: data/ui/limiter.glade:635 data/ui/compressor.glade:1104
+#: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
+#: data/ui/equalizer.glade:778 data/ui/equalizer_band.glade:183
+#: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
+#: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
+#: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
+#: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
+#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/deesser.glade:878 data/ui/convolver.glade:698
+#: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
+#: data/ui/webrtc.glade:850 data/ui/delay.glade:469
 msgid "Reset"
 msgstr "Zurücksetzen"
 
@@ -209,26 +227,30 @@ msgstr "Priorität"
 msgid "Audio effects for PulseAudio applications"
 msgstr "Audioeffekte für Pulseaudio-Anwendungen"
 
-#: data/ui/app_info.glade:51
+#: data/ui/app_info.glade:54
 msgid "Format"
 msgstr "Format"
 
-#: data/ui/app_info.glade:78 data/ui/convolver.glade:257
+#: data/ui/app_info.glade:81 data/ui/convolver.glade:257
 msgid "Rate"
 msgstr "Rate"
 
-#: data/ui/app_info.glade:105 data/ui/pulse_info.glade:238
+#: data/ui/app_info.glade:108 data/ui/pulse_info.glade:238
 #: data/ui/stereo_tools.glade:629
 msgid "Channels"
 msgstr "Kanäle"
 
-#: data/ui/app_info.glade:132
+#: data/ui/app_info.glade:135
 msgid "Resampler"
 msgstr "Resampler"
 
-#: data/ui/app_info.glade:213
+#: data/ui/app_info.glade:216
 msgid "State"
 msgstr "Status"
+
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+msgid "Blacklist"
+msgstr "Sperrliste"
 
 #: data/ui/pulse_info.glade:76
 msgid "Version"
@@ -325,7 +347,7 @@ msgstr "Gewichte"
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
 #: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
@@ -344,7 +366,7 @@ msgstr "Eingang"
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:530 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
@@ -421,7 +443,7 @@ msgstr "Dämpfung"
 
 #: data/ui/limiter.glade:569 data/ui/compressor.glade:1039
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
-#: data/ui/equalizer.glade:707 data/ui/reverb.glade:826
+#: data/ui/equalizer.glade:713 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
@@ -564,12 +586,12 @@ msgstr "Mitte"
 msgid "Side"
 msgstr "Seite"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr "Links"
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr "Rechts"
@@ -858,7 +880,6 @@ msgid "Mute"
 msgstr "Stummschalten"
 
 #: data/ui/equalizer_preset_row.glade:37 data/ui/irs_row.glade:59
-#: data/ui/preset_row.glade:51
 msgid "Apply"
 msgstr "Anwenden"
 
@@ -1080,7 +1101,7 @@ msgstr "Abgrenzung"
 msgid "Feed"
 msgstr "Speisung"
 
-#: data/ui/crossfeed.glade:432
+#: data/ui/crossfeed.glade:468
 msgid "Crossfeed"
 msgstr "Crossfeed"
 
@@ -1188,7 +1209,7 @@ msgstr "Dauer"
 msgid "Samples"
 msgstr "Probenahme"
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:281
 msgid "Impulse Response"
 msgstr "Impulsantwort"
 
@@ -1345,6 +1366,10 @@ msgstr "Spracherkennung"
 #: data/ui/delay.glade:24
 msgid "Delay"
 msgstr "Verzögerung"
+
+#: data/ui/preset_row.glade:51
+msgid "Load"
+msgstr ""
 
 #: data/ui/preset_row.glade:68
 msgid "Save current settings to this preset file"
@@ -1546,10 +1571,6 @@ msgstr "Eingangs-Presets: "
 msgid "Applications"
 msgstr "Anwendungen"
 
-#: src/blacklist_settings_ui.cpp:71
-msgid "Blacklist"
-msgstr "Sperrliste"
-
 #: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Allgemein"
@@ -1558,19 +1579,19 @@ msgstr "Allgemein"
 msgid "Pulseaudio"
 msgstr "PulseAudio"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Open"
 msgstr "Öffnen"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: src/app_info_ui.cpp:86
+#: src/app_info_ui.cpp:89
 msgid "paused"
 msgstr "Pausiert"
 
-#: src/app_info_ui.cpp:88
+#: src/app_info_ui.cpp:91
 msgid "playing"
 msgstr "Spielt"
 
@@ -1578,19 +1599,19 @@ msgstr "Spielt"
 msgid "Calibration Microphone"
 msgstr "Kalibrationsmikrofon"
 
-#: src/convolver_ui.cpp:252
+#: src/convolver_ui.cpp:276
 msgid "Import Impulse File"
 msgstr "Impulsdatei importieren"
 
-#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
+#: src/convolver_ui.cpp:321 src/convolver_ui.cpp:322 src/convolver_ui.cpp:324
 msgid "Failed"
 msgstr "Gescheitert"
 
-#: src/convolver_ui.cpp:302
+#: src/convolver_ui.cpp:326
 msgid "Could Not Load The Impulse File"
 msgstr "Die Impulsdatei konnte nicht geladen werden"
 
-#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
+#: src/equalizer_ui.cpp:344 src/equalizer_ui.cpp:468
 msgid "infinity"
 msgstr "Unendlich"
 

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-02 17:20+0200\n"
+"POT-Creation-Date: 2020-05-28 22:40+0200\n"
 "PO-Revision-Date: 2017-08-29 11:00+0200\n"
 "Last-Translator: Nathan Graule <solarliner@gmail.com>\n"
 "Language-Team: \n"
@@ -135,14 +135,14 @@ msgstr ""
 
 #: data/ui/pulse_settings.glade:210 data/ui/pulse_settings.glade:301
 #: data/ui/pulse_settings.glade:500 data/ui/pulse_settings.glade:591
-#: data/ui/app_info.glade:159
+#: data/ui/app_info.glade:162
 #, fuzzy
 msgid "Buffer"
 msgstr "Latence"
 
 #: data/ui/pulse_settings.glade:243 data/ui/pulse_settings.glade:334
 #: data/ui/pulse_settings.glade:513 data/ui/pulse_settings.glade:604
-#: data/ui/app_info.glade:186
+#: data/ui/app_info.glade:189
 msgid "Latency"
 msgstr "Latence"
 
@@ -151,26 +151,34 @@ msgstr "Latence"
 msgid "Pipeline Output"
 msgstr "Égaliseur - Sortie"
 
-#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:130
+#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:143
 #, fuzzy
 msgid "Input Effects"
 msgstr "PulseEffects"
 
-#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:224
+#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:250
 #, fuzzy
 msgid "Output Effects"
 msgstr "Limiteur d'entrée"
 
-#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:147
+#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:160
 #: data/ui/presets_menu.glade:68 data/ui/presets_menu.glade:177
 #, fuzzy
 msgid "Create Preset"
 msgstr "Sauvegarder préglage"
 
-#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:166
+#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:179
 #: data/ui/pulse_info.glade:49 data/ui/presets_menu.glade:55
 #: data/ui/presets_menu.glade:164
 msgid "Name"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:132
+msgid "Reconnect the microphone to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:239
+msgid "Restart the player to apply new changes made to the blacklist"
 msgstr ""
 
 #: data/ui/general_settings.glade:31
@@ -185,8 +193,18 @@ msgstr ""
 msgid "Use Dark Theme"
 msgstr "Utiliser thème sombre"
 
-#: data/ui/general_settings.glade:116 data/ui/equalizer_band.glade:183
-#: data/ui/equalizer_band.glade:229
+#: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
+#: data/ui/limiter.glade:635 data/ui/compressor.glade:1104
+#: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
+#: data/ui/equalizer.glade:778 data/ui/equalizer_band.glade:183
+#: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
+#: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
+#: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
+#: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
+#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/deesser.glade:878 data/ui/convolver.glade:698
+#: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
+#: data/ui/webrtc.glade:850 data/ui/delay.glade:469
 msgid "Reset"
 msgstr "Remettre à zéro"
 
@@ -223,25 +241,29 @@ msgstr ""
 msgid "Audio effects for PulseAudio applications"
 msgstr "Effets audio pour applications PulseAudio"
 
-#: data/ui/app_info.glade:51
+#: data/ui/app_info.glade:54
 msgid "Format"
 msgstr ""
 
-#: data/ui/app_info.glade:78 data/ui/convolver.glade:257
+#: data/ui/app_info.glade:81 data/ui/convolver.glade:257
 msgid "Rate"
 msgstr ""
 
-#: data/ui/app_info.glade:105 data/ui/pulse_info.glade:238
+#: data/ui/app_info.glade:108 data/ui/pulse_info.glade:238
 #: data/ui/stereo_tools.glade:629
 msgid "Channels"
 msgstr ""
 
-#: data/ui/app_info.glade:132
+#: data/ui/app_info.glade:135
 msgid "Resampler"
 msgstr ""
 
-#: data/ui/app_info.glade:213
+#: data/ui/app_info.glade:216
 msgid "State"
+msgstr ""
+
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+msgid "Blacklist"
 msgstr ""
 
 #: data/ui/pulse_info.glade:76
@@ -343,7 +365,7 @@ msgstr ""
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
 #: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
@@ -362,7 +384,7 @@ msgstr "Entrée"
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:530 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
@@ -444,7 +466,7 @@ msgstr "Atténuation"
 
 #: data/ui/limiter.glade:569 data/ui/compressor.glade:1039
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
-#: data/ui/equalizer.glade:707 data/ui/reverb.glade:826
+#: data/ui/equalizer.glade:713 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
@@ -598,12 +620,12 @@ msgstr "Niveau"
 msgid "Side"
 msgstr "Gain d'entrée [dB]"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr ""
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr ""
@@ -904,7 +926,6 @@ msgid "Mute"
 msgstr ""
 
 #: data/ui/equalizer_preset_row.glade:37 data/ui/irs_row.glade:59
-#: data/ui/preset_row.glade:51
 msgid "Apply"
 msgstr ""
 
@@ -1148,7 +1169,7 @@ msgstr "Coupure [Hz]"
 msgid "Feed"
 msgstr "Coudée [dB]"
 
-#: data/ui/crossfeed.glade:432
+#: data/ui/crossfeed.glade:468
 msgid "Crossfeed"
 msgstr ""
 
@@ -1263,7 +1284,7 @@ msgstr "Calibration"
 msgid "Samples"
 msgstr ""
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:281
 #, fuzzy
 msgid "Impulse Response"
 msgstr "Réponse plane"
@@ -1438,6 +1459,10 @@ msgstr "Atténuation"
 #, fuzzy
 msgid "Delay"
 msgstr "Relâche [ms]"
+
+#: data/ui/preset_row.glade:51
+msgid "Load"
+msgstr ""
 
 #: data/ui/preset_row.glade:68
 msgid "Save current settings to this preset file"
@@ -1645,10 +1670,6 @@ msgstr "Ouvrir préréglage"
 msgid "Applications"
 msgstr "Calibration"
 
-#: src/blacklist_settings_ui.cpp:71
-msgid "Blacklist"
-msgstr ""
-
 #: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Général"
@@ -1657,20 +1678,20 @@ msgstr "Général"
 msgid "Pulseaudio"
 msgstr ""
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Open"
 msgstr ""
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 #, fuzzy
 msgid "Cancel"
 msgstr "Amélioration audio"
 
-#: src/app_info_ui.cpp:86
+#: src/app_info_ui.cpp:89
 msgid "paused"
 msgstr ""
 
-#: src/app_info_ui.cpp:88
+#: src/app_info_ui.cpp:91
 msgid "playing"
 msgstr ""
 
@@ -1679,20 +1700,20 @@ msgstr ""
 msgid "Calibration Microphone"
 msgstr "Calibration de la correction microphone"
 
-#: src/convolver_ui.cpp:252
+#: src/convolver_ui.cpp:276
 #, fuzzy
 msgid "Import Impulse File"
 msgstr "Réponse plane"
 
-#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
+#: src/convolver_ui.cpp:321 src/convolver_ui.cpp:322 src/convolver_ui.cpp:324
 msgid "Failed"
 msgstr ""
 
-#: src/convolver_ui.cpp:302
+#: src/convolver_ui.cpp:326
 msgid "Could Not Load The Impulse File"
 msgstr ""
 
-#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
+#: src/equalizer_ui.cpp:344 src/equalizer_ui.cpp:468
 msgid "infinity"
 msgstr ""
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PulseEffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-02 17:20+0200\n"
+"POT-Creation-Date: 2020-05-28 22:40+0200\n"
 "PO-Revision-Date: 2018-11-22 20:12+0200\n"
 "Last-Translator: flipwise <tyx027@gmail.com>\n"
 "Language-Team: Croatian\n"
@@ -137,13 +137,13 @@ msgstr ""
 
 #: data/ui/pulse_settings.glade:210 data/ui/pulse_settings.glade:301
 #: data/ui/pulse_settings.glade:500 data/ui/pulse_settings.glade:591
-#: data/ui/app_info.glade:159
+#: data/ui/app_info.glade:162
 msgid "Buffer"
 msgstr "Latencija međuspremnika"
 
 #: data/ui/pulse_settings.glade:243 data/ui/pulse_settings.glade:334
 #: data/ui/pulse_settings.glade:513 data/ui/pulse_settings.glade:604
-#: data/ui/app_info.glade:186
+#: data/ui/app_info.glade:189
 msgid "Latency"
 msgstr "Latencija"
 
@@ -152,24 +152,32 @@ msgstr "Latencija"
 msgid "Pipeline Output"
 msgstr "Ekvalizator - Izlaz"
 
-#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:130
+#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:143
 msgid "Input Effects"
 msgstr "Ulazni efekti"
 
-#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:224
+#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:250
 msgid "Output Effects"
 msgstr "Izlazni efekti"
 
-#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:147
+#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:160
 #: data/ui/presets_menu.glade:68 data/ui/presets_menu.glade:177
 msgid "Create Preset"
 msgstr "Stvori predložak"
 
-#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:166
+#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:179
 #: data/ui/pulse_info.glade:49 data/ui/presets_menu.glade:55
 #: data/ui/presets_menu.glade:164
 msgid "Name"
 msgstr "Naziv"
+
+#: data/ui/blacklist_settings.glade:132
+msgid "Reconnect the microphone to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:239
+msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
 
 #: data/ui/general_settings.glade:31
 msgid "Start Service at Login"
@@ -183,8 +191,18 @@ msgstr ""
 msgid "Use Dark Theme"
 msgstr "Koristi tamnu temu"
 
-#: data/ui/general_settings.glade:116 data/ui/equalizer_band.glade:183
-#: data/ui/equalizer_band.glade:229
+#: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
+#: data/ui/limiter.glade:635 data/ui/compressor.glade:1104
+#: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
+#: data/ui/equalizer.glade:778 data/ui/equalizer_band.glade:183
+#: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
+#: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
+#: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
+#: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
+#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/deesser.glade:878 data/ui/convolver.glade:698
+#: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
+#: data/ui/webrtc.glade:850 data/ui/delay.glade:469
 msgid "Reset"
 msgstr "Vrati na tvorničke postavke"
 
@@ -222,26 +240,30 @@ msgstr ""
 msgid "Audio effects for PulseAudio applications"
 msgstr "Zvučni efekti za Pulseaudio aplikacije"
 
-#: data/ui/app_info.glade:51
+#: data/ui/app_info.glade:54
 msgid "Format"
 msgstr "Format"
 
-#: data/ui/app_info.glade:78 data/ui/convolver.glade:257
+#: data/ui/app_info.glade:81 data/ui/convolver.glade:257
 msgid "Rate"
 msgstr "Frekvencija"
 
-#: data/ui/app_info.glade:105 data/ui/pulse_info.glade:238
+#: data/ui/app_info.glade:108 data/ui/pulse_info.glade:238
 #: data/ui/stereo_tools.glade:629
 msgid "Channels"
 msgstr "Kanali"
 
-#: data/ui/app_info.glade:132
+#: data/ui/app_info.glade:135
 msgid "Resampler"
 msgstr "Promjena frekvencije"
 
-#: data/ui/app_info.glade:213
+#: data/ui/app_info.glade:216
 msgid "State"
 msgstr "Stanje"
+
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+msgid "Blacklist"
+msgstr "Crna lista"
 
 #: data/ui/pulse_info.glade:76
 msgid "Version"
@@ -348,7 +370,7 @@ msgstr "Otežanja"
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
 #: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
@@ -367,7 +389,7 @@ msgstr "Ulaz"
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:530 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
@@ -444,7 +466,7 @@ msgstr "Prigušenje"
 
 #: data/ui/limiter.glade:569 data/ui/compressor.glade:1039
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
-#: data/ui/equalizer.glade:707 data/ui/reverb.glade:826
+#: data/ui/equalizer.glade:713 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
@@ -595,12 +617,12 @@ msgstr "Srednji nivo"
 msgid "Side"
 msgstr "Strana"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr "Lijevo"
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr "Desno"
@@ -906,7 +928,6 @@ msgid "Mute"
 msgstr "Bezvučno"
 
 #: data/ui/equalizer_preset_row.glade:37 data/ui/irs_row.glade:59
-#: data/ui/preset_row.glade:51
 msgid "Apply"
 msgstr ""
 
@@ -1143,7 +1164,7 @@ msgstr "Prekid"
 msgid "Feed"
 msgstr "Dovod zvuka"
 
-#: data/ui/crossfeed.glade:432
+#: data/ui/crossfeed.glade:468
 msgid "Crossfeed"
 msgstr "Križno spajanje"
 
@@ -1260,7 +1281,7 @@ msgstr "Trajanje"
 msgid "Samples"
 msgstr "Semplovi"
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:281
 #, fuzzy
 msgid "Impulse Response"
 msgstr "Reakcija impulsa"
@@ -1425,6 +1446,10 @@ msgstr "Detektor glasa"
 #: data/ui/delay.glade:24
 msgid "Delay"
 msgstr "Kašnjenje"
+
+#: data/ui/preset_row.glade:51
+msgid "Load"
+msgstr ""
 
 #: data/ui/preset_row.glade:68
 #, fuzzy
@@ -1629,10 +1654,6 @@ msgstr "Učitaj predloške"
 msgid "Applications"
 msgstr "Aplikacije"
 
-#: src/blacklist_settings_ui.cpp:71
-msgid "Blacklist"
-msgstr "Crna lista"
-
 #: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Općenito"
@@ -1641,19 +1662,19 @@ msgstr "Općenito"
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Open"
 msgstr "Otvori"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Cancel"
 msgstr "Poništi"
 
-#: src/app_info_ui.cpp:86
+#: src/app_info_ui.cpp:89
 msgid "paused"
 msgstr "pauzirano"
 
-#: src/app_info_ui.cpp:88
+#: src/app_info_ui.cpp:91
 msgid "playing"
 msgstr "reprodukcija"
 
@@ -1662,20 +1683,20 @@ msgstr "reprodukcija"
 msgid "Calibration Microphone"
 msgstr "Kalibracija mikrofona"
 
-#: src/convolver_ui.cpp:252
+#: src/convolver_ui.cpp:276
 #, fuzzy
 msgid "Import Impulse File"
 msgstr "Učitaj impuls datoteku"
 
-#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
+#: src/convolver_ui.cpp:321 src/convolver_ui.cpp:322 src/convolver_ui.cpp:324
 msgid "Failed"
 msgstr "Nije uspjelo"
 
-#: src/convolver_ui.cpp:302
+#: src/convolver_ui.cpp:326
 msgid "Could Not Load The Impulse File"
 msgstr "Nije bilo moguće učitati impuls datoteku"
 
-#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
+#: src/equalizer_ui.cpp:344 src/equalizer_ui.cpp:468
 msgid "infinity"
 msgstr ""
 

--- a/po/id_ID.po
+++ b/po/id_ID.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pulseeffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-02 17:20+0200\n"
+"POT-Creation-Date: 2020-05-28 22:40+0200\n"
 "PO-Revision-Date: 2019-01-17 18:30+0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -131,13 +131,13 @@ msgstr ""
 
 #: data/ui/pulse_settings.glade:210 data/ui/pulse_settings.glade:301
 #: data/ui/pulse_settings.glade:500 data/ui/pulse_settings.glade:591
-#: data/ui/app_info.glade:159
+#: data/ui/app_info.glade:162
 msgid "Buffer"
 msgstr "Ukuran Penyangga"
 
 #: data/ui/pulse_settings.glade:243 data/ui/pulse_settings.glade:334
 #: data/ui/pulse_settings.glade:513 data/ui/pulse_settings.glade:604
-#: data/ui/app_info.glade:186
+#: data/ui/app_info.glade:189
 msgid "Latency"
 msgstr "Besar Latensi"
 
@@ -145,24 +145,32 @@ msgstr "Besar Latensi"
 msgid "Pipeline Output"
 msgstr ""
 
-#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:130
+#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:143
 msgid "Input Effects"
 msgstr "Efek Input"
 
-#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:224
+#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:250
 msgid "Output Effects"
 msgstr "Efek Luaran"
 
-#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:147
+#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:160
 #: data/ui/presets_menu.glade:68 data/ui/presets_menu.glade:177
 msgid "Create Preset"
 msgstr "Buat Preset"
 
-#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:166
+#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:179
 #: data/ui/pulse_info.glade:49 data/ui/presets_menu.glade:55
 #: data/ui/presets_menu.glade:164
 msgid "Name"
 msgstr "Nama"
+
+#: data/ui/blacklist_settings.glade:132
+msgid "Reconnect the microphone to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:239
+msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
 
 #: data/ui/general_settings.glade:31
 msgid "Start Service at Login"
@@ -176,8 +184,18 @@ msgstr "Proses Semua Output"
 msgid "Use Dark Theme"
 msgstr "Gunakan Tema Gelap"
 
-#: data/ui/general_settings.glade:116 data/ui/equalizer_band.glade:183
-#: data/ui/equalizer_band.glade:229
+#: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
+#: data/ui/limiter.glade:635 data/ui/compressor.glade:1104
+#: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
+#: data/ui/equalizer.glade:778 data/ui/equalizer_band.glade:183
+#: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
+#: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
+#: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
+#: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
+#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/deesser.glade:878 data/ui/convolver.glade:698
+#: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
+#: data/ui/webrtc.glade:850 data/ui/delay.glade:469
 msgid "Reset"
 msgstr "Atur Ulang"
 
@@ -213,26 +231,30 @@ msgstr "Atur Prioritas"
 msgid "Audio effects for PulseAudio applications"
 msgstr "Terapkan Efek Suara via PulseAudio"
 
-#: data/ui/app_info.glade:51
+#: data/ui/app_info.glade:54
 msgid "Format"
 msgstr "Format Resampling"
 
-#: data/ui/app_info.glade:78 data/ui/convolver.glade:257
+#: data/ui/app_info.glade:81 data/ui/convolver.glade:257
 msgid "Rate"
 msgstr "Rataan Frekuensi"
 
-#: data/ui/app_info.glade:105 data/ui/pulse_info.glade:238
+#: data/ui/app_info.glade:108 data/ui/pulse_info.glade:238
 #: data/ui/stereo_tools.glade:629
 msgid "Channels"
 msgstr "Total Kanal"
 
-#: data/ui/app_info.glade:132
+#: data/ui/app_info.glade:135
 msgid "Resampler"
 msgstr "Modus Penyampling"
 
-#: data/ui/app_info.glade:213
+#: data/ui/app_info.glade:216
 msgid "State"
 msgstr "Status"
+
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+msgid "Blacklist"
+msgstr "Daftar Blokir"
 
 #: data/ui/pulse_info.glade:76
 msgid "Version"
@@ -337,7 +359,7 @@ msgstr "Tinggi"
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
 #: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
@@ -356,7 +378,7 @@ msgstr "Masukan"
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:530 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
@@ -433,7 +455,7 @@ msgstr "Atenuasi"
 
 #: data/ui/limiter.glade:569 data/ui/compressor.glade:1039
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
-#: data/ui/equalizer.glade:707 data/ui/reverb.glade:826
+#: data/ui/equalizer.glade:713 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
@@ -581,12 +603,12 @@ msgstr "Volume Kanal Tengah"
 msgid "Side"
 msgstr "Volume Kanal Sisi"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr "Kiri"
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr "Kanan"
@@ -877,7 +899,6 @@ msgid "Mute"
 msgstr "Bungkam"
 
 #: data/ui/equalizer_preset_row.glade:37 data/ui/irs_row.glade:59
-#: data/ui/preset_row.glade:51
 msgid "Apply"
 msgstr "Terapkan"
 
@@ -1099,7 +1120,7 @@ msgstr "Frekuensi Potong"
 msgid "Feed"
 msgstr "Volume Penyuapan"
 
-#: data/ui/crossfeed.glade:432
+#: data/ui/crossfeed.glade:468
 msgid "Crossfeed"
 msgstr "Crossfeed"
 
@@ -1207,7 +1228,7 @@ msgstr "Durasi"
 msgid "Samples"
 msgstr "Jumlah Sampel"
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:281
 msgid "Impulse Response"
 msgstr "Respons Impuls"
 
@@ -1367,6 +1388,10 @@ msgstr "Pelacak Vokal"
 #, fuzzy
 msgid "Delay"
 msgstr "Penundaan"
+
+#: data/ui/preset_row.glade:51
+msgid "Load"
+msgstr ""
 
 #: data/ui/preset_row.glade:68
 msgid "Save current settings to this preset file"
@@ -1565,10 +1590,6 @@ msgstr "Preset Input"
 msgid "Applications"
 msgstr "Aplikasi"
 
-#: src/blacklist_settings_ui.cpp:71
-msgid "Blacklist"
-msgstr "Daftar Blokir"
-
 #: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Umum"
@@ -1577,19 +1598,19 @@ msgstr "Umum"
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Open"
 msgstr "Buka"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Cancel"
 msgstr "Batal"
 
-#: src/app_info_ui.cpp:86
+#: src/app_info_ui.cpp:89
 msgid "paused"
 msgstr "terjeda"
 
-#: src/app_info_ui.cpp:88
+#: src/app_info_ui.cpp:91
 msgid "playing"
 msgstr "memutar"
 
@@ -1597,19 +1618,19 @@ msgstr "memutar"
 msgid "Calibration Microphone"
 msgstr "Kalibrasikan Mikrofon"
 
-#: src/convolver_ui.cpp:252
+#: src/convolver_ui.cpp:276
 msgid "Import Impulse File"
 msgstr "Muat Berkas Impuls"
 
-#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
+#: src/convolver_ui.cpp:321 src/convolver_ui.cpp:322 src/convolver_ui.cpp:324
 msgid "Failed"
 msgstr "Gagal"
 
-#: src/convolver_ui.cpp:302
+#: src/convolver_ui.cpp:326
 msgid "Could Not Load The Impulse File"
 msgstr "Tidak dapat Memuat Berkas Impuls"
 
-#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
+#: src/equalizer_ui.cpp:344 src/equalizer_ui.cpp:468
 msgid "infinity"
 msgstr "Tak Terbatas"
 

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-02 17:20+0200\n"
+"POT-Creation-Date: 2020-05-28 22:40+0200\n"
 "PO-Revision-Date: 2019-03-28 17:38+0100\n"
 "Last-Translator: Gianluca Boiano <morf3089@gmail.com>\n"
 "Language-Team: \n"
@@ -129,13 +129,13 @@ msgstr "Pipeline di Ingresso"
 
 #: data/ui/pulse_settings.glade:210 data/ui/pulse_settings.glade:301
 #: data/ui/pulse_settings.glade:500 data/ui/pulse_settings.glade:591
-#: data/ui/app_info.glade:159
+#: data/ui/app_info.glade:162
 msgid "Buffer"
 msgstr "Buffer"
 
 #: data/ui/pulse_settings.glade:243 data/ui/pulse_settings.glade:334
 #: data/ui/pulse_settings.glade:513 data/ui/pulse_settings.glade:604
-#: data/ui/app_info.glade:186
+#: data/ui/app_info.glade:189
 msgid "Latency"
 msgstr "Latenza"
 
@@ -143,24 +143,34 @@ msgstr "Latenza"
 msgid "Pipeline Output"
 msgstr "Pipeline di Uscita"
 
-#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:130
+#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:143
 msgid "Input Effects"
 msgstr "Effetti in Ingresso"
 
-#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:224
+#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:250
 msgid "Output Effects"
 msgstr "Effetti in Uscita"
 
-#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:147
+#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:160
 #: data/ui/presets_menu.glade:68 data/ui/presets_menu.glade:177
 msgid "Create Preset"
 msgstr "Crea Profilo"
 
-#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:166
+#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:179
 #: data/ui/pulse_info.glade:49 data/ui/presets_menu.glade:55
 #: data/ui/presets_menu.glade:164
 msgid "Name"
 msgstr "Nome"
+
+#: data/ui/blacklist_settings.glade:132
+msgid "Reconnect the microphone to apply new changes made to the blacklist"
+msgstr ""
+"Riconnetti il microfono per applicare le modifiche apportate alla blacklist"
+
+#: data/ui/blacklist_settings.glade:239
+msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
+"Riavvia il media player per applicare le modifiche apportate alla blacklist"
 
 #: data/ui/general_settings.glade:31
 msgid "Start Service at Login"
@@ -174,8 +184,18 @@ msgstr "Elabora Ogni Uscita"
 msgid "Use Dark Theme"
 msgstr "Usa Tema Scuro"
 
-#: data/ui/general_settings.glade:116 data/ui/equalizer_band.glade:183
-#: data/ui/equalizer_band.glade:229
+#: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
+#: data/ui/limiter.glade:635 data/ui/compressor.glade:1104
+#: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
+#: data/ui/equalizer.glade:778 data/ui/equalizer_band.glade:183
+#: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
+#: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
+#: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
+#: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
+#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/deesser.glade:878 data/ui/convolver.glade:698
+#: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
+#: data/ui/webrtc.glade:850 data/ui/delay.glade:469
 msgid "Reset"
 msgstr "Reset"
 
@@ -211,26 +231,30 @@ msgstr "Valore Priorità"
 msgid "Audio effects for PulseAudio applications"
 msgstr "Effetti audio per applicazioni PulseAudio"
 
-#: data/ui/app_info.glade:51
+#: data/ui/app_info.glade:54
 msgid "Format"
 msgstr "Formato"
 
-#: data/ui/app_info.glade:78 data/ui/convolver.glade:257
+#: data/ui/app_info.glade:81 data/ui/convolver.glade:257
 msgid "Rate"
 msgstr "Frequenza"
 
-#: data/ui/app_info.glade:105 data/ui/pulse_info.glade:238
+#: data/ui/app_info.glade:108 data/ui/pulse_info.glade:238
 #: data/ui/stereo_tools.glade:629
 msgid "Channels"
 msgstr "Canali"
 
-#: data/ui/app_info.glade:132
+#: data/ui/app_info.glade:135
 msgid "Resampler"
 msgstr "Ricampionamento"
 
-#: data/ui/app_info.glade:213
+#: data/ui/app_info.glade:216
 msgid "State"
 msgstr "Stato"
+
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+msgid "Blacklist"
+msgstr "Blacklist"
 
 #: data/ui/pulse_info.glade:76
 msgid "Version"
@@ -327,7 +351,7 @@ msgstr "Ampiezze"
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
 #: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
@@ -346,7 +370,7 @@ msgstr "Ingresso"
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:530 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
@@ -423,7 +447,7 @@ msgstr "Attenuazione"
 
 #: data/ui/limiter.glade:569 data/ui/compressor.glade:1039
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
-#: data/ui/equalizer.glade:707 data/ui/reverb.glade:826
+#: data/ui/equalizer.glade:713 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
@@ -566,12 +590,12 @@ msgstr "Intermedia"
 msgid "Side"
 msgstr "Laterale"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr "Canale Sinistro"
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr "Canale Destro"
@@ -860,7 +884,6 @@ msgid "Mute"
 msgstr "Muto"
 
 #: data/ui/equalizer_preset_row.glade:37 data/ui/irs_row.glade:59
-#: data/ui/preset_row.glade:51
 msgid "Apply"
 msgstr "Applica"
 
@@ -1082,7 +1105,7 @@ msgstr "Taglio"
 msgid "Feed"
 msgstr "Feed"
 
-#: data/ui/crossfeed.glade:432
+#: data/ui/crossfeed.glade:468
 msgid "Crossfeed"
 msgstr "Crossfeed"
 
@@ -1190,7 +1213,7 @@ msgstr "Durata"
 msgid "Samples"
 msgstr "Campioni"
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:281
 msgid "Impulse Response"
 msgstr "Risposta all'Impulso"
 
@@ -1347,6 +1370,10 @@ msgstr "Rilevatore Voce"
 #: data/ui/delay.glade:24
 msgid "Delay"
 msgstr "Ritardo"
+
+#: data/ui/preset_row.glade:51
+msgid "Load"
+msgstr "Carica"
 
 #: data/ui/preset_row.glade:68
 msgid "Save current settings to this preset file"
@@ -1546,10 +1573,6 @@ msgstr "Profili Ingresso: "
 msgid "Applications"
 msgstr "Applicazioni"
 
-#: src/blacklist_settings_ui.cpp:71
-msgid "Blacklist"
-msgstr "Blacklist"
-
 #: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Generale"
@@ -1558,19 +1581,19 @@ msgstr "Generale"
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Open"
 msgstr "Apri"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Cancel"
 msgstr "Annulla"
 
-#: src/app_info_ui.cpp:86
+#: src/app_info_ui.cpp:89
 msgid "paused"
 msgstr "pausa"
 
-#: src/app_info_ui.cpp:88
+#: src/app_info_ui.cpp:91
 msgid "playing"
 msgstr "riproduzione"
 
@@ -1578,19 +1601,19 @@ msgstr "riproduzione"
 msgid "Calibration Microphone"
 msgstr "Calibrazione Microfono"
 
-#: src/convolver_ui.cpp:252
+#: src/convolver_ui.cpp:276
 msgid "Import Impulse File"
 msgstr "Importa File Impulso"
 
-#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
+#: src/convolver_ui.cpp:321 src/convolver_ui.cpp:322 src/convolver_ui.cpp:324
 msgid "Failed"
 msgstr "Fallito"
 
-#: src/convolver_ui.cpp:302
+#: src/convolver_ui.cpp:326
 msgid "Could Not Load The Impulse File"
 msgstr "Impossibile Caricare File Impulso"
 
-#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
+#: src/equalizer_ui.cpp:344 src/equalizer_ui.cpp:468
 msgid "infinity"
 msgstr "infinito"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PulseEffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-02 17:20+0200\n"
+"POT-Creation-Date: 2020-05-28 22:40+0200\n"
 "PO-Revision-Date: 2018-06-21 21:34+0200\n"
 "Last-Translator: Piotr Komur, pkomur@gmail.com\n"
 "Language-Team: \n"
@@ -133,13 +133,13 @@ msgstr ""
 
 #: data/ui/pulse_settings.glade:210 data/ui/pulse_settings.glade:301
 #: data/ui/pulse_settings.glade:500 data/ui/pulse_settings.glade:591
-#: data/ui/app_info.glade:159
+#: data/ui/app_info.glade:162
 msgid "Buffer"
 msgstr "Bufor"
 
 #: data/ui/pulse_settings.glade:243 data/ui/pulse_settings.glade:334
 #: data/ui/pulse_settings.glade:513 data/ui/pulse_settings.glade:604
-#: data/ui/app_info.glade:186
+#: data/ui/app_info.glade:189
 msgid "Latency"
 msgstr "Oczekiwanie"
 
@@ -147,24 +147,32 @@ msgstr "Oczekiwanie"
 msgid "Pipeline Output"
 msgstr ""
 
-#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:130
+#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:143
 msgid "Input Effects"
 msgstr "Efekty wejściowe"
 
-#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:224
+#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:250
 msgid "Output Effects"
 msgstr "Efekty wyjściowe"
 
-#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:147
+#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:160
 #: data/ui/presets_menu.glade:68 data/ui/presets_menu.glade:177
 msgid "Create Preset"
 msgstr "Utwórz profil"
 
-#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:166
+#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:179
 #: data/ui/pulse_info.glade:49 data/ui/presets_menu.glade:55
 #: data/ui/presets_menu.glade:164
 msgid "Name"
 msgstr "Nazwa"
+
+#: data/ui/blacklist_settings.glade:132
+msgid "Reconnect the microphone to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:239
+msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
 
 #: data/ui/general_settings.glade:31
 msgid "Start Service at Login"
@@ -178,8 +186,18 @@ msgstr ""
 msgid "Use Dark Theme"
 msgstr "Używaj ciemnego motywu"
 
-#: data/ui/general_settings.glade:116 data/ui/equalizer_band.glade:183
-#: data/ui/equalizer_band.glade:229
+#: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
+#: data/ui/limiter.glade:635 data/ui/compressor.glade:1104
+#: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
+#: data/ui/equalizer.glade:778 data/ui/equalizer_band.glade:183
+#: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
+#: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
+#: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
+#: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
+#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/deesser.glade:878 data/ui/convolver.glade:698
+#: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
+#: data/ui/webrtc.glade:850 data/ui/delay.glade:469
 msgid "Reset"
 msgstr "Zresetuj"
 
@@ -217,27 +235,31 @@ msgstr ""
 msgid "Audio effects for PulseAudio applications"
 msgstr "Efekty dźwiękowe dla programu Pulseaudio"
 
-#: data/ui/app_info.glade:51
+#: data/ui/app_info.glade:54
 msgid "Format"
 msgstr "Format"
 
 # Próbkowanie?
-#: data/ui/app_info.glade:78 data/ui/convolver.glade:257
+#: data/ui/app_info.glade:81 data/ui/convolver.glade:257
 msgid "Rate"
 msgstr "Częstotliwość"
 
-#: data/ui/app_info.glade:105 data/ui/pulse_info.glade:238
+#: data/ui/app_info.glade:108 data/ui/pulse_info.glade:238
 #: data/ui/stereo_tools.glade:629
 msgid "Channels"
 msgstr "Kanały"
 
-#: data/ui/app_info.glade:132
+#: data/ui/app_info.glade:135
 msgid "Resampler"
 msgstr "Resampler"
 
-#: data/ui/app_info.glade:213
+#: data/ui/app_info.glade:216
 msgid "State"
 msgstr "Stan"
+
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+msgid "Blacklist"
+msgstr ""
 
 #: data/ui/pulse_info.glade:76
 msgid "Version"
@@ -344,7 +366,7 @@ msgstr "Wysokość"
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
 #: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
@@ -363,7 +385,7 @@ msgstr "Wejście"
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:530 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
@@ -442,7 +464,7 @@ msgstr "Tłumienie"
 
 #: data/ui/limiter.glade:569 data/ui/compressor.glade:1039
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
-#: data/ui/equalizer.glade:707 data/ui/reverb.glade:826
+#: data/ui/equalizer.glade:713 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
@@ -594,12 +616,12 @@ msgstr "Środek"
 msgid "Side"
 msgstr "Strona"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr "Lewy"
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr "Prawy"
@@ -900,7 +922,6 @@ msgid "Mute"
 msgstr "Wycisz"
 
 #: data/ui/equalizer_preset_row.glade:37 data/ui/irs_row.glade:59
-#: data/ui/preset_row.glade:51
 msgid "Apply"
 msgstr ""
 
@@ -1134,7 +1155,7 @@ msgstr "Odcięcie"
 msgid "Feed"
 msgstr "Feed"
 
-#: data/ui/crossfeed.glade:432
+#: data/ui/crossfeed.glade:468
 msgid "Crossfeed"
 msgstr "Crossfeed"
 
@@ -1245,7 +1266,7 @@ msgstr "Kalibracja"
 msgid "Samples"
 msgstr "Resampler"
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:281
 #, fuzzy
 msgid "Impulse Response"
 msgstr "Płaska odpowiedź"
@@ -1407,6 +1428,10 @@ msgstr "Wykrywanie głosu"
 #, fuzzy
 msgid "Delay"
 msgstr "Przedopóźnienie"
+
+#: data/ui/preset_row.glade:51
+msgid "Load"
+msgstr ""
 
 #: data/ui/preset_row.glade:68
 msgid "Save current settings to this preset file"
@@ -1611,10 +1636,6 @@ msgstr "Importuj profile"
 msgid "Applications"
 msgstr "Programy"
 
-#: src/blacklist_settings_ui.cpp:71
-msgid "Blacklist"
-msgstr ""
-
 #: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Ogólne"
@@ -1623,20 +1644,20 @@ msgstr "Ogólne"
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Open"
 msgstr ""
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 #, fuzzy
 msgid "Cancel"
 msgstr "Balans"
 
-#: src/app_info_ui.cpp:86
+#: src/app_info_ui.cpp:89
 msgid "paused"
 msgstr "zatrzymany"
 
-#: src/app_info_ui.cpp:88
+#: src/app_info_ui.cpp:91
 msgid "playing"
 msgstr "gra"
 
@@ -1644,19 +1665,19 @@ msgstr "gra"
 msgid "Calibration Microphone"
 msgstr "Kalibracja mikrofonu"
 
-#: src/convolver_ui.cpp:252
+#: src/convolver_ui.cpp:276
 msgid "Import Impulse File"
 msgstr ""
 
-#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
+#: src/convolver_ui.cpp:321 src/convolver_ui.cpp:322 src/convolver_ui.cpp:324
 msgid "Failed"
 msgstr ""
 
-#: src/convolver_ui.cpp:302
+#: src/convolver_ui.cpp:326
 msgid "Could Not Load The Impulse File"
 msgstr ""
 
-#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
+#: src/equalizer_ui.cpp:344 src/equalizer_ui.cpp:468
 msgid "infinity"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PulseEffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-02 17:20+0200\n"
+"POT-Creation-Date: 2020-05-28 22:40+0200\n"
 "PO-Revision-Date: 2019-09-10 12:56-0300\n"
 "Last-Translator: Patrik Nilsson <translation_AT_hembas.se>\n"
 "Language-Team: Portuguese <>\n"
@@ -130,13 +130,13 @@ msgstr "Entrada da Pipeline"
 
 #: data/ui/pulse_settings.glade:210 data/ui/pulse_settings.glade:301
 #: data/ui/pulse_settings.glade:500 data/ui/pulse_settings.glade:591
-#: data/ui/app_info.glade:159
+#: data/ui/app_info.glade:162
 msgid "Buffer"
 msgstr "Buffer"
 
 #: data/ui/pulse_settings.glade:243 data/ui/pulse_settings.glade:334
 #: data/ui/pulse_settings.glade:513 data/ui/pulse_settings.glade:604
-#: data/ui/app_info.glade:186
+#: data/ui/app_info.glade:189
 msgid "Latency"
 msgstr "Latência"
 
@@ -144,24 +144,32 @@ msgstr "Latência"
 msgid "Pipeline Output"
 msgstr "Saída da Pipeline"
 
-#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:130
+#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:143
 msgid "Input Effects"
 msgstr "Efeitos de Entrada"
 
-#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:224
+#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:250
 msgid "Output Effects"
 msgstr "Efeitos de Saída"
 
-#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:147
+#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:160
 #: data/ui/presets_menu.glade:68 data/ui/presets_menu.glade:177
 msgid "Create Preset"
 msgstr "Criar Predefinição"
 
-#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:166
+#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:179
 #: data/ui/pulse_info.glade:49 data/ui/presets_menu.glade:55
 #: data/ui/presets_menu.glade:164
 msgid "Name"
 msgstr "Nome"
+
+#: data/ui/blacklist_settings.glade:132
+msgid "Reconnect the microphone to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:239
+msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
 
 #: data/ui/general_settings.glade:31
 msgid "Start Service at Login"
@@ -175,8 +183,18 @@ msgstr "Processar Todas as Saídas"
 msgid "Use Dark Theme"
 msgstr "Usar Tema Escuro"
 
-#: data/ui/general_settings.glade:116 data/ui/equalizer_band.glade:183
-#: data/ui/equalizer_band.glade:229
+#: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
+#: data/ui/limiter.glade:635 data/ui/compressor.glade:1104
+#: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
+#: data/ui/equalizer.glade:778 data/ui/equalizer_band.glade:183
+#: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
+#: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
+#: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
+#: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
+#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/deesser.glade:878 data/ui/convolver.glade:698
+#: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
+#: data/ui/webrtc.glade:850 data/ui/delay.glade:469
 msgid "Reset"
 msgstr "Resetar"
 
@@ -212,26 +230,30 @@ msgstr "Prioridade"
 msgid "Audio effects for PulseAudio applications"
 msgstr "Efeitos de áudio para programas que Utilizam Pulseaudio"
 
-#: data/ui/app_info.glade:51
+#: data/ui/app_info.glade:54
 msgid "Format"
 msgstr "Formato"
 
-#: data/ui/app_info.glade:78 data/ui/convolver.glade:257
+#: data/ui/app_info.glade:81 data/ui/convolver.glade:257
 msgid "Rate"
 msgstr "Taxa"
 
-#: data/ui/app_info.glade:105 data/ui/pulse_info.glade:238
+#: data/ui/app_info.glade:108 data/ui/pulse_info.glade:238
 #: data/ui/stereo_tools.glade:629
 msgid "Channels"
 msgstr "Canais"
 
-#: data/ui/app_info.glade:132
+#: data/ui/app_info.glade:135
 msgid "Resampler"
 msgstr "Resampler"
 
-#: data/ui/app_info.glade:213
+#: data/ui/app_info.glade:216
 msgid "State"
 msgstr "Estado"
+
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+msgid "Blacklist"
+msgstr "Lista Negra"
 
 #: data/ui/pulse_info.glade:76
 msgid "Version"
@@ -329,7 +351,7 @@ msgstr "Pesos"
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
 #: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
@@ -348,7 +370,7 @@ msgstr "Entrada"
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:530 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
@@ -425,7 +447,7 @@ msgstr "Atenuação"
 
 #: data/ui/limiter.glade:569 data/ui/compressor.glade:1039
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
-#: data/ui/equalizer.glade:707 data/ui/reverb.glade:826
+#: data/ui/equalizer.glade:713 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
@@ -568,12 +590,12 @@ msgstr "Meio"
 msgid "Side"
 msgstr "Lado"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr "Esquerda"
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr "Direita"
@@ -862,7 +884,6 @@ msgid "Mute"
 msgstr "Mudo"
 
 #: data/ui/equalizer_preset_row.glade:37 data/ui/irs_row.glade:59
-#: data/ui/preset_row.glade:51
 msgid "Apply"
 msgstr "Aplicar"
 
@@ -1084,7 +1105,7 @@ msgstr "Corte"
 msgid "Feed"
 msgstr "Alimentação"
 
-#: data/ui/crossfeed.glade:432
+#: data/ui/crossfeed.glade:468
 msgid "Crossfeed"
 msgstr "Crossfeed"
 
@@ -1192,7 +1213,7 @@ msgstr "Duração"
 msgid "Samples"
 msgstr "Amostras"
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:281
 msgid "Impulse Response"
 msgstr "Resposta de Impulso"
 
@@ -1349,6 +1370,10 @@ msgstr "Detector de Voz"
 #: data/ui/delay.glade:24
 msgid "Delay"
 msgstr "Atraso"
+
+#: data/ui/preset_row.glade:51
+msgid "Load"
+msgstr ""
 
 #: data/ui/preset_row.glade:68
 msgid "Save current settings to this preset file"
@@ -1550,10 +1575,6 @@ msgstr "Predefinições de Entrada: "
 msgid "Applications"
 msgstr "Aplicativos"
 
-#: src/blacklist_settings_ui.cpp:71
-msgid "Blacklist"
-msgstr "Lista Negra"
-
 #: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Geral"
@@ -1562,19 +1583,19 @@ msgstr "Geral"
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Open"
 msgstr "Abrir"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/app_info_ui.cpp:86
+#: src/app_info_ui.cpp:89
 msgid "paused"
 msgstr "pausado"
 
-#: src/app_info_ui.cpp:88
+#: src/app_info_ui.cpp:91
 msgid "playing"
 msgstr "tocando"
 
@@ -1582,19 +1603,19 @@ msgstr "tocando"
 msgid "Calibration Microphone"
 msgstr "Microfone de Calibração"
 
-#: src/convolver_ui.cpp:252
+#: src/convolver_ui.cpp:276
 msgid "Import Impulse File"
 msgstr "Importar Arquivo com a Resposta de Impulso"
 
-#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
+#: src/convolver_ui.cpp:321 src/convolver_ui.cpp:322 src/convolver_ui.cpp:324
 msgid "Failed"
 msgstr "Falhou"
 
-#: src/convolver_ui.cpp:302
+#: src/convolver_ui.cpp:326
 msgid "Could Not Load The Impulse File"
 msgstr "Não Foi Possível Carregar o Arquivo com o Impulso"
 
-#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
+#: src/equalizer_ui.cpp:344 src/equalizer_ui.cpp:468
 msgid "infinity"
 msgstr "infinito"
 

--- a/po/pulseeffects.pot
+++ b/po/pulseeffects.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pulseeffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-02 17:20+0200\n"
+"POT-Creation-Date: 2020-05-28 22:40+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -126,13 +126,13 @@ msgstr ""
 
 #: data/ui/pulse_settings.glade:210 data/ui/pulse_settings.glade:301
 #: data/ui/pulse_settings.glade:500 data/ui/pulse_settings.glade:591
-#: data/ui/app_info.glade:159
+#: data/ui/app_info.glade:162
 msgid "Buffer"
 msgstr ""
 
 #: data/ui/pulse_settings.glade:243 data/ui/pulse_settings.glade:334
 #: data/ui/pulse_settings.glade:513 data/ui/pulse_settings.glade:604
-#: data/ui/app_info.glade:186
+#: data/ui/app_info.glade:189
 msgid "Latency"
 msgstr ""
 
@@ -140,23 +140,31 @@ msgstr ""
 msgid "Pipeline Output"
 msgstr ""
 
-#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:130
+#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:143
 msgid "Input Effects"
 msgstr ""
 
-#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:224
+#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:250
 msgid "Output Effects"
 msgstr ""
 
-#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:147
+#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:160
 #: data/ui/presets_menu.glade:68 data/ui/presets_menu.glade:177
 msgid "Create Preset"
 msgstr ""
 
-#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:166
+#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:179
 #: data/ui/pulse_info.glade:49 data/ui/presets_menu.glade:55
 #: data/ui/presets_menu.glade:164
 msgid "Name"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:132
+msgid "Reconnect the microphone to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:239
+msgid "Restart the player to apply new changes made to the blacklist"
 msgstr ""
 
 #: data/ui/general_settings.glade:31
@@ -171,8 +179,18 @@ msgstr ""
 msgid "Use Dark Theme"
 msgstr ""
 
-#: data/ui/general_settings.glade:116 data/ui/equalizer_band.glade:183
-#: data/ui/equalizer_band.glade:229
+#: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
+#: data/ui/limiter.glade:635 data/ui/compressor.glade:1104
+#: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
+#: data/ui/equalizer.glade:778 data/ui/equalizer_band.glade:183
+#: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
+#: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
+#: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
+#: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
+#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/deesser.glade:878 data/ui/convolver.glade:698
+#: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
+#: data/ui/webrtc.glade:850 data/ui/delay.glade:469
 msgid "Reset"
 msgstr ""
 
@@ -208,25 +226,29 @@ msgstr ""
 msgid "Audio effects for PulseAudio applications"
 msgstr ""
 
-#: data/ui/app_info.glade:51
+#: data/ui/app_info.glade:54
 msgid "Format"
 msgstr ""
 
-#: data/ui/app_info.glade:78 data/ui/convolver.glade:257
+#: data/ui/app_info.glade:81 data/ui/convolver.glade:257
 msgid "Rate"
 msgstr ""
 
-#: data/ui/app_info.glade:105 data/ui/pulse_info.glade:238
+#: data/ui/app_info.glade:108 data/ui/pulse_info.glade:238
 #: data/ui/stereo_tools.glade:629
 msgid "Channels"
 msgstr ""
 
-#: data/ui/app_info.glade:132
+#: data/ui/app_info.glade:135
 msgid "Resampler"
 msgstr ""
 
-#: data/ui/app_info.glade:213
+#: data/ui/app_info.glade:216
 msgid "State"
+msgstr ""
+
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+msgid "Blacklist"
 msgstr ""
 
 #: data/ui/pulse_info.glade:76
@@ -324,7 +346,7 @@ msgstr ""
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
 #: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
@@ -343,7 +365,7 @@ msgstr ""
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:530 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
@@ -420,7 +442,7 @@ msgstr ""
 
 #: data/ui/limiter.glade:569 data/ui/compressor.glade:1039
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
-#: data/ui/equalizer.glade:707 data/ui/reverb.glade:826
+#: data/ui/equalizer.glade:713 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
@@ -563,12 +585,12 @@ msgstr ""
 msgid "Side"
 msgstr ""
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr ""
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr ""
@@ -857,7 +879,6 @@ msgid "Mute"
 msgstr ""
 
 #: data/ui/equalizer_preset_row.glade:37 data/ui/irs_row.glade:59
-#: data/ui/preset_row.glade:51
 msgid "Apply"
 msgstr ""
 
@@ -1079,7 +1100,7 @@ msgstr ""
 msgid "Feed"
 msgstr ""
 
-#: data/ui/crossfeed.glade:432
+#: data/ui/crossfeed.glade:468
 msgid "Crossfeed"
 msgstr ""
 
@@ -1187,7 +1208,7 @@ msgstr ""
 msgid "Samples"
 msgstr ""
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:281
 msgid "Impulse Response"
 msgstr ""
 
@@ -1342,6 +1363,10 @@ msgstr ""
 
 #: data/ui/delay.glade:24
 msgid "Delay"
+msgstr ""
+
+#: data/ui/preset_row.glade:51
+msgid "Load"
 msgstr ""
 
 #: data/ui/preset_row.glade:68
@@ -1528,10 +1553,6 @@ msgstr ""
 msgid "Applications"
 msgstr ""
 
-#: src/blacklist_settings_ui.cpp:71
-msgid "Blacklist"
-msgstr ""
-
 #: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr ""
@@ -1540,19 +1561,19 @@ msgstr ""
 msgid "Pulseaudio"
 msgstr ""
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Open"
 msgstr ""
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Cancel"
 msgstr ""
 
-#: src/app_info_ui.cpp:86
+#: src/app_info_ui.cpp:89
 msgid "paused"
 msgstr ""
 
-#: src/app_info_ui.cpp:88
+#: src/app_info_ui.cpp:91
 msgid "playing"
 msgstr ""
 
@@ -1560,18 +1581,18 @@ msgstr ""
 msgid "Calibration Microphone"
 msgstr ""
 
-#: src/convolver_ui.cpp:252
+#: src/convolver_ui.cpp:276
 msgid "Import Impulse File"
 msgstr ""
 
-#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
+#: src/convolver_ui.cpp:321 src/convolver_ui.cpp:322 src/convolver_ui.cpp:324
 msgid "Failed"
 msgstr ""
 
-#: src/convolver_ui.cpp:302
+#: src/convolver_ui.cpp:326
 msgid "Could Not Load The Impulse File"
 msgstr ""
 
-#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
+#: src/equalizer_ui.cpp:344 src/equalizer_ui.cpp:468
 msgid "infinity"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-02 17:20+0200\n"
+"POT-Creation-Date: 2020-05-28 22:40+0200\n"
 "PO-Revision-Date: 2018-07-18 22:14+0300\n"
 "Last-Translator: Mikhail Novosyolov <mikhailnov@dumalogiya.ru>\n"
 "Language-Team: \n"
@@ -130,13 +130,13 @@ msgstr ""
 
 #: data/ui/pulse_settings.glade:210 data/ui/pulse_settings.glade:301
 #: data/ui/pulse_settings.glade:500 data/ui/pulse_settings.glade:591
-#: data/ui/app_info.glade:159
+#: data/ui/app_info.glade:162
 msgid "Buffer"
 msgstr "Буфер"
 
 #: data/ui/pulse_settings.glade:243 data/ui/pulse_settings.glade:334
 #: data/ui/pulse_settings.glade:513 data/ui/pulse_settings.glade:604
-#: data/ui/app_info.glade:186
+#: data/ui/app_info.glade:189
 msgid "Latency"
 msgstr "Задержка"
 
@@ -145,24 +145,32 @@ msgstr "Задержка"
 msgid "Pipeline Output"
 msgstr "Эквалайзер - Выход"
 
-#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:130
+#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:143
 msgid "Input Effects"
 msgstr "Эффекты для ввода звука"
 
-#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:224
+#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:250
 msgid "Output Effects"
 msgstr "Эффекты для вывода звука"
 
-#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:147
+#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:160
 #: data/ui/presets_menu.glade:68 data/ui/presets_menu.glade:177
 msgid "Create Preset"
 msgstr "Создать новый набор предустановок"
 
-#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:166
+#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:179
 #: data/ui/pulse_info.glade:49 data/ui/presets_menu.glade:55
 #: data/ui/presets_menu.glade:164
 msgid "Name"
 msgstr "Название"
+
+#: data/ui/blacklist_settings.glade:132
+msgid "Reconnect the microphone to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:239
+msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
 
 #: data/ui/general_settings.glade:31
 msgid "Start Service at Login"
@@ -176,8 +184,18 @@ msgstr "Вкл. для всех выводов"
 msgid "Use Dark Theme"
 msgstr "Исп. тёмную тему"
 
-#: data/ui/general_settings.glade:116 data/ui/equalizer_band.glade:183
-#: data/ui/equalizer_band.glade:229
+#: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
+#: data/ui/limiter.glade:635 data/ui/compressor.glade:1104
+#: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
+#: data/ui/equalizer.glade:778 data/ui/equalizer_band.glade:183
+#: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
+#: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
+#: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
+#: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
+#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/deesser.glade:878 data/ui/convolver.glade:698
+#: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
+#: data/ui/webrtc.glade:850 data/ui/delay.glade:469
 msgid "Reset"
 msgstr "Сбросить"
 
@@ -213,26 +231,30 @@ msgstr "Приоритет"
 msgid "Audio effects for PulseAudio applications"
 msgstr "Аудиоэффекты для приложений PulseAudio"
 
-#: data/ui/app_info.glade:51
+#: data/ui/app_info.glade:54
 msgid "Format"
 msgstr "Формат"
 
-#: data/ui/app_info.glade:78 data/ui/convolver.glade:257
+#: data/ui/app_info.glade:81 data/ui/convolver.glade:257
 msgid "Rate"
 msgstr "Частота"
 
-#: data/ui/app_info.glade:105 data/ui/pulse_info.glade:238
+#: data/ui/app_info.glade:108 data/ui/pulse_info.glade:238
 #: data/ui/stereo_tools.glade:629
 msgid "Channels"
 msgstr "Каналы"
 
-#: data/ui/app_info.glade:132
+#: data/ui/app_info.glade:135
 msgid "Resampler"
 msgstr "Ресемплер"
 
-#: data/ui/app_info.glade:213
+#: data/ui/app_info.glade:216
 msgid "State"
 msgstr "Состояние"
+
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+msgid "Blacklist"
+msgstr "Черный список"
 
 #: data/ui/pulse_info.glade:76
 msgid "Version"
@@ -346,7 +368,7 @@ msgstr "Вес в расчете громкости"
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
 #: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
@@ -365,7 +387,7 @@ msgstr "Вход"
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:530 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
@@ -443,7 +465,7 @@ msgstr "Затухание"
 
 #: data/ui/limiter.glade:569 data/ui/compressor.glade:1039
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
-#: data/ui/equalizer.glade:707 data/ui/reverb.glade:826
+#: data/ui/equalizer.glade:713 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
@@ -587,12 +609,12 @@ msgstr "Средний"
 msgid "Side"
 msgstr "Усиление ввода [дБ]"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr "Левый"
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr "Правый"
@@ -884,7 +906,6 @@ msgid "Mute"
 msgstr "Приглушить"
 
 #: data/ui/equalizer_preset_row.glade:37 data/ui/irs_row.glade:59
-#: data/ui/preset_row.glade:51
 msgid "Apply"
 msgstr "Применить"
 
@@ -1110,7 +1131,7 @@ msgstr "Усечение"
 msgid "Feed"
 msgstr "Подача"
 
-#: data/ui/crossfeed.glade:432
+#: data/ui/crossfeed.glade:468
 msgid "Crossfeed"
 msgstr "Перекрестная подача"
 
@@ -1221,7 +1242,7 @@ msgstr "Продолжительность"
 msgid "Samples"
 msgstr "Образцы"
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:281
 msgid "Impulse Response"
 msgstr "Импульсная реакция"
 
@@ -1380,6 +1401,10 @@ msgstr "Обнаруживатель голоса"
 #: data/ui/delay.glade:24
 msgid "Delay"
 msgstr "Задержка"
+
+#: data/ui/preset_row.glade:51
+msgid "Load"
+msgstr ""
 
 #: data/ui/preset_row.glade:68
 msgid "Save current settings to this preset file"
@@ -1581,10 +1606,6 @@ msgstr "Входные предустановки: "
 msgid "Applications"
 msgstr "Приложения"
 
-#: src/blacklist_settings_ui.cpp:71
-msgid "Blacklist"
-msgstr "Черный список"
-
 #: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Общие"
@@ -1593,19 +1614,19 @@ msgstr "Общие"
 msgid "Pulseaudio"
 msgstr ""
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Open"
 msgstr "Открыть"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Cancel"
 msgstr "Отмена"
 
-#: src/app_info_ui.cpp:86
+#: src/app_info_ui.cpp:89
 msgid "paused"
 msgstr "на паузе"
 
-#: src/app_info_ui.cpp:88
+#: src/app_info_ui.cpp:91
 msgid "playing"
 msgstr "воспроизводится"
 
@@ -1613,19 +1634,19 @@ msgstr "воспроизводится"
 msgid "Calibration Microphone"
 msgstr "Калибровка корректировки микрофона"
 
-#: src/convolver_ui.cpp:252
+#: src/convolver_ui.cpp:276
 msgid "Import Impulse File"
 msgstr "Импортировать импульс"
 
-#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
+#: src/convolver_ui.cpp:321 src/convolver_ui.cpp:322 src/convolver_ui.cpp:324
 msgid "Failed"
 msgstr "Не получилось"
 
-#: src/convolver_ui.cpp:302
+#: src/convolver_ui.cpp:326
 msgid "Could Not Load The Impulse File"
 msgstr "Не смогли загрузить файл с импульсными реакциями"
 
-#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
+#: src/equalizer_ui.cpp:344 src/equalizer_ui.cpp:468
 msgid "infinity"
 msgstr ""
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-02 17:20+0200\n"
+"POT-Creation-Date: 2020-05-28 22:40+0200\n"
 "PO-Revision-Date: 2019-09-07 22:19+0200\n"
 "Last-Translator: Mlocik97\n"
 "Language-Team: \n"
@@ -135,13 +135,13 @@ msgstr ""
 
 #: data/ui/pulse_settings.glade:210 data/ui/pulse_settings.glade:301
 #: data/ui/pulse_settings.glade:500 data/ui/pulse_settings.glade:591
-#: data/ui/app_info.glade:159
+#: data/ui/app_info.glade:162
 msgid "Buffer"
 msgstr "Vyrovnávacia Pamäť"
 
 #: data/ui/pulse_settings.glade:243 data/ui/pulse_settings.glade:334
 #: data/ui/pulse_settings.glade:513 data/ui/pulse_settings.glade:604
-#: data/ui/app_info.glade:186
+#: data/ui/app_info.glade:189
 msgid "Latency"
 msgstr "Odozva"
 
@@ -149,27 +149,35 @@ msgstr "Odozva"
 msgid "Pipeline Output"
 msgstr ""
 
-#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:130
+#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:143
 #, fuzzy
 msgid "Input Effects"
 msgstr "Vstupné Efekty"
 
-#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:224
+#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:250
 #, fuzzy
 msgid "Output Effects"
 msgstr "Výstupné Efekty"
 
-#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:147
+#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:160
 #: data/ui/presets_menu.glade:68 data/ui/presets_menu.glade:177
 #, fuzzy
 msgid "Create Preset"
 msgstr "Vytvoriť Predvoľbu"
 
-#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:166
+#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:179
 #: data/ui/pulse_info.glade:49 data/ui/presets_menu.glade:55
 #: data/ui/presets_menu.glade:164
 msgid "Name"
 msgstr "Názov"
+
+#: data/ui/blacklist_settings.glade:132
+msgid "Reconnect the microphone to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:239
+msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
 
 #: data/ui/general_settings.glade:31
 msgid "Start Service at Login"
@@ -183,8 +191,18 @@ msgstr "Spracovať Všetky Výstupy"
 msgid "Use Dark Theme"
 msgstr "Použiť Tmavú Tému"
 
-#: data/ui/general_settings.glade:116 data/ui/equalizer_band.glade:183
-#: data/ui/equalizer_band.glade:229
+#: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
+#: data/ui/limiter.glade:635 data/ui/compressor.glade:1104
+#: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
+#: data/ui/equalizer.glade:778 data/ui/equalizer_band.glade:183
+#: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
+#: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
+#: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
+#: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
+#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/deesser.glade:878 data/ui/convolver.glade:698
+#: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
+#: data/ui/webrtc.glade:850 data/ui/delay.glade:469
 #, fuzzy
 msgid "Reset"
 msgstr "Vrátit na Predvolené"
@@ -222,26 +240,30 @@ msgstr "Priorita"
 msgid "Audio effects for PulseAudio applications"
 msgstr "Zvukové efekty pre programy Pulseaudio"
 
-#: data/ui/app_info.glade:51
+#: data/ui/app_info.glade:54
 msgid "Format"
 msgstr "Formát"
 
-#: data/ui/app_info.glade:78 data/ui/convolver.glade:257
+#: data/ui/app_info.glade:81 data/ui/convolver.glade:257
 msgid "Rate"
 msgstr ""
 
-#: data/ui/app_info.glade:105 data/ui/pulse_info.glade:238
+#: data/ui/app_info.glade:108 data/ui/pulse_info.glade:238
 #: data/ui/stereo_tools.glade:629
 msgid "Channels"
 msgstr "Kanály"
 
-#: data/ui/app_info.glade:132
+#: data/ui/app_info.glade:135
 msgid "Resampler"
 msgstr "Prevzorkovač"
 
-#: data/ui/app_info.glade:213
+#: data/ui/app_info.glade:216
 msgid "State"
 msgstr "Stav"
+
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+msgid "Blacklist"
+msgstr "Čierny List"
 
 #: data/ui/pulse_info.glade:76
 msgid "Version"
@@ -345,7 +367,7 @@ msgstr "Váhy"
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
 #: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
@@ -364,7 +386,7 @@ msgstr "Vstup"
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:530 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
@@ -446,7 +468,7 @@ msgstr "Zoslabenie"
 
 #: data/ui/limiter.glade:569 data/ui/compressor.glade:1039
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
-#: data/ui/equalizer.glade:707 data/ui/reverb.glade:826
+#: data/ui/equalizer.glade:713 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
@@ -599,12 +621,12 @@ msgstr "Stredný"
 msgid "Side"
 msgstr "Postranný"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr "Ľavý"
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr "Pravý"
@@ -903,7 +925,6 @@ msgid "Mute"
 msgstr "Stíšený"
 
 #: data/ui/equalizer_preset_row.glade:37 data/ui/irs_row.glade:59
-#: data/ui/preset_row.glade:51
 msgid "Apply"
 msgstr "Použiť"
 
@@ -1138,7 +1159,7 @@ msgstr "Zrezanie [Hz]"
 msgid "Feed"
 msgstr "Koleno [dB]"
 
-#: data/ui/crossfeed.glade:432
+#: data/ui/crossfeed.glade:468
 msgid "Crossfeed"
 msgstr ""
 
@@ -1252,7 +1273,7 @@ msgstr "Zoslabenie"
 msgid "Samples"
 msgstr "Vzorky"
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:281
 msgid "Impulse Response"
 msgstr ""
 
@@ -1422,6 +1443,10 @@ msgstr "Zoslabenie"
 #, fuzzy
 msgid "Delay"
 msgstr "Uvoľnenie [ms]"
+
+#: data/ui/preset_row.glade:51
+msgid "Load"
+msgstr ""
 
 #: data/ui/preset_row.glade:68
 msgid "Save current settings to this preset file"
@@ -1613,10 +1638,6 @@ msgstr "Načítať predvoľbu"
 msgid "Applications"
 msgstr "Aplikácie"
 
-#: src/blacklist_settings_ui.cpp:71
-msgid "Blacklist"
-msgstr "Čierny List"
-
 #: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Všeobecné"
@@ -1625,19 +1646,19 @@ msgstr "Všeobecné"
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Open"
 msgstr "Otvoriť"
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: src/app_info_ui.cpp:86
+#: src/app_info_ui.cpp:89
 msgid "paused"
 msgstr "pozastavené"
 
-#: src/app_info_ui.cpp:88
+#: src/app_info_ui.cpp:91
 msgid "playing"
 msgstr "hrá"
 
@@ -1645,20 +1666,20 @@ msgstr "hrá"
 msgid "Calibration Microphone"
 msgstr "Kalibrovať Mikrofón"
 
-#: src/convolver_ui.cpp:252
+#: src/convolver_ui.cpp:276
 #, fuzzy
 msgid "Import Impulse File"
 msgstr "Načítať predvoľbu"
 
-#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
+#: src/convolver_ui.cpp:321 src/convolver_ui.cpp:322 src/convolver_ui.cpp:324
 msgid "Failed"
 msgstr "Zlyhalo"
 
-#: src/convolver_ui.cpp:302
+#: src/convolver_ui.cpp:326
 msgid "Could Not Load The Impulse File"
 msgstr "Nie Je Možné Načítať Impulse súbor"
 
-#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
+#: src/equalizer_ui.cpp:344 src/equalizer_ui.cpp:468
 msgid "infinity"
 msgstr "Nekonečno"
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-02 17:20+0200\n"
+"POT-Creation-Date: 2020-05-28 22:40+0200\n"
 "PO-Revision-Date: 2017-10-14 10:20+0200\n"
 "Last-Translator: Patrik Nilsson <translation_AT_hembas.se>\n"
 "Language-Team: \n"
@@ -133,14 +133,14 @@ msgstr ""
 
 #: data/ui/pulse_settings.glade:210 data/ui/pulse_settings.glade:301
 #: data/ui/pulse_settings.glade:500 data/ui/pulse_settings.glade:591
-#: data/ui/app_info.glade:159
+#: data/ui/app_info.glade:162
 #, fuzzy
 msgid "Buffer"
 msgstr "Latens"
 
 #: data/ui/pulse_settings.glade:243 data/ui/pulse_settings.glade:334
 #: data/ui/pulse_settings.glade:513 data/ui/pulse_settings.glade:604
-#: data/ui/app_info.glade:186
+#: data/ui/app_info.glade:189
 msgid "Latency"
 msgstr "Latens"
 
@@ -149,27 +149,35 @@ msgstr "Latens"
 msgid "Pipeline Output"
 msgstr "Ljudutjämnare - Utgång"
 
-#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:130
+#: data/ui/pulse_settings.glade:370 data/ui/blacklist_settings.glade:143
 #, fuzzy
 msgid "Input Effects"
 msgstr "PulseEffects"
 
-#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:224
+#: data/ui/pulse_settings.glade:660 data/ui/blacklist_settings.glade:250
 #, fuzzy
 msgid "Output Effects"
 msgstr "Ingångs-begränsning"
 
-#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:147
+#: data/ui/blacklist_settings.glade:53 data/ui/blacklist_settings.glade:160
 #: data/ui/presets_menu.glade:68 data/ui/presets_menu.glade:177
 #, fuzzy
 msgid "Create Preset"
 msgstr "Ta bort profil"
 
-#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:166
+#: data/ui/blacklist_settings.glade:72 data/ui/blacklist_settings.glade:179
 #: data/ui/pulse_info.glade:49 data/ui/presets_menu.glade:55
 #: data/ui/presets_menu.glade:164
 msgid "Name"
 msgstr "Namn"
+
+#: data/ui/blacklist_settings.glade:132
+msgid "Reconnect the microphone to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:239
+msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
 
 #: data/ui/general_settings.glade:31
 msgid "Start Service at Login"
@@ -183,8 +191,18 @@ msgstr ""
 msgid "Use Dark Theme"
 msgstr "Använd mörkt tema"
 
-#: data/ui/general_settings.glade:116 data/ui/equalizer_band.glade:183
-#: data/ui/equalizer_band.glade:229
+#: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
+#: data/ui/limiter.glade:635 data/ui/compressor.glade:1104
+#: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
+#: data/ui/equalizer.glade:778 data/ui/equalizer_band.glade:183
+#: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
+#: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
+#: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
+#: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
+#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/deesser.glade:878 data/ui/convolver.glade:698
+#: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
+#: data/ui/webrtc.glade:850 data/ui/delay.glade:469
 msgid "Reset"
 msgstr "Återställ"
 
@@ -221,25 +239,29 @@ msgstr ""
 msgid "Audio effects for PulseAudio applications"
 msgstr "Ljudeffekter för PulseAudio applikationer"
 
-#: data/ui/app_info.glade:51
+#: data/ui/app_info.glade:54
 msgid "Format"
 msgstr "Format"
 
-#: data/ui/app_info.glade:78 data/ui/convolver.glade:257
+#: data/ui/app_info.glade:81 data/ui/convolver.glade:257
 msgid "Rate"
 msgstr "Takt"
 
-#: data/ui/app_info.glade:105 data/ui/pulse_info.glade:238
+#: data/ui/app_info.glade:108 data/ui/pulse_info.glade:238
 #: data/ui/stereo_tools.glade:629
 msgid "Channels"
 msgstr "Kanaler"
 
-#: data/ui/app_info.glade:132
+#: data/ui/app_info.glade:135
 msgid "Resampler"
 msgstr "Resampler"
 
-#: data/ui/app_info.glade:213
+#: data/ui/app_info.glade:216
 msgid "State"
+msgstr ""
+
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+msgid "Blacklist"
 msgstr ""
 
 #: data/ui/pulse_info.glade:76
@@ -344,7 +366,7 @@ msgstr ""
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
 #: data/ui/limiter.glade:365 data/ui/compressor.glade:717
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
-#: data/ui/equalizer.glade:510 data/ui/reverb.glade:630
+#: data/ui/equalizer.glade:516 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
@@ -363,7 +385,7 @@ msgstr "Ingång"
 #: data/ui/multiband_compressor.glade:1508
 #: data/ui/multiband_compressor.glade:1886
 #: data/ui/multiband_compressor.glade:1973 data/ui/filter.glade:383
-#: data/ui/equalizer.glade:524 data/ui/reverb.glade:645
+#: data/ui/equalizer.glade:530 data/ui/reverb.glade:645
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
@@ -445,7 +467,7 @@ msgstr "Försvagning"
 
 #: data/ui/limiter.glade:569 data/ui/compressor.glade:1039
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
-#: data/ui/equalizer.glade:707 data/ui/reverb.glade:826
+#: data/ui/equalizer.glade:713 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
@@ -599,12 +621,12 @@ msgstr "Nivå"
 msgid "Side"
 msgstr "Ingångsförstärkning (dB)"
 
-#: data/ui/compressor.glade:645 data/ui/equalizer.glade:442
+#: data/ui/compressor.glade:645 data/ui/equalizer.glade:448
 #: data/ui/stereo_tools.glade:524 data/ui/delay.glade:131
 msgid "Left"
 msgstr ""
 
-#: data/ui/compressor.glade:646 data/ui/equalizer.glade:483
+#: data/ui/compressor.glade:646 data/ui/equalizer.glade:489
 #: data/ui/stereo_tools.glade:596 data/ui/delay.glade:163
 msgid "Right"
 msgstr ""
@@ -906,7 +928,6 @@ msgid "Mute"
 msgstr ""
 
 #: data/ui/equalizer_preset_row.glade:37 data/ui/irs_row.glade:59
-#: data/ui/preset_row.glade:51
 msgid "Apply"
 msgstr ""
 
@@ -1150,7 +1171,7 @@ msgstr "Cut-off (Hz)"
 msgid "Feed"
 msgstr "Knee-värde (dB)"
 
-#: data/ui/crossfeed.glade:432
+#: data/ui/crossfeed.glade:468
 msgid "Crossfeed"
 msgstr ""
 
@@ -1267,7 +1288,7 @@ msgstr "Kalibrering"
 msgid "Samples"
 msgstr "Resampler"
 
-#: data/ui/convolver.glade:342 src/convolver_ui.cpp:257
+#: data/ui/convolver.glade:342 src/convolver_ui.cpp:281
 #, fuzzy
 msgid "Impulse Response"
 msgstr "Platt respons"
@@ -1441,6 +1462,10 @@ msgstr "Försvagning"
 #, fuzzy
 msgid "Delay"
 msgstr "Release (ms)"
+
+#: data/ui/preset_row.glade:51
+msgid "Load"
+msgstr ""
 
 #: data/ui/preset_row.glade:68
 #, fuzzy
@@ -1649,10 +1674,6 @@ msgstr "Öppna förinställning"
 msgid "Applications"
 msgstr "Program"
 
-#: src/blacklist_settings_ui.cpp:71
-msgid "Blacklist"
-msgstr ""
-
 #: src/general_settings_ui.cpp:124
 msgid "General"
 msgstr "Allmänt"
@@ -1661,20 +1682,20 @@ msgstr "Allmänt"
 msgid "Pulseaudio"
 msgstr ""
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 msgid "Open"
 msgstr ""
 
-#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:253
+#: src/presets_menu_ui.cpp:111 src/convolver_ui.cpp:277
 #, fuzzy
 msgid "Cancel"
 msgstr "Ljudförstärkare"
 
-#: src/app_info_ui.cpp:86
+#: src/app_info_ui.cpp:89
 msgid "paused"
 msgstr ""
 
-#: src/app_info_ui.cpp:88
+#: src/app_info_ui.cpp:91
 msgid "playing"
 msgstr ""
 
@@ -1683,20 +1704,20 @@ msgstr ""
 msgid "Calibration Microphone"
 msgstr "Kalibrering och mikrofon korrigering"
 
-#: src/convolver_ui.cpp:252
+#: src/convolver_ui.cpp:276
 #, fuzzy
 msgid "Import Impulse File"
 msgstr "Platt respons"
 
-#: src/convolver_ui.cpp:297 src/convolver_ui.cpp:298 src/convolver_ui.cpp:300
+#: src/convolver_ui.cpp:321 src/convolver_ui.cpp:322 src/convolver_ui.cpp:324
 msgid "Failed"
 msgstr ""
 
-#: src/convolver_ui.cpp:302
+#: src/convolver_ui.cpp:326
 msgid "Could Not Load The Impulse File"
 msgstr ""
 
-#: src/equalizer_ui.cpp:341 src/equalizer_ui.cpp:465
+#: src/equalizer_ui.cpp:344 src/equalizer_ui.cpp:468
 msgid "infinity"
 msgstr ""
 

--- a/src/app_info_ui.cpp
+++ b/src/app_info_ui.cpp
@@ -105,6 +105,7 @@ void AppInfoUi::connect_signals() {
     if (blacklist->get_active()) {
       // Add new entry to blacklist vector
       BlacklistSettingsUi::add_new_entry(Gio::Settings::create("com.github.wwmm.pulseeffects"), app_info->name, preset_type);
+      enable->set_sensitive(false);
 
       if (preset_type == PresetType::output) {
         pm->remove_sink_input_from_pulseeffects(app_info->name, app_info->index);
@@ -116,6 +117,7 @@ void AppInfoUi::connect_signals() {
     } else {
       // Remove app name entry from blacklist vector
       BlacklistSettingsUi::remove_entry(Gio::Settings::create("com.github.wwmm.pulseeffects"), app_info->name, preset_type);
+      enable->set_sensitive(true);
 
       if (preset_type == PresetType::output) {
         pm->move_sink_input_to_pulseeffects(app_info->name, app_info->index);

--- a/src/application_ui.cpp
+++ b/src/application_ui.cpp
@@ -74,7 +74,7 @@ ApplicationUi::ApplicationUi(BaseObjectType* cobject,
 
   presets_menu_label->set_text(settings->get_string("last-used-preset"));
 
-  connections.push_back(settings->signal_changed("last-used-preset").connect([=](auto key) {
+  connections.emplace_back(settings->signal_changed("last-used-preset").connect([=](auto key) {
     presets_menu_label->set_text(settings->get_string("last-used-preset"));
   }));
 

--- a/src/blacklist_settings_ui.cpp
+++ b/src/blacklist_settings_ui.cpp
@@ -34,10 +34,10 @@ BlacklistSettingsUi::BlacklistSettingsUi(BaseObjectType* cobject, const Glib::Re
     }
   });
 
-  connections.push_back(
+  connections.emplace_back(
       settings->signal_changed("blacklist-in").connect([&](auto key) { populate_blacklist_in_listbox(); }));
 
-  connections.push_back(
+  connections.emplace_back(
       settings->signal_changed("blacklist-out").connect([&](auto key) { populate_blacklist_out_listbox(); }));
 
   populate_blacklist_in_listbox();
@@ -118,7 +118,7 @@ void BlacklistSettingsUi::populate_blacklist_in_listbox() {
     row->set_name(name);
     label->set_text(name);
 
-    connections.push_back(remove_btn->signal_clicked().connect([=]() {
+    connections.emplace_back(remove_btn->signal_clicked().connect([=]() {
       remove_entry(settings, name, PresetType::input);
 
       populate_blacklist_in_listbox();
@@ -152,7 +152,7 @@ void BlacklistSettingsUi::populate_blacklist_out_listbox() {
     row->set_name(name);
     label->set_text(name);
 
-    connections.push_back(remove_btn->signal_clicked().connect([=]() {
+    connections.emplace_back(remove_btn->signal_clicked().connect([=]() {
       remove_entry(settings, name, PresetType::output);
 
       populate_blacklist_out_listbox();

--- a/src/calibration_mic.cpp
+++ b/src/calibration_mic.cpp
@@ -118,7 +118,7 @@ CalibrationMic::CalibrationMic() {
     }
 
     if (f > min_spectrum_freq) {
-      spectrum_freqs.push_back(f);
+      spectrum_freqs.emplace_back(f);
     }
   }
 

--- a/src/calibration_signals.cpp
+++ b/src/calibration_signals.cpp
@@ -105,7 +105,7 @@ CalibrationSignals::CalibrationSignals() {
     }
 
     if (f > min_spectrum_freq) {
-      spectrum_freqs.push_back(f);
+      spectrum_freqs.emplace_back(f);
     }
   }
 

--- a/src/convolver/gstpeconvolver.cpp
+++ b/src/convolver/gstpeconvolver.cpp
@@ -246,7 +246,7 @@ static GstFlowReturn gst_peconvolver_transform_ip(GstBaseTransform* trans, GstBu
 
     auto future = std::async(std::launch::async, f);
 
-    peconvolver->futures.push_back(std::move(future));
+    peconvolver->futures.emplace_back(std::move(future));
   }
 
   return GST_FLOW_OK;

--- a/src/convolver_ui.cpp
+++ b/src/convolver_ui.cpp
@@ -102,13 +102,13 @@ ConvolverUi::ConvolverUi(BaseObjectType* cobject,
 
   auto future = std::async(std::launch::async, f);
 
-  futures.push_back(std::move(future));
+  futures.emplace_back(std::move(future));
 
   /* this is necessary to update the interface with the irs info when a preset
      is loaded
   */
 
-  connections.push_back(settings->signal_changed("kernel-path").connect([=](auto key) {
+  connections.emplace_back(settings->signal_changed("kernel-path").connect([=](auto key) {
     auto f = [=]() {
       std::lock_guard<std::mutex> lock(lock_guard_irs_info);
       get_irs_info();
@@ -116,7 +116,7 @@ ConvolverUi::ConvolverUi(BaseObjectType* cobject,
 
     auto future = std::async(std::launch::async, f);
 
-    futures.push_back(std::move(future));
+    futures.emplace_back(std::move(future));
   }));
 }
 
@@ -153,7 +153,7 @@ auto ConvolverUi::get_irs_names() -> std::vector<std::string> {
   while (it != boost::filesystem::directory_iterator{}) {
     if (boost::filesystem::is_regular_file(it->status())) {
       if (it->path().extension().string() == ".irs") {
-        names.push_back(it->path().stem().string());
+        names.emplace_back(it->path().stem().string());
       }
     }
 
@@ -242,12 +242,12 @@ void ConvolverUi::populate_irs_listbox() {
     row->set_name(name);
     label->set_text(name);
 
-    connections.push_back(remove_btn->signal_clicked().connect([=]() {
+    connections.emplace_back(remove_btn->signal_clicked().connect([=]() {
       remove_irs_file(name);
       populate_irs_listbox();
     }));
 
-    connections.push_back(apply_btn->signal_clicked().connect([=]() {
+    connections.emplace_back(apply_btn->signal_clicked().connect([=]() {
       auto irs_file = irs_dir / boost::filesystem::path{row->get_name() + ".irs"};
 
       settings->set_string("kernel-path", irs_file.string());
@@ -360,9 +360,9 @@ void ConvolverUi::get_irs_info() {
 
   // ensure that the fft can be computed
   if (left_mag.size() % 2 != 0)
-    left_mag.push_back(0);
+    left_mag.emplace_back(0);
   if (right_mag.size() % 2 != 0)
-    right_mag.push_back(0);
+    right_mag.emplace_back(0);
 
   left_mag.shrink_to_fit();
   right_mag.shrink_to_fit();

--- a/src/crystalizer_ui.cpp
+++ b/src/crystalizer_ui.cpp
@@ -94,7 +94,7 @@ void CrystalizerUi::build_bands(const int& nbands) {
 
     auto band_intensity = Glib::RefPtr<Gtk::Adjustment>::cast_dynamic(B->get_object("band_intensity"));
 
-    connections.push_back(band_mute->signal_toggled().connect([=]() {
+    connections.emplace_back(band_mute->signal_toggled().connect([=]() {
       if (band_mute->get_active()) {
         band_scale->set_sensitive(false);
       } else {

--- a/src/effects_base_ui.cpp
+++ b/src/effects_base_ui.cpp
@@ -36,7 +36,7 @@ EffectsBaseUi::EffectsBaseUi(const Glib::RefPtr<Gtk::Builder>& builder,
 
   listbox->set_sort_func(sigc::mem_fun(*this, &EffectsBaseUi::on_listbox_sort));
 
-  connections.push_back(settings->signal_changed("plugins").connect([=](auto key) { listbox->invalidate_sort(); }));
+  connections.emplace_back(settings->signal_changed("plugins").connect([=](auto key) { listbox->invalidate_sort(); }));
 }
 
 EffectsBaseUi::~EffectsBaseUi() {
@@ -61,7 +61,7 @@ void EffectsBaseUi::on_app_added(std::shared_ptr<AppInfo> app_info) {
 
   apps_box->add(*appui);
 
-  apps_list.push_back(appui);
+  apps_list.emplace_back(appui);
 }
 
 void EffectsBaseUi::on_app_changed(const std::shared_ptr<AppInfo>& app_info) {

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -226,7 +226,7 @@ EqualizerUi::EqualizerUi(BaseObjectType* cobject,
 
   presets_listbox->set_sort_func(sigc::ptr_fun(&EqualizerUi::on_listbox_sort));
 
-  connections.push_back(settings->signal_changed("split-channels").connect([&](auto key) {
+  connections.emplace_back(settings->signal_changed("split-channels").connect([&](auto key) {
     for (auto c : connections_bands) {
       c.disconnect();
     }
@@ -361,19 +361,19 @@ void EqualizerUi::build_bands(Gtk::Grid* bands_grid, const Glib::RefPtr<Gio::Set
       band_label->set_text(msg.str());
     };
 
-    connections_bands.push_back(band_frequency->signal_value_changed().connect(update_w));
+    connections_bands.emplace_back(band_frequency->signal_value_changed().connect(update_w));
 
-    connections_bands.push_back(band_frequency->signal_value_changed().connect(update_band_label));
+    connections_bands.emplace_back(band_frequency->signal_value_changed().connect(update_band_label));
 
-    connections_bands.push_back(band_quality->signal_value_changed().connect(update_w));
+    connections_bands.emplace_back(band_quality->signal_value_changed().connect(update_w));
 
-    connections_bands.push_back(reset_frequency->signal_clicked().connect(
+    connections_bands.emplace_back(reset_frequency->signal_clicked().connect(
         [=]() { cfg->reset(std::string("band" + std::to_string(n) + "-frequency")); }));
 
-    connections_bands.push_back(
+    connections_bands.emplace_back(
         reset_quality->signal_clicked().connect([=]() { cfg->reset(std::string("band" + std::to_string(n) + "-q")); }));
 
-    connections_bands.push_back(band_type->signal_changed().connect([=]() {
+    connections_bands.emplace_back(band_type->signal_changed().connect([=]() {
       if (band_type->get_active_row_number() == 1 || band_type->get_active_row_number() == 3 ||
           band_type->get_active_row_number() == 5 || band_type->get_active_row_number() == 7) {
         band_scale->set_sensitive(true);
@@ -485,52 +485,52 @@ void EqualizerUi::build_unified_bands(const int& nbands) {
       band_label->set_text(msg.str());
     };
 
-    connections_bands.push_back(band_frequency->signal_value_changed().connect(update_w));
+    connections_bands.emplace_back(band_frequency->signal_value_changed().connect(update_w));
 
-    connections_bands.push_back(band_frequency->signal_value_changed().connect(update_band_label));
+    connections_bands.emplace_back(band_frequency->signal_value_changed().connect(update_band_label));
 
-    connections_bands.push_back(band_quality->signal_value_changed().connect(update_w));
+    connections_bands.emplace_back(band_quality->signal_value_changed().connect(update_w));
 
     /*right channel
       we need the bindgins below for the right channel equalizer to be updated
       they have to be before the bindings for the left channel.
      */
 
-    connections_bands.push_back(band_gain->signal_value_changed().connect([=]() {
+    connections_bands.emplace_back(band_gain->signal_value_changed().connect([=]() {
       settings_right->set_double(std::string("band" + std::to_string(n) + "-gain"), band_gain->get_value());
     }));
 
-    connections_bands.push_back(band_frequency->signal_value_changed().connect([=]() {
+    connections_bands.emplace_back(band_frequency->signal_value_changed().connect([=]() {
       settings_right->set_double(std::string("band" + std::to_string(n) + "-frequency"), band_frequency->get_value());
     }));
 
-    connections_bands.push_back(band_quality->signal_value_changed().connect([=]() {
+    connections_bands.emplace_back(band_quality->signal_value_changed().connect([=]() {
       settings_right->set_double(std::string("band" + std::to_string(n) + "-q"), band_quality->get_value());
     }));
 
-    connections_bands.push_back(band_type->signal_changed().connect([=]() {
+    connections_bands.emplace_back(band_type->signal_changed().connect([=]() {
       settings_right->set_enum(std::string("band" + std::to_string(n) + "-type"), band_type->get_active_row_number());
     }));
 
-    connections_bands.push_back(band_mode->signal_changed().connect([=]() {
+    connections_bands.emplace_back(band_mode->signal_changed().connect([=]() {
       settings_right->set_enum(std::string("band" + std::to_string(n) + "-mode"), band_mode->get_active_row_number());
     }));
 
-    connections_bands.push_back(band_slope->signal_changed().connect([=]() {
+    connections_bands.emplace_back(band_slope->signal_changed().connect([=]() {
       settings_right->set_enum(std::string("band" + std::to_string(n) + "-slope"), band_slope->get_active_row_number());
     }));
 
-    connections_bands.push_back(band_solo->signal_toggled().connect([=]() {
+    connections_bands.emplace_back(band_solo->signal_toggled().connect([=]() {
       settings_right->set_boolean(std::string("band" + std::to_string(n) + "-solo"), band_solo->get_active());
     }));
 
-    connections_bands.push_back(band_mute->signal_toggled().connect([=]() {
+    connections_bands.emplace_back(band_mute->signal_toggled().connect([=]() {
       settings_right->set_boolean(std::string("band" + std::to_string(n) + "-mute"), band_mute->get_active());
     }));
 
     // left channel
 
-    connections_bands.push_back(band_type->signal_changed().connect([=]() {
+    connections_bands.emplace_back(band_type->signal_changed().connect([=]() {
       if (band_type->get_active_row_number() == 1 || band_type->get_active_row_number() == 3 ||
           band_type->get_active_row_number() == 5 || band_type->get_active_row_number() == 7) {
         band_scale->set_sensitive(true);
@@ -539,13 +539,13 @@ void EqualizerUi::build_unified_bands(const int& nbands) {
       }
     }));
 
-    connections_bands.push_back(reset_frequency->signal_clicked().connect([=]() {
+    connections_bands.emplace_back(reset_frequency->signal_clicked().connect([=]() {
       settings_left->reset(std::string("band" + std::to_string(n) + "-frequency"));
 
       settings_right->reset(std::string("band" + std::to_string(n) + "-frequency"));
     }));
 
-    connections_bands.push_back(reset_quality->signal_clicked().connect([=]() {
+    connections_bands.emplace_back(reset_quality->signal_clicked().connect([=]() {
       settings_left->reset(std::string("band" + std::to_string(n) + "-q"));
 
       settings_right->reset(std::string("band" + std::to_string(n) + "-q"));
@@ -741,7 +741,7 @@ void EqualizerUi::populate_presets_listbox() {
 
     label->set_text(name);
 
-    connections.push_back(apply_btn->signal_clicked().connect([=]() { load_preset(row->get_name() + ".json"); }));
+    connections.emplace_back(apply_btn->signal_clicked().connect([=]() { load_preset(row->get_name() + ".json"); }));
 
     presets_listbox->add(*row);
 
@@ -751,7 +751,6 @@ void EqualizerUi::populate_presets_listbox() {
 
 void EqualizerUi::reset() {
   try {
-    settings->reset("state");
     settings->reset("mode");
     settings->reset("num-bands");
     settings->reset("split-channels");

--- a/src/general_settings_ui.cpp
+++ b/src/general_settings_ui.cpp
@@ -64,7 +64,7 @@ GeneralSettingsUi::GeneralSettingsUi(BaseObjectType* cobject,
 
   about_button->signal_clicked().connect([=]() { app->activate_action("about"); });
 
-  connections.push_back(settings->signal_changed("priority-type").connect([&](auto key) {
+  connections.emplace_back(settings->signal_changed("priority-type").connect([&](auto key) {
     set_priority_controls_visibility();
 
     app->sie->set_null_pipeline();
@@ -74,7 +74,7 @@ GeneralSettingsUi::GeneralSettingsUi(BaseObjectType* cobject,
     app->soe->update_pipeline_state();
   }));
 
-  connections.push_back(settings->signal_changed("realtime-priority").connect([&](auto key) {
+  connections.emplace_back(settings->signal_changed("realtime-priority").connect([&](auto key) {
     app->sie->set_null_pipeline();
     app->soe->set_null_pipeline();
 
@@ -82,7 +82,7 @@ GeneralSettingsUi::GeneralSettingsUi(BaseObjectType* cobject,
     app->soe->update_pipeline_state();
   }));
 
-  connections.push_back(settings->signal_changed("niceness").connect([&](auto key) {
+  connections.emplace_back(settings->signal_changed("niceness").connect([&](auto key) {
     app->sie->set_null_pipeline();
     app->soe->set_null_pipeline();
 

--- a/src/pipeline_base.cpp
+++ b/src/pipeline_base.cpp
@@ -589,7 +589,7 @@ void PipelineBase::on_app_added(const std::shared_ptr<AppInfo>& app_info) {
     }
   }
 
-  apps_list.push_back(app_info);
+  apps_list.emplace_back(app_info);
 
   update_pipeline_state();
 }
@@ -646,7 +646,7 @@ void PipelineBase::init_spectrum(const uint& sampling_rate) {
     }
 
     if (f > min_spectrum_freq) {
-      spectrum_freqs.push_back(f);
+      spectrum_freqs.emplace_back(f);
 
       if (spectrum_start_index == 0) {
         spectrum_start_index = n;

--- a/src/plugin_ui_base.cpp
+++ b/src/plugin_ui_base.cpp
@@ -21,7 +21,7 @@ PluginUiBase::PluginUiBase(const Glib::RefPtr<Gtk::Builder>& builder, const std:
 
   // gsettings bindings
 
-  connections.push_back(settings->signal_changed("state").connect(
+  connections.emplace_back(settings->signal_changed("state").connect(
       [=](auto key) { settings->set_boolean("post-messages", settings->get_boolean(key)); }));
 
   auto flag = Gio::SettingsBindFlags::SETTINGS_BIND_DEFAULT;

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -314,7 +314,7 @@ void PresetsManager::load(PresetType preset_type, const std::string& name) {
 
           for (const auto& v : aux.get()) {
             if (v == value) {
-              output_plugins.push_back(value);
+              output_plugins.emplace_back(value);
 
               break;
             }
@@ -323,7 +323,7 @@ void PresetsManager::load(PresetType preset_type, const std::string& name) {
 
         for (const auto& v : aux.get()) {
           if (std::find(output_plugins.begin(), output_plugins.end(), v) == output_plugins.end()) {
-            output_plugins.push_back(v);
+            output_plugins.emplace_back(v);
           }
         }
       } catch (const boost::property_tree::ptree_error& e) {
@@ -360,7 +360,7 @@ void PresetsManager::load(PresetType preset_type, const std::string& name) {
 
           for (const auto& v : aux.get()) {
             if (v == value) {
-              input_plugins.push_back(value);
+              input_plugins.emplace_back(value);
 
               break;
             }
@@ -369,7 +369,7 @@ void PresetsManager::load(PresetType preset_type, const std::string& name) {
 
         for (const auto& v : aux.get()) {
           if (std::find(input_plugins.begin(), input_plugins.end(), v) == input_plugins.end()) {
-            input_plugins.push_back(v);
+            input_plugins.emplace_back(v);
           }
         }
       } catch (const boost::property_tree::ptree_error& e) {

--- a/src/presets_menu_ui.cpp
+++ b/src/presets_menu_ui.cpp
@@ -229,15 +229,15 @@ void PresetsMenuUi::populate_listbox(PresetType preset_type) {
       autoload_btn->set_active(true);
     }
 
-    connections.push_back(apply_btn->signal_clicked().connect([=]() {
+    connections.emplace_back(apply_btn->signal_clicked().connect([=]() {
       settings->set_string("last-used-preset", row->get_name());
 
       app->presets_manager->load(preset_type, row->get_name());
     }));
 
-    connections.push_back(save_btn->signal_clicked().connect([=]() { app->presets_manager->save(preset_type, name); }));
+    connections.emplace_back(save_btn->signal_clicked().connect([=]() { app->presets_manager->save(preset_type, name); }));
 
-    connections.push_back(autoload_btn->signal_toggled().connect([=]() {
+    connections.emplace_back(autoload_btn->signal_toggled().connect([=]() {
       if (preset_type == PresetType::output) {
         auto dev_name = build_device_name(preset_type, app->pm->server_info.default_sink_name);
 
@@ -259,7 +259,7 @@ void PresetsMenuUi::populate_listbox(PresetType preset_type) {
       populate_listbox(preset_type);
     }));
 
-    connections.push_back(remove_btn->signal_clicked().connect([=]() {
+    connections.emplace_back(remove_btn->signal_clicked().connect([=]() {
       app->presets_manager->remove(preset_type, name);
 
       populate_listbox(preset_type);

--- a/src/pulse_settings_ui.cpp
+++ b/src/pulse_settings_ui.cpp
@@ -93,9 +93,9 @@ PulseSettingsUi::PulseSettingsUi(BaseObjectType* cobject,
   use_default_sink->signal_toggled().connect(sigc::mem_fun(*this, &PulseSettingsUi::on_use_default_sink_toggled));
   use_default_source->signal_toggled().connect(sigc::mem_fun(*this, &PulseSettingsUi::on_use_default_source_toggled));
 
-  connections.push_back(
+  connections.emplace_back(
       input_device->signal_changed().connect(sigc::mem_fun(*this, &PulseSettingsUi::on_input_device_changed)));
-  connections.push_back(
+  connections.emplace_back(
       output_device->signal_changed().connect(sigc::mem_fun(*this, &PulseSettingsUi::on_output_device_changed)));
 
   app->pm->sink_added.connect(sigc::mem_fun(*this, &PulseSettingsUi::on_sink_added));

--- a/src/spectrum_preset.cpp
+++ b/src/spectrum_preset.cpp
@@ -84,7 +84,7 @@ void SpectrumPreset::load(boost::property_tree::ptree& root,
     std::vector<double> color;
 
     for (auto& p : root.get_child("spectrum.color")) {
-      color.push_back(p.second.get<double>(""));
+      color.emplace_back(p.second.get<double>(""));
     }
 
     auto v = Glib::Variant<std::vector<double>>::create(color);
@@ -100,7 +100,7 @@ void SpectrumPreset::load(boost::property_tree::ptree& root,
     std::vector<double> color;
 
     for (auto& p : root.get_child("spectrum.gradient-color")) {
-      color.push_back(p.second.get<double>(""));
+      color.emplace_back(p.second.get<double>(""));
     }
 
     auto v = Glib::Variant<std::vector<double>>::create(color);

--- a/src/spectrum_settings_ui.cpp
+++ b/src/spectrum_settings_ui.cpp
@@ -53,7 +53,7 @@ SpectrumSettingsUi::SpectrumSettingsUi(BaseObjectType* cobject,
 
   // signals connection
 
-  connections.push_back(settings->signal_changed("color").connect([&](auto key) {
+  connections.emplace_back(settings->signal_changed("color").connect([&](auto key) {
     Glib::Variant<std::vector<double>> v;
 
     settings->get_value("color", v);
@@ -67,7 +67,7 @@ SpectrumSettingsUi::SpectrumSettingsUi(BaseObjectType* cobject,
     spectrum_color_button->set_rgba(color);
   }));
 
-  connections.push_back(settings->signal_changed("gradient-color").connect([&](auto key) {
+  connections.emplace_back(settings->signal_changed("gradient-color").connect([&](auto key) {
     Glib::Variant<std::vector<double>> v;
 
     settings->get_value("gradient-color", v);

--- a/src/spectrum_ui.cpp
+++ b/src/spectrum_ui.cpp
@@ -14,16 +14,16 @@ SpectrumUi::SpectrumUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>
   spectrum->signal_leave_notify_event().connect(sigc::mem_fun(*this, &SpectrumUi::on_spectrum_leave_notify_event));
   spectrum->signal_motion_notify_event().connect(sigc::mem_fun(*this, &SpectrumUi::on_spectrum_motion_notify_event));
 
-  connections.push_back(settings->signal_changed("use-custom-color").connect([&](auto key) {
+  connections.emplace_back(settings->signal_changed("use-custom-color").connect([&](auto key) {
     init_color();
     init_gradient_color();
   }));
 
-  connections.push_back(settings->signal_changed("color").connect([&](auto key) { init_color(); }));
+  connections.emplace_back(settings->signal_changed("color").connect([&](auto key) { init_color(); }));
 
-  connections.push_back(settings->signal_changed("gradient-color").connect([&](auto key) { init_gradient_color(); }));
+  connections.emplace_back(settings->signal_changed("gradient-color").connect([&](auto key) { init_gradient_color(); }));
 
-  connections.push_back(settings->signal_changed("height").connect([&](auto key) {
+  connections.emplace_back(settings->signal_changed("height").connect([&](auto key) {
     auto v = settings->get_int("height");
 
     spectrum->set_size_request(-1, v);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -35,7 +35,7 @@ auto logspace(const float& start, const float& stop, const uint& npoints) -> std
   float v = start;
 
   while (v < stop) {
-    output.push_back(powf(10.0F, v));
+    output.emplace_back(powf(10.0F, v));
 
     v += delta;
   }
@@ -51,7 +51,7 @@ auto linspace(const float& start, const float& stop, const uint& npoints) -> std
   float v = start;
 
   while (v < stop) {
-    output.push_back(v);
+    output.emplace_back(v);
 
     v += delta;
   }


### PR DESCRIPTION
1. Modified _apply_ button to _load_ in presets list UI; related to #680 
2. State switch in app_info_ui is made insensitive when the blacklist button is toggled and sensitive when it's untoggled; related to #626 
3. Modified blacklist icon to `symbolic` type since other icons are using this type
4. Removed the line to reset the state inside the reset method of equalizer UI class; now equalizer plugin it's acting like all other plugins when the reset  button is pressed: all options are reset except the state
5. Remaining vector `push_back` methods were all switched to `emplace_back` which has better performance, if not equal; past commits already done this in other parts of the code, but not all; push_back has been kept for types different from vector which I'm not sure if it can be applied
6. Updated Italian translation for new labels

Successfully compiled and tested.