### PR TITLE
Option to show/hide blacklisted apps

### DIFF
--- a/data/schemas/com.github.wwmm.pulseeffects.gschema.xml
+++ b/data/schemas/com.github.wwmm.pulseeffects.gschema.xml
@@ -206,6 +206,9 @@
         <key name="custom-source" type="s">
             <default>""</default>
         </key>
+        <key name="show-blacklisted-apps" type="b">
+            <default>false</default>
+        </key>
         <key name="blacklist-in" type="as">
             <default>[]</default>
         </key>

--- a/data/ui/app_info.glade
+++ b/data/ui/app_info.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkImage" id="blacklist_icon">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -238,7 +238,7 @@
             <property name="can_focus">False</property>
             <property name="halign">center</property>
             <property name="valign">center</property>
-            <property name="stock">gtk-missing-image</property>
+            <property name="icon_name">image-missing</property>
           </object>
           <packing>
             <property name="left_attach">0</property>

--- a/data/ui/application.glade
+++ b/data/ui/application.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkImage" id="image_bypass">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -25,49 +25,26 @@
   </object>
   <object class="GtkApplicationWindow" id="ApplicationUi">
     <property name="can_focus">False</property>
+    <child>
+      <object class="GtkStack" id="stack">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="hexpand">True</property>
+        <property name="vexpand">True</property>
+        <property name="hhomogeneous">False</property>
+        <property name="vhomogeneous">False</property>
+        <property name="transition_duration">250</property>
+        <property name="transition_type">crossfade</property>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+    </child>
     <child type="titlebar">
       <object class="GtkHeaderBar" id="headerbar">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="show_close_button">True</property>
-        <child>
-          <object class="GtkStackSwitcher" id="stack_switcher">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="valign">center</property>
-            <property name="stack">stack</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkButton" id="calibration_button">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="tooltip_text" translatable="yes">Test Signals</property>
-            <property name="halign">center</property>
-            <property name="valign">center</property>
-            <property name="image">image_test</property>
-            <property name="always_show_image">True</property>
-          </object>
-          <packing>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkToggleButton" id="bypass_button">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="tooltip_text" translatable="yes">Global Bypass</property>
-            <property name="halign">center</property>
-            <property name="valign">center</property>
-            <property name="image">image_bypass</property>
-            <property name="always_show_image">True</property>
-          </object>
-          <packing>
-            <property name="position">2</property>
-          </packing>
-        </child>
         <child type="title">
           <object class="GtkGrid">
             <property name="visible">True</property>
@@ -148,6 +125,44 @@
           </object>
         </child>
         <child>
+          <object class="GtkStackSwitcher" id="stack_switcher">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="valign">center</property>
+            <property name="stack">stack</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkButton" id="calibration_button">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="tooltip_text" translatable="yes">Test Signals</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+            <property name="image">image_test</property>
+            <property name="always_show_image">True</property>
+          </object>
+          <packing>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkToggleButton" id="bypass_button">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="tooltip_text" translatable="yes">Global Bypass</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+            <property name="image">image_bypass</property>
+            <property name="always_show_image">True</property>
+          </object>
+          <packing>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkMenuButton" id="settings_popover_button">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
@@ -208,21 +223,6 @@
         </child>
       </object>
     </child>
-    <child>
-      <object class="GtkStack" id="stack">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="hexpand">True</property>
-        <property name="vexpand">True</property>
-        <property name="hhomogeneous">False</property>
-        <property name="vhomogeneous">False</property>
-        <property name="transition_duration">250</property>
-        <property name="transition_type">crossfade</property>
-        <child>
-          <placeholder/>
-        </child>
-      </object>
-    </child>
   </object>
   <object class="GtkPopover" id="settings_menu">
     <property name="can_focus">False</property>
@@ -231,8 +231,8 @@
       <object class="GtkGrid">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_left">6</property>
-        <property name="margin_right">6</property>
+        <property name="margin_start">6</property>
+        <property name="margin_end">6</property>
         <property name="margin_top">6</property>
         <property name="margin_bottom">6</property>
         <property name="row_spacing">18</property>

--- a/data/ui/autogain.glade
+++ b/data/ui/autogain.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkImage" id="image1">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -374,7 +374,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -389,7 +389,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>

--- a/data/ui/bass_enhancer.glade
+++ b/data/ui/bass_enhancer.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="amount">
     <property name="lower">-100</property>
     <property name="upper">36</property>
@@ -475,7 +475,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -507,7 +507,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>

--- a/data/ui/blacklist_settings.glade
+++ b/data/ui/blacklist_settings.glade
@@ -78,6 +78,19 @@
               </packing>
             </child>
             <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_bottom">2</property>
+                <property name="label" translatable="yes">Reconnect the microphone to apply new changes made to the blacklist</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+                <property name="width">2</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkFrame">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
@@ -121,19 +134,6 @@
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">1</property>
-                <property name="width">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_bottom">2</property>
-                <property name="label" translatable="yes">Reconnect the microphone to apply new changes made to the blacklist</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
                 <property name="width">2</property>
               </packing>
             </child>
@@ -250,6 +250,42 @@
             <property name="title" translatable="yes">Output Effects</property>
             <property name="icon_name">audio-speakers-symbolic</property>
             <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkGrid">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">center</property>
+        <property name="row_spacing">6</property>
+        <property name="column_spacing">6</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Show Blacklisted Apps in Main Tab</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="show_blacklisted_apps">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="halign">start</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
           </packing>
         </child>
       </object>

--- a/data/ui/calibration.glade
+++ b/data/ui/calibration.glade
@@ -1,29 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkWindow" id="window">
     <property name="can_focus">False</property>
-    <child type="titlebar">
-      <object class="GtkHeaderBar" id="headerbar">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="title">PulseEffects</property>
-        <property name="spacing">2</property>
-        <property name="show_close_button">True</property>
-        <child>
-          <object class="GtkStackSwitcher" id="stack_switcher">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="valign">center</property>
-            <property name="stack">stack</property>
-          </object>
-          <packing>
-            <property name="position">3</property>
-          </packing>
-        </child>
-      </object>
-    </child>
     <child>
       <object class="GtkGrid">
         <property name="visible">True</property>
@@ -61,8 +41,8 @@
               <object class="GtkBox" id="spectrum_labels">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="margin_left">6</property>
-                <property name="margin_right">6</property>
+                <property name="margin_start">6</property>
+                <property name="margin_end">6</property>
                 <property name="homogeneous">True</property>
                 <child>
                   <object class="GtkBox">
@@ -253,6 +233,26 @@
           <packing>
             <property name="left_attach">0</property>
             <property name="top_attach">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child type="titlebar">
+      <object class="GtkHeaderBar" id="headerbar">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="title">PulseEffects</property>
+        <property name="spacing">2</property>
+        <property name="show_close_button">True</property>
+        <child>
+          <object class="GtkStackSwitcher" id="stack_switcher">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="valign">center</property>
+            <property name="stack">stack</property>
+          </object>
+          <packing>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/data/ui/calibration_mic.glade
+++ b/data/ui/calibration_mic.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="time_window_adjustment">
     <property name="lower">1</property>
     <property name="upper">60</property>
@@ -14,8 +14,8 @@
     <property name="can_focus">False</property>
     <property name="halign">center</property>
     <property name="valign">center</property>
-    <property name="margin_left">6</property>
-    <property name="margin_right">6</property>
+    <property name="margin_start">6</property>
+    <property name="margin_end">6</property>
     <property name="margin_top">6</property>
     <property name="margin_bottom">6</property>
     <property name="row_spacing">12</property>

--- a/data/ui/calibration_signals.glade
+++ b/data/ui/calibration_signals.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="frequency_adjustment">
     <property name="upper">20000</property>
     <property name="step_increment">1</property>
@@ -11,14 +11,14 @@
   <object class="GtkAdjustment" id="volume_adjustment">
     <property name="upper">1</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.050000000000000003</property>
+    <property name="page_increment">0.05</property>
     <signal name="value-changed" handler="on_wave2_volume_value_changed" swapped="no"/>
   </object>
   <object class="GtkGrid" id="widgets_grid">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="margin_left">3</property>
-    <property name="margin_right">3</property>
+    <property name="margin_start">3</property>
+    <property name="margin_end">3</property>
     <property name="margin_top">3</property>
     <property name="margin_bottom">3</property>
     <property name="column_spacing">3</property>

--- a/data/ui/client_info.glade
+++ b/data/ui/client_info.glade
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkListBoxRow" id="client_row">
     <property name="visible">True</property>
     <property name="can_focus">True</property>
-    <property name="margin_left">6</property>
-    <property name="margin_right">6</property>
+    <property name="margin_start">6</property>
+    <property name="margin_end">6</property>
     <property name="hexpand">True</property>
     <property name="activatable">False</property>
     <property name="selectable">False</property>

--- a/data/ui/compressor.glade
+++ b/data/ui/compressor.glade
@@ -102,7 +102,7 @@
   <object class="GtkAdjustment" id="lookahead">
     <property name="upper">20</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkAdjustment" id="makeup">
     <property name="lower">-60</property>
@@ -120,20 +120,20 @@
   <object class="GtkAdjustment" id="preamp">
     <property name="upper">40</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkAdjustment" id="ratio">
     <property name="lower">1</property>
     <property name="upper">100</property>
     <property name="value">4</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkAdjustment" id="reactivity">
     <property name="upper">250</property>
     <property name="value">10</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkAdjustment" id="release">
     <property name="upper">5000</property>

--- a/data/ui/convolver.glade
+++ b/data/ui/convolver.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkImage" id="image1">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -91,8 +91,8 @@
       <object class="GtkGrid">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_left">6</property>
-        <property name="margin_right">6</property>
+        <property name="margin_start">6</property>
+        <property name="margin_end">6</property>
         <property name="margin_top">6</property>
         <property name="margin_bottom">6</property>
         <property name="row_spacing">18</property>
@@ -473,7 +473,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -488,7 +488,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>

--- a/data/ui/crossfeed.glade
+++ b/data/ui/crossfeed.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="fcut">
     <property name="lower">300</property>
     <property name="upper">2000</property>
@@ -12,8 +12,8 @@
   <object class="GtkAdjustment" id="feed">
     <property name="lower">1</property>
     <property name="upper">15</property>
-    <property name="value">4.50</property>
-    <property name="step_increment">0.10</property>
+    <property name="value">4.5</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
     <signal name="value-changed" handler="on_feed_value_changed" swapped="no"/>
   </object>
@@ -198,7 +198,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -213,7 +213,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>

--- a/data/ui/crystalizer.glade
+++ b/data/ui/crystalizer.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="freq1">
     <property name="lower">10</property>
     <property name="upper">20000</property>
@@ -224,7 +224,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -239,7 +239,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>

--- a/data/ui/crystalizer_band.glade
+++ b/data/ui/crystalizer_band.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="band_intensity">
     <property name="lower">-40</property>
     <property name="upper">32</property>
@@ -16,8 +16,8 @@
         <property name="can_focus">False</property>
         <property name="halign">center</property>
         <property name="valign">center</property>
-        <property name="margin_left">6</property>
-        <property name="margin_right">6</property>
+        <property name="margin_start">6</property>
+        <property name="margin_end">6</property>
         <property name="margin_top">6</property>
         <property name="margin_bottom">6</property>
         <property name="column_spacing">6</property>

--- a/data/ui/deesser.glade
+++ b/data/ui/deesser.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="f1_freq">
     <property name="lower">10</property>
     <property name="upper">18000</property>
@@ -33,10 +33,10 @@
     <signal name="value-changed" handler="on_f2_level_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="f2_q">
-    <property name="lower">0.10</property>
+    <property name="lower">0.1</property>
     <property name="upper">100</property>
     <property name="value">1</property>
-    <property name="step_increment">0.10</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkImage" id="image1">
@@ -564,7 +564,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -579,7 +579,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>
@@ -744,7 +744,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Reduction</property>
               </object>
               <packing>
@@ -758,6 +758,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Detected</property>
               </object>
               <packing>

--- a/data/ui/effects_base.glade
+++ b/data/ui/effects_base.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkBox" id="widgets_box">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -58,7 +58,7 @@
           <object class="GtkStack" id="stack">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="margin_right">6</property>
+            <property name="margin_end">6</property>
             <property name="margin_top">6</property>
             <property name="margin_bottom">6</property>
             <property name="hexpand">True</property>

--- a/data/ui/equalizer.glade
+++ b/data/ui/equalizer.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkImage" id="image1">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -99,8 +99,8 @@
       <object class="GtkGrid">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_left">6</property>
-        <property name="margin_right">6</property>
+        <property name="margin_start">6</property>
+        <property name="margin_end">6</property>
         <property name="margin_top">6</property>
         <property name="margin_bottom">6</property>
         <property name="row_spacing">18</property>
@@ -211,7 +211,7 @@
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="valign">center</property>
-                    <property name="margin_left">12</property>
+                    <property name="margin_start">12</property>
                     <signal name="clicked" handler="on_flat_response_button_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -226,7 +226,7 @@
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="valign">center</property>
-                    <property name="margin_left">12</property>
+                    <property name="margin_start">12</property>
                   </object>
                   <packing>
                     <property name="left_attach">2</property>
@@ -240,7 +240,7 @@
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="valign">center</property>
-                    <property name="margin_left">12</property>
+                    <property name="margin_start">12</property>
                   </object>
                   <packing>
                     <property name="left_attach">2</property>

--- a/data/ui/equalizer_band.glade
+++ b/data/ui/equalizer_band.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="band_frequency">
     <property name="lower">10</property>
     <property name="upper">24000</property>
@@ -12,11 +12,11 @@
     <property name="lower">-35</property>
     <property name="upper">35</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkAdjustment" id="band_quality">
     <property name="upper">100</property>
-    <property name="value">4.3600000000000003</property>
+    <property name="value">4.36</property>
     <property name="step_increment">0.01</property>
     <property name="page_increment">0.01</property>
   </object>
@@ -28,8 +28,8 @@
         <property name="can_focus">False</property>
         <property name="halign">center</property>
         <property name="valign">center</property>
-        <property name="margin_left">6</property>
-        <property name="margin_right">6</property>
+        <property name="margin_start">6</property>
+        <property name="margin_end">6</property>
         <property name="margin_top">6</property>
         <property name="margin_bottom">6</property>
         <property name="row_spacing">24</property>

--- a/data/ui/equalizer_preset_row.glade
+++ b/data/ui/equalizer_preset_row.glade
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkListBoxRow" id="preset_row">
     <property name="visible">True</property>
     <property name="can_focus">True</property>
-    <property name="margin_left">6</property>
-    <property name="margin_right">6</property>
+    <property name="margin_start">6</property>
+    <property name="margin_end">6</property>
     <property name="margin_top">6</property>
     <property name="margin_bottom">6</property>
     <property name="activatable">False</property>

--- a/data/ui/exciter.glade
+++ b/data/ui/exciter.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="amount">
     <property name="lower">-100</property>
     <property name="upper">36</property>
@@ -22,11 +22,11 @@
     <property name="page_increment">1000</property>
   </object>
   <object class="GtkAdjustment" id="harmonics">
-    <property name="lower">0.10</property>
+    <property name="lower">0.1</property>
     <property name="upper">10</property>
-    <property name="value">8.50</property>
-    <property name="step_increment">0.10</property>
-    <property name="page_increment">0.10</property>
+    <property name="value">8.5</property>
+    <property name="step_increment">0.1</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkImage" id="image1">
     <property name="visible">True</property>
@@ -386,7 +386,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Harmonics</property>
               </object>
               <packing>
@@ -479,7 +479,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -511,7 +511,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>

--- a/data/ui/filter.glade
+++ b/data/ui/filter.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="frequency">
     <property name="lower">10</property>
     <property name="upper">20000</property>
@@ -112,8 +112,8 @@
       <object class="GtkGrid">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_left">6</property>
-        <property name="margin_right">6</property>
+        <property name="margin_start">6</property>
+        <property name="margin_end">6</property>
         <property name="margin_top">6</property>
         <property name="margin_bottom">6</property>
         <property name="column_spacing">3</property>
@@ -173,8 +173,8 @@
     <property name="lower">-3</property>
     <property name="upper">30</property>
     <property name="value">-3</property>
-    <property name="step_increment">0.10</property>
-    <property name="page_increment">0.10</property>
+    <property name="step_increment">0.1</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkGrid" id="widgets_grid">
     <property name="visible">True</property>
@@ -364,7 +364,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -379,7 +379,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>

--- a/data/ui/gate.glade
+++ b/data/ui/gate.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="attack">
     <property name="lower">0.01</property>
     <property name="upper">2000</property>
@@ -483,7 +483,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -498,7 +498,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>
@@ -663,7 +663,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Gating</property>
               </object>
               <packing>

--- a/data/ui/general_settings.glade
+++ b/data/ui/general_settings.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="adjustment_niceness">
     <property name="lower">-20</property>
     <property name="upper">19</property>
@@ -10,7 +10,7 @@
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustment_priority">
-    <property name="upper">99.989999999999995</property>
+    <property name="upper">99.99</property>
     <property name="value">4</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
@@ -103,7 +103,7 @@
         <property name="can_focus">False</property>
         <property name="halign">end</property>
         <property name="valign">center</property>
-        <property name="margin_left">24</property>
+        <property name="margin_start">24</property>
         <property name="label" translatable="yes">Settings</property>
       </object>
       <packing>
@@ -128,7 +128,7 @@
       <object class="GtkComboBoxText" id="priority_type">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_left">32</property>
+        <property name="margin_start">32</property>
         <items>
           <item translatable="yes">Niceness</item>
           <item translatable="yes">Real Time</item>
@@ -147,7 +147,7 @@
         <property name="can_focus">False</property>
         <property name="halign">center</property>
         <property name="valign">center</property>
-        <property name="margin_left">32</property>
+        <property name="margin_start">32</property>
         <property name="label" translatable="yes">Priority Type</property>
       </object>
       <packing>
@@ -164,7 +164,7 @@
         <property name="receives_default">True</property>
         <property name="halign">start</property>
         <property name="valign">center</property>
-        <property name="margin_left">32</property>
+        <property name="margin_start">32</property>
       </object>
       <packing>
         <property name="left_attach">4</property>
@@ -202,7 +202,7 @@
         <property name="can_focus">False</property>
         <property name="halign">end</property>
         <property name="valign">center</property>
-        <property name="margin_left">32</property>
+        <property name="margin_start">32</property>
         <property name="label" translatable="yes">Niceness</property>
       </object>
       <packing>
@@ -228,7 +228,7 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="halign">end</property>
-        <property name="margin_left">32</property>
+        <property name="margin_start">32</property>
         <property name="label" translatable="yes">Priority</property>
       </object>
       <packing>

--- a/data/ui/irs_row.glade
+++ b/data/ui/irs_row.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkImage" id="image_delete">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -11,8 +11,8 @@
     <property name="visible">True</property>
     <property name="can_focus">True</property>
     <property name="valign">center</property>
-    <property name="margin_left">6</property>
-    <property name="margin_right">6</property>
+    <property name="margin_start">6</property>
+    <property name="margin_end">6</property>
     <property name="margin_top">6</property>
     <property name="margin_bottom">6</property>
     <property name="activatable">False</property>

--- a/data/ui/limiter.glade
+++ b/data/ui/limiter.glade
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="asc_level">
     <property name="upper">1</property>
-    <property name="value">0.50</property>
+    <property name="value">0.5</property>
     <property name="step_increment">0.01</property>
     <property name="page_increment">0.01</property>
   </object>
@@ -100,11 +100,11 @@
     <signal name="value-changed" handler="on_limit_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="lookahead">
-    <property name="lower">0.10</property>
+    <property name="lower">0.1</property>
     <property name="upper">10</property>
     <property name="value">5</property>
-    <property name="step_increment">0.10</property>
-    <property name="page_increment">0.10</property>
+    <property name="step_increment">0.1</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkAdjustment" id="oversampling">
     <property name="lower">1</property>
@@ -269,7 +269,7 @@
                 <property name="digits">2</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
-                <property name="value">0.50</property>
+                <property name="value">0.5</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
@@ -361,7 +361,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -376,7 +376,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>
@@ -391,7 +391,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Attenuation</property>
               </object>
               <packing>

--- a/data/ui/maximizer.glade
+++ b/data/ui/maximizer.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="ceiling">
     <property name="lower">-30</property>
     <property name="step_increment">1</property>
@@ -235,7 +235,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -250,7 +250,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>
@@ -265,7 +265,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Gain Reduction</property>
               </object>
               <packing>

--- a/data/ui/module_info.glade
+++ b/data/ui/module_info.glade
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkListBoxRow" id="module_row">
     <property name="visible">True</property>
     <property name="can_focus">True</property>
-    <property name="margin_left">6</property>
-    <property name="margin_right">6</property>
+    <property name="margin_start">6</property>
+    <property name="margin_end">6</property>
     <property name="hexpand">True</property>
     <property name="activatable">False</property>
     <property name="selectable">False</property>

--- a/data/ui/multiband_compressor.glade
+++ b/data/ui/multiband_compressor.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="attack0">
     <property name="lower">0.01</property>
     <property name="upper">2000</property>
@@ -186,25 +186,25 @@
     <property name="upper">20</property>
     <property name="value">2</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkAdjustment" id="ratio1">
     <property name="lower">1</property>
     <property name="upper">20</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkAdjustment" id="ratio2">
     <property name="lower">1</property>
     <property name="upper">20</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkAdjustment" id="ratio3">
     <property name="lower">1</property>
     <property name="upper">20</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkAdjustment" id="release0">
     <property name="lower">0.01</property>
@@ -1954,7 +1954,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -1969,7 +1969,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>

--- a/data/ui/multiband_gate.glade
+++ b/data/ui/multiband_gate.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="attack0">
     <property name="lower">0.01</property>
     <property name="upper">2000</property>
@@ -206,25 +206,25 @@
     <property name="upper">20</property>
     <property name="value">2</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkAdjustment" id="ratio1">
     <property name="lower">1</property>
     <property name="upper">20</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkAdjustment" id="ratio2">
     <property name="lower">1</property>
     <property name="upper">20</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkAdjustment" id="ratio3">
     <property name="lower">1</property>
     <property name="upper">20</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkAdjustment" id="release0">
     <property name="lower">0.01</property>
@@ -2103,7 +2103,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -2118,7 +2118,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>

--- a/data/ui/preset_row.glade
+++ b/data/ui/preset_row.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkImage" id="image_autoload">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -21,8 +21,8 @@
     <property name="visible">True</property>
     <property name="can_focus">True</property>
     <property name="valign">center</property>
-    <property name="margin_left">6</property>
-    <property name="margin_right">6</property>
+    <property name="margin_start">6</property>
+    <property name="margin_end">6</property>
     <property name="margin_top">6</property>
     <property name="margin_bottom">6</property>
     <property name="activatable">False</property>

--- a/data/ui/presets_menu.glade
+++ b/data/ui/presets_menu.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkImage" id="image_add_input">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -25,8 +25,8 @@
   <object class="GtkGrid" id="widgets_grid">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="margin_left">6</property>
-    <property name="margin_right">6</property>
+    <property name="margin_start">6</property>
+    <property name="margin_end">6</property>
     <property name="margin_top">6</property>
     <property name="margin_bottom">6</property>
     <property name="row_spacing">18</property>

--- a/data/ui/pulse_conf_file_line.glade
+++ b/data/ui/pulse_conf_file_line.glade
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkListBoxRow" id="conf_row">
     <property name="visible">True</property>
     <property name="can_focus">True</property>
-    <property name="margin_left">6</property>
-    <property name="margin_right">6</property>
+    <property name="margin_start">6</property>
+    <property name="margin_end">6</property>
     <property name="hexpand">True</property>
     <property name="activatable">False</property>
     <property name="selectable">False</property>

--- a/data/ui/pulse_info.glade
+++ b/data/ui/pulse_info.glade
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkBox" id="widgets_box">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="margin_left">6</property>
-    <property name="margin_right">6</property>
+    <property name="margin_start">6</property>
+    <property name="margin_end">6</property>
     <property name="margin_top">6</property>
     <property name="margin_bottom">6</property>
     <property name="hexpand">True</property>

--- a/data/ui/reverb.glade
+++ b/data/ui/reverb.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="amount">
     <property name="lower">-100</property>
     <property name="upper">6</property>
@@ -25,9 +25,9 @@
   </object>
   <object class="GtkAdjustment" id="diffusion">
     <property name="upper">1</property>
-    <property name="value">0.50</property>
+    <property name="value">0.5</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.10</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkAdjustment" id="dry">
     <property name="lower">-100</property>
@@ -145,8 +145,8 @@
         <property name="can_focus">False</property>
         <property name="halign">center</property>
         <property name="valign">center</property>
-        <property name="margin_left">6</property>
-        <property name="margin_right">6</property>
+        <property name="margin_start">6</property>
+        <property name="margin_end">6</property>
         <property name="margin_top">6</property>
         <property name="margin_bottom">6</property>
         <property name="row_spacing">6</property>
@@ -626,7 +626,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -641,7 +641,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_right">3</property>
+                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>

--- a/data/ui/spectrum.glade
+++ b/data/ui/spectrum.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkGrid" id="widgets_grid">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -22,8 +22,8 @@
       <object class="GtkBox" id="spectrum_labels">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_left">6</property>
-        <property name="margin_right">6</property>
+        <property name="margin_start">6</property>
+        <property name="margin_end">6</property>
         <property name="homogeneous">True</property>
         <child>
           <object class="GtkBox">

--- a/data/ui/spectrum_settings.glade
+++ b/data/ui/spectrum_settings.glade
@@ -4,7 +4,7 @@
   <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="exponent">
     <property name="upper">10</property>
-    <property name="step_increment">0,01</property>
+    <property name="step_increment">0.01</property>
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="height">
@@ -14,11 +14,11 @@
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="line_width">
-    <property name="lower">0,10</property>
+    <property name="lower">0.10</property>
     <property name="upper">100</property>
     <property name="value">2</property>
-    <property name="step_increment">0,10</property>
-    <property name="page_increment">0,10</property>
+    <property name="step_increment">0.10</property>
+    <property name="page_increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="n_points">
     <property name="lower">2</property>
@@ -34,7 +34,7 @@
   </object>
   <object class="GtkAdjustment" id="scale">
     <property name="upper">10</property>
-    <property name="step_increment">0,01</property>
+    <property name="step_increment">0.01</property>
     <property name="page_increment">10</property>
   </object>
   <object class="GtkGrid" id="widgets_grid">

--- a/data/ui/spectrum_settings.glade
+++ b/data/ui/spectrum_settings.glade
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="exponent">
     <property name="upper">10</property>
-    <property name="step_increment">0.01</property>
+    <property name="step_increment">0,01</property>
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="height">
@@ -14,11 +14,11 @@
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="line_width">
-    <property name="lower">0.10000000000000001</property>
+    <property name="lower">0,10</property>
     <property name="upper">100</property>
     <property name="value">2</property>
-    <property name="step_increment">0.10000000000000001</property>
-    <property name="page_increment">0.10000000000000001</property>
+    <property name="step_increment">0,10</property>
+    <property name="page_increment">0,10</property>
   </object>
   <object class="GtkAdjustment" id="n_points">
     <property name="lower">2</property>
@@ -34,13 +34,14 @@
   </object>
   <object class="GtkAdjustment" id="scale">
     <property name="upper">10</property>
-    <property name="step_increment">0.01</property>
+    <property name="step_increment">0,01</property>
     <property name="page_increment">10</property>
   </object>
   <object class="GtkGrid" id="widgets_grid">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="halign">center</property>
+    <property name="valign">center</property>
     <property name="row_spacing">18</property>
     <child>
       <object class="GtkGrid">
@@ -181,7 +182,7 @@
             <property name="can_focus">False</property>
             <property name="halign">end</property>
             <property name="valign">center</property>
-            <property name="margin_left">30</property>
+            <property name="margin_start">30</property>
             <property name="label" translatable="yes">Spectrum Color</property>
           </object>
           <packing>
@@ -209,7 +210,7 @@
             <property name="can_focus">False</property>
             <property name="halign">end</property>
             <property name="valign">center</property>
-            <property name="margin_left">30</property>
+            <property name="margin_start">30</property>
             <property name="label" translatable="yes">Gradient Color</property>
           </object>
           <packing>
@@ -237,7 +238,7 @@
             <property name="can_focus">False</property>
             <property name="halign">end</property>
             <property name="valign">center</property>
-            <property name="margin_left">30</property>
+            <property name="margin_start">30</property>
             <property name="label" translatable="yes">Spectrum Type</property>
           </object>
           <packing>
@@ -267,7 +268,7 @@
             <property name="can_focus">False</property>
             <property name="halign">end</property>
             <property name="valign">center</property>
-            <property name="margin_left">30</property>
+            <property name="margin_start">30</property>
             <property name="label" translatable="yes">Points</property>
           </object>
           <packing>
@@ -299,7 +300,7 @@
             <property name="can_focus">False</property>
             <property name="halign">end</property>
             <property name="valign">center</property>
-            <property name="margin_left">30</property>
+            <property name="margin_start">30</property>
             <property name="label" translatable="yes">Height</property>
           </object>
           <packing>
@@ -332,7 +333,7 @@
             <property name="can_focus">False</property>
             <property name="halign">end</property>
             <property name="valign">center</property>
-            <property name="margin_left">30</property>
+            <property name="margin_start">30</property>
             <property name="label" translatable="yes">Scale</property>
           </object>
           <packing>
@@ -365,7 +366,7 @@
             <property name="can_focus">False</property>
             <property name="halign">end</property>
             <property name="valign">center</property>
-            <property name="margin_left">30</property>
+            <property name="margin_start">30</property>
             <property name="label" translatable="yes">Exponent</property>
           </object>
           <packing>
@@ -398,7 +399,7 @@
             <property name="can_focus">False</property>
             <property name="halign">end</property>
             <property name="valign">center</property>
-            <property name="margin_left">30</property>
+            <property name="margin_start">30</property>
             <property name="label" translatable="yes">Sampling</property>
           </object>
           <packing>
@@ -429,7 +430,7 @@
             <property name="can_focus">False</property>
             <property name="halign">end</property>
             <property name="valign">center</property>
-            <property name="margin_left">30</property>
+            <property name="margin_start">30</property>
             <property name="label" translatable="yes">Line Width</property>
           </object>
           <packing>
@@ -455,24 +456,6 @@
             <property name="left_attach">5</property>
             <property name="top_attach">3</property>
           </packing>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
         </child>
         <child>
           <placeholder/>

--- a/include/app_info_ui.hpp
+++ b/include/app_info_ui.hpp
@@ -1,7 +1,6 @@
 #ifndef APP_INFO_UI_HPP
 #define APP_INFO_UI_HPP
 
-#include <giomm/settings.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/grid.h>
 #include <gtkmm/image.h>
@@ -45,7 +44,7 @@ class AppInfoUi : public Gtk::Grid {
  private:
   std::string log_tag = "app_info_ui: ";
 
-  bool running = true, enabled = true, blacklisted = true, pre_bl_state = true;
+  bool running = true, is_enabled = true, is_blacklisted = true, pre_bl_state = true;
 
   sigc::connection enable_connection;
   sigc::connection volume_connection;
@@ -54,7 +53,6 @@ class AppInfoUi : public Gtk::Grid {
   sigc::connection timeout_connection;
 
   PulseManager* pm = nullptr;
-  Glib::RefPtr<Gio::Settings> settings;
 
   void init_widgets();
 

--- a/include/blacklist_settings_ui.hpp
+++ b/include/blacklist_settings_ui.hpp
@@ -5,13 +5,14 @@
 #include <glibmm/i18n.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/button.h>
+#include <gtkmm/switch.h>
 #include <gtkmm/entry.h>
 #include <gtkmm/grid.h>
 #include <gtkmm/listbox.h>
 #include <gtkmm/scrolledwindow.h>
 #include <gtkmm/stack.h>
-
 #include "preset_type.hpp"
+#include "util.hpp"
 
 class BlacklistSettingsUi : public Gtk::Grid {
  public:
@@ -23,24 +24,29 @@ class BlacklistSettingsUi : public Gtk::Grid {
   ~BlacklistSettingsUi() override;
 
   static void add_to_stack(Gtk::Stack* stack);
-  static bool add_new_entry(Glib::RefPtr<Gio::Settings> settings, const std::string& name, PresetType preset_type);
-  static void remove_entry(Glib::RefPtr<Gio::Settings> settings, const std::string& name, PresetType preset_type);
+
+  // Blacklist management static methods
+  static auto add_new_entry(const std::string& name, PresetType preset_type) -> bool;
+  static void remove_entry(const std::string& name, PresetType preset_type);
+  static auto app_is_blacklisted(const std::string& name, PresetType preset_type) -> bool;
+  static auto get_blacklisted_apps_visibility() -> bool;
 
  private:
   std::string log_tag = "blacklist_settings_ui: ";
 
-  Glib::RefPtr<Gio::Settings> settings;
+  static Glib::RefPtr<Gio::Settings> settings;
 
+  Gtk::Switch *show_blacklisted_apps = nullptr;
   Gtk::Button *add_blacklist_in = nullptr, *add_blacklist_out = nullptr;
-  Gtk::ListBox *blacklist_in_listbox = nullptr, *blacklist_out_listbox = nullptr;
+  static Gtk::ListBox *blacklist_in_listbox, *blacklist_out_listbox;
   Gtk::Entry *blacklist_in_name = nullptr, *blacklist_out_name = nullptr;
   Gtk::ScrolledWindow *blacklist_in_scrolled_window = nullptr, *blacklist_out_scrolled_window = nullptr;
 
-  std::vector<sigc::connection> connections;
+  static std::vector<sigc::connection> connections;
 
-  void populate_blacklist_in_listbox();
+  static void populate_blacklist_in_listbox();
 
-  void populate_blacklist_out_listbox();
+  static void populate_blacklist_out_listbox();
 
   static auto on_listbox_sort(Gtk::ListBoxRow* row1, Gtk::ListBoxRow* row2) -> int;
 };

--- a/include/effects_base_ui.hpp
+++ b/include/effects_base_ui.hpp
@@ -9,9 +9,12 @@
 #include <gtkmm/stack.h>
 #include <memory>
 #include <vector>
-#include "app_info_ui.hpp"
 #include "pulse_manager.hpp"
+#include "app_info_ui.hpp"
 #include "spectrum_ui.hpp"
+#include "blacklist_settings_ui.hpp"
+#include "preset_type.hpp"
+#include "util.hpp"
 
 class EffectsBaseUi {
  public:
@@ -24,7 +27,7 @@ class EffectsBaseUi {
   auto operator=(const EffectsBaseUi &&) -> EffectsBaseUi& = delete;
   virtual ~EffectsBaseUi();
 
-  void on_app_added(std::shared_ptr<AppInfo> app_info);
+  virtual void on_app_added(std::shared_ptr<AppInfo> app_info) = 0;
   void on_app_changed(const std::shared_ptr<AppInfo>& app_info);
   void on_app_removed(uint idx);
 
@@ -32,10 +35,14 @@ class EffectsBaseUi {
   Glib::RefPtr<Gio::Settings> settings;
   Gtk::ListBox* listbox = nullptr;
   Gtk::Stack* stack = nullptr;
+  Gtk::Box* apps_box = nullptr;
+
+  PulseManager* pm = nullptr;
+
+  std::vector<AppInfoUi*> apps_list;
+  std::vector<sigc::connection> connections;
 
   SpectrumUi* spectrum_ui = nullptr;
-
-  std::vector<sigc::connection> connections;
 
   template <typename T>
   void add_to_listbox(T p) {
@@ -131,13 +138,7 @@ class EffectsBaseUi {
   }
 
  private:
-  Gtk::Box* apps_box = nullptr;
-
-  PulseManager* pm = nullptr;
-
   Gtk::Box* placeholder_spectrum = nullptr;
-
-  std::vector<AppInfoUi*> apps_list;
 
   auto on_listbox_sort(Gtk::ListBoxRow* row1, Gtk::ListBoxRow* row2) -> int;
 };

--- a/include/pulse_manager.hpp
+++ b/include/pulse_manager.hpp
@@ -68,6 +68,7 @@ struct AppInfo {
   std::string format;
   int mute;
   bool connected;
+  bool visible;
   uint buffer;
   uint latency;
   int corked;
@@ -101,10 +102,10 @@ class PulseManager {
   void find_source_outputs();
   void find_sinks();
   void find_sources();
-  void move_sink_input_to_pulseeffects(const std::string& name, uint idx);
-  void remove_sink_input_from_pulseeffects(const std::string& name, uint idx);
-  void move_source_output_to_pulseeffects(const std::string& name, uint idx);
-  void remove_source_output_from_pulseeffects(const std::string& name, uint idx);
+  auto move_sink_input_to_pulseeffects(const std::string& name, uint idx) -> bool;
+  auto remove_sink_input_from_pulseeffects(const std::string& name, uint idx) -> bool;
+  auto move_source_output_to_pulseeffects(const std::string& name, uint idx) -> bool;
+  auto remove_source_output_from_pulseeffects(const std::string& name, uint idx) -> bool;
   void set_sink_input_volume(const std::string& name, uint idx, uint8_t channels, uint value);
   void set_sink_input_mute(const std::string& name, uint idx, bool state);
   void set_source_output_volume(const std::string& name, uint idx, uint8_t channels, uint value);
@@ -279,7 +280,11 @@ class PulseManager {
       }
     }
 
+    // Connection flag: it specifies only the primary state that can be enabled/disabled by the user
     ai->connected = app_is_connected(info);
+
+    // Initialize visibility to true, it will be properly updated forward
+    ai->visible = true;
 
     // linear volume
     ai->volume = 100 * pa_cvolume_max(&info->volume) / PA_VOLUME_NORM;
@@ -294,6 +299,7 @@ class PulseManager {
 
     ai->index = info->index;
     ai->name = app_name;
+    ai->app_type = "";
     ai->icon_name = icon_name;
     ai->channels = info->volume.channels;
     ai->rate = info->sample_spec.rate;

--- a/include/sink_input_effects_ui.hpp
+++ b/include/sink_input_effects_ui.hpp
@@ -20,7 +20,6 @@
 #include "multiband_compressor_ui.hpp"
 #include "multiband_gate_ui.hpp"
 #include "pitch_ui.hpp"
-#include "preset_type.hpp"
 #include "reverb_ui.hpp"
 #include "sink_input_effects.hpp"
 #include "stereo_tools_ui.hpp"
@@ -38,6 +37,8 @@ class SinkInputEffectsUi : public Gtk::Box, public EffectsBaseUi {
   ~SinkInputEffectsUi() override;
 
   static auto add_to_stack(Gtk::Stack* stack, SinkInputEffects* sie_ptr) -> SinkInputEffectsUi*;
+
+  void on_app_added(std::shared_ptr<AppInfo> app_info) override;
 
  protected:
   std::string log_tag = "sie_ui: ";

--- a/include/source_output_effects_ui.hpp
+++ b/include/source_output_effects_ui.hpp
@@ -11,7 +11,6 @@
 #include "multiband_compressor_ui.hpp"
 #include "multiband_gate_ui.hpp"
 #include "pitch_ui.hpp"
-#include "preset_type.hpp"
 #include "reverb_ui.hpp"
 #include "source_output_effects.hpp"
 #include "webrtc_ui.hpp"
@@ -29,6 +28,8 @@ class SourceOutputEffectsUi : public Gtk::Box, public EffectsBaseUi {
   ~SourceOutputEffectsUi() override;
 
   static auto add_to_stack(Gtk::Stack* stack, SourceOutputEffects* soe_ptr) -> SourceOutputEffectsUi*;
+
+  void on_app_added(std::shared_ptr<AppInfo> app_info) override;
 
  protected:
   std::string log_tag = "soe_ui: ";

--- a/po/cs.po
+++ b/po/cs.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 22:40+0200\n"
+"POT-Creation-Date: 2020-06-13 20:34+0200\n"
 "PO-Revision-Date: 2019-08-25 21:29+0200\n"
 "Last-Translator: Pavel Fric <pavelfric@seznam.cz>\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
@@ -161,12 +161,16 @@ msgstr "Vytvořit přednastavení"
 msgid "Name"
 msgstr "Název"
 
-#: data/ui/blacklist_settings.glade:132
+#: data/ui/blacklist_settings.glade:85
 msgid "Reconnect the microphone to apply new changes made to the blacklist"
 msgstr ""
 
 #: data/ui/blacklist_settings.glade:239
 msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:273
+msgid "Show Blacklisted Apps in Main Tab"
 msgstr ""
 
 #: data/ui/general_settings.glade:31
@@ -249,7 +253,7 @@ msgstr "Převzorkovač"
 msgid "State"
 msgstr "Stav"
 
-#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:122
 msgid "Blacklist"
 msgstr "Černá listina"
 
@@ -1589,11 +1593,11 @@ msgstr "Otevřít"
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: src/app_info_ui.cpp:89
+#: src/app_info_ui.cpp:97
 msgid "paused"
 msgstr "Pozastaveno"
 
-#: src/app_info_ui.cpp:91
+#: src/app_info_ui.cpp:99
 msgid "playing"
 msgstr "Přehrává se"
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PulseEffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 22:40+0200\n"
+"POT-Creation-Date: 2020-06-13 20:34+0200\n"
 "PO-Revision-Date: 2020-01-12 17:49+0100\n"
 "Last-Translator: David Keller <blobcodes@protonmail.com>\n"
 "Language-Team: \n"
@@ -160,12 +160,16 @@ msgstr "Preset erstellen"
 msgid "Name"
 msgstr "Name"
 
-#: data/ui/blacklist_settings.glade:132
+#: data/ui/blacklist_settings.glade:85
 msgid "Reconnect the microphone to apply new changes made to the blacklist"
 msgstr ""
 
 #: data/ui/blacklist_settings.glade:239
 msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:273
+msgid "Show Blacklisted Apps in Main Tab"
 msgstr ""
 
 #: data/ui/general_settings.glade:31
@@ -248,7 +252,7 @@ msgstr "Resampler"
 msgid "State"
 msgstr "Status"
 
-#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:122
 msgid "Blacklist"
 msgstr "Sperrliste"
 
@@ -1587,11 +1591,11 @@ msgstr "Öffnen"
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: src/app_info_ui.cpp:89
+#: src/app_info_ui.cpp:97
 msgid "paused"
 msgstr "Pausiert"
 
-#: src/app_info_ui.cpp:91
+#: src/app_info_ui.cpp:99
 msgid "playing"
 msgstr "Spielt"
 

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 22:40+0200\n"
+"POT-Creation-Date: 2020-06-13 20:34+0200\n"
 "PO-Revision-Date: 2017-08-29 11:00+0200\n"
 "Last-Translator: Nathan Graule <solarliner@gmail.com>\n"
 "Language-Team: \n"
@@ -173,12 +173,16 @@ msgstr "Sauvegarder préglage"
 msgid "Name"
 msgstr ""
 
-#: data/ui/blacklist_settings.glade:132
+#: data/ui/blacklist_settings.glade:85
 msgid "Reconnect the microphone to apply new changes made to the blacklist"
 msgstr ""
 
 #: data/ui/blacklist_settings.glade:239
 msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:273
+msgid "Show Blacklisted Apps in Main Tab"
 msgstr ""
 
 #: data/ui/general_settings.glade:31
@@ -262,7 +266,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:122
 msgid "Blacklist"
 msgstr ""
 
@@ -1687,11 +1691,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Amélioration audio"
 
-#: src/app_info_ui.cpp:89
+#: src/app_info_ui.cpp:97
 msgid "paused"
 msgstr ""
 
-#: src/app_info_ui.cpp:91
+#: src/app_info_ui.cpp:99
 msgid "playing"
 msgstr ""
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PulseEffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 22:40+0200\n"
+"POT-Creation-Date: 2020-06-13 20:34+0200\n"
 "PO-Revision-Date: 2018-11-22 20:12+0200\n"
 "Last-Translator: flipwise <tyx027@gmail.com>\n"
 "Language-Team: Croatian\n"
@@ -171,12 +171,16 @@ msgstr "Stvori predložak"
 msgid "Name"
 msgstr "Naziv"
 
-#: data/ui/blacklist_settings.glade:132
+#: data/ui/blacklist_settings.glade:85
 msgid "Reconnect the microphone to apply new changes made to the blacklist"
 msgstr ""
 
 #: data/ui/blacklist_settings.glade:239
 msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:273
+msgid "Show Blacklisted Apps in Main Tab"
 msgstr ""
 
 #: data/ui/general_settings.glade:31
@@ -261,7 +265,7 @@ msgstr "Promjena frekvencije"
 msgid "State"
 msgstr "Stanje"
 
-#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:122
 msgid "Blacklist"
 msgstr "Crna lista"
 
@@ -1670,11 +1674,11 @@ msgstr "Otvori"
 msgid "Cancel"
 msgstr "Poništi"
 
-#: src/app_info_ui.cpp:89
+#: src/app_info_ui.cpp:97
 msgid "paused"
 msgstr "pauzirano"
 
-#: src/app_info_ui.cpp:91
+#: src/app_info_ui.cpp:99
 msgid "playing"
 msgstr "reprodukcija"
 

--- a/po/id_ID.po
+++ b/po/id_ID.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pulseeffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 22:40+0200\n"
+"POT-Creation-Date: 2020-06-13 20:34+0200\n"
 "PO-Revision-Date: 2019-01-17 18:30+0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -164,12 +164,16 @@ msgstr "Buat Preset"
 msgid "Name"
 msgstr "Nama"
 
-#: data/ui/blacklist_settings.glade:132
+#: data/ui/blacklist_settings.glade:85
 msgid "Reconnect the microphone to apply new changes made to the blacklist"
 msgstr ""
 
 #: data/ui/blacklist_settings.glade:239
 msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:273
+msgid "Show Blacklisted Apps in Main Tab"
 msgstr ""
 
 #: data/ui/general_settings.glade:31
@@ -252,7 +256,7 @@ msgstr "Modus Penyampling"
 msgid "State"
 msgstr "Status"
 
-#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:122
 msgid "Blacklist"
 msgstr "Daftar Blokir"
 
@@ -1606,11 +1610,11 @@ msgstr "Buka"
 msgid "Cancel"
 msgstr "Batal"
 
-#: src/app_info_ui.cpp:89
+#: src/app_info_ui.cpp:97
 msgid "paused"
 msgstr "terjeda"
 
-#: src/app_info_ui.cpp:91
+#: src/app_info_ui.cpp:99
 msgid "playing"
 msgstr "memutar"
 

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 22:40+0200\n"
+"POT-Creation-Date: 2020-06-13 20:34+0200\n"
 "PO-Revision-Date: 2019-03-28 17:38+0100\n"
 "Last-Translator: Gianluca Boiano <morf3089@gmail.com>\n"
 "Language-Team: \n"
@@ -162,7 +162,7 @@ msgstr "Crea Profilo"
 msgid "Name"
 msgstr "Nome"
 
-#: data/ui/blacklist_settings.glade:132
+#: data/ui/blacklist_settings.glade:85
 msgid "Reconnect the microphone to apply new changes made to the blacklist"
 msgstr ""
 "Riconnetti il microfono per applicare le modifiche apportate alla blacklist"
@@ -171,6 +171,10 @@ msgstr ""
 msgid "Restart the player to apply new changes made to the blacklist"
 msgstr ""
 "Riavvia il media player per applicare le modifiche apportate alla blacklist"
+
+#: data/ui/blacklist_settings.glade:273
+msgid "Show Blacklisted Apps in Main Tab"
+msgstr "Mostra Applicazioni Escluse nella Scheda Principale"
 
 #: data/ui/general_settings.glade:31
 msgid "Start Service at Login"
@@ -252,7 +256,7 @@ msgstr "Ricampionamento"
 msgid "State"
 msgstr "Stato"
 
-#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:122
 msgid "Blacklist"
 msgstr "Blacklist"
 
@@ -1589,11 +1593,11 @@ msgstr "Apri"
 msgid "Cancel"
 msgstr "Annulla"
 
-#: src/app_info_ui.cpp:89
+#: src/app_info_ui.cpp:97
 msgid "paused"
 msgstr "pausa"
 
-#: src/app_info_ui.cpp:91
+#: src/app_info_ui.cpp:99
 msgid "playing"
 msgstr "riproduzione"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PulseEffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 22:40+0200\n"
+"POT-Creation-Date: 2020-06-13 20:34+0200\n"
 "PO-Revision-Date: 2018-06-21 21:34+0200\n"
 "Last-Translator: Piotr Komur, pkomur@gmail.com\n"
 "Language-Team: \n"
@@ -166,12 +166,16 @@ msgstr "Utwórz profil"
 msgid "Name"
 msgstr "Nazwa"
 
-#: data/ui/blacklist_settings.glade:132
+#: data/ui/blacklist_settings.glade:85
 msgid "Reconnect the microphone to apply new changes made to the blacklist"
 msgstr ""
 
 #: data/ui/blacklist_settings.glade:239
 msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:273
+msgid "Show Blacklisted Apps in Main Tab"
 msgstr ""
 
 #: data/ui/general_settings.glade:31
@@ -257,7 +261,7 @@ msgstr "Resampler"
 msgid "State"
 msgstr "Stan"
 
-#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:122
 msgid "Blacklist"
 msgstr ""
 
@@ -1653,11 +1657,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Balans"
 
-#: src/app_info_ui.cpp:89
+#: src/app_info_ui.cpp:97
 msgid "paused"
 msgstr "zatrzymany"
 
-#: src/app_info_ui.cpp:91
+#: src/app_info_ui.cpp:99
 msgid "playing"
 msgstr "gra"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PulseEffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 22:40+0200\n"
+"POT-Creation-Date: 2020-06-13 20:34+0200\n"
 "PO-Revision-Date: 2019-09-10 12:56-0300\n"
 "Last-Translator: Patrik Nilsson <translation_AT_hembas.se>\n"
 "Language-Team: Portuguese <>\n"
@@ -163,12 +163,16 @@ msgstr "Criar Predefinição"
 msgid "Name"
 msgstr "Nome"
 
-#: data/ui/blacklist_settings.glade:132
+#: data/ui/blacklist_settings.glade:85
 msgid "Reconnect the microphone to apply new changes made to the blacklist"
 msgstr ""
 
 #: data/ui/blacklist_settings.glade:239
 msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:273
+msgid "Show Blacklisted Apps in Main Tab"
 msgstr ""
 
 #: data/ui/general_settings.glade:31
@@ -251,7 +255,7 @@ msgstr "Resampler"
 msgid "State"
 msgstr "Estado"
 
-#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:122
 msgid "Blacklist"
 msgstr "Lista Negra"
 
@@ -1591,11 +1595,11 @@ msgstr "Abrir"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/app_info_ui.cpp:89
+#: src/app_info_ui.cpp:97
 msgid "paused"
 msgstr "pausado"
 
-#: src/app_info_ui.cpp:91
+#: src/app_info_ui.cpp:99
 msgid "playing"
 msgstr "tocando"
 

--- a/po/pulseeffects.pot
+++ b/po/pulseeffects.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pulseeffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 22:40+0200\n"
+"POT-Creation-Date: 2020-06-13 20:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -159,12 +159,16 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: data/ui/blacklist_settings.glade:132
+#: data/ui/blacklist_settings.glade:85
 msgid "Reconnect the microphone to apply new changes made to the blacklist"
 msgstr ""
 
 #: data/ui/blacklist_settings.glade:239
 msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:273
+msgid "Show Blacklisted Apps in Main Tab"
 msgstr ""
 
 #: data/ui/general_settings.glade:31
@@ -247,7 +251,7 @@ msgstr ""
 msgid "State"
 msgstr ""
 
-#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:122
 msgid "Blacklist"
 msgstr ""
 
@@ -1569,11 +1573,11 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/app_info_ui.cpp:89
+#: src/app_info_ui.cpp:97
 msgid "paused"
 msgstr ""
 
-#: src/app_info_ui.cpp:91
+#: src/app_info_ui.cpp:99
 msgid "playing"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 22:40+0200\n"
+"POT-Creation-Date: 2020-06-13 20:34+0200\n"
 "PO-Revision-Date: 2018-07-18 22:14+0300\n"
 "Last-Translator: Mikhail Novosyolov <mikhailnov@dumalogiya.ru>\n"
 "Language-Team: \n"
@@ -164,12 +164,16 @@ msgstr "Создать новый набор предустановок"
 msgid "Name"
 msgstr "Название"
 
-#: data/ui/blacklist_settings.glade:132
+#: data/ui/blacklist_settings.glade:85
 msgid "Reconnect the microphone to apply new changes made to the blacklist"
 msgstr ""
 
 #: data/ui/blacklist_settings.glade:239
 msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:273
+msgid "Show Blacklisted Apps in Main Tab"
 msgstr ""
 
 #: data/ui/general_settings.glade:31
@@ -252,7 +256,7 @@ msgstr "Ресемплер"
 msgid "State"
 msgstr "Состояние"
 
-#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:122
 msgid "Blacklist"
 msgstr "Черный список"
 
@@ -1622,11 +1626,11 @@ msgstr "Открыть"
 msgid "Cancel"
 msgstr "Отмена"
 
-#: src/app_info_ui.cpp:89
+#: src/app_info_ui.cpp:97
 msgid "paused"
 msgstr "на паузе"
 
-#: src/app_info_ui.cpp:91
+#: src/app_info_ui.cpp:99
 msgid "playing"
 msgstr "воспроизводится"
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 22:40+0200\n"
+"POT-Creation-Date: 2020-06-13 20:34+0200\n"
 "PO-Revision-Date: 2019-09-07 22:19+0200\n"
 "Last-Translator: Mlocik97\n"
 "Language-Team: \n"
@@ -171,12 +171,16 @@ msgstr "Vytvoriť Predvoľbu"
 msgid "Name"
 msgstr "Názov"
 
-#: data/ui/blacklist_settings.glade:132
+#: data/ui/blacklist_settings.glade:85
 msgid "Reconnect the microphone to apply new changes made to the blacklist"
 msgstr ""
 
 #: data/ui/blacklist_settings.glade:239
 msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:273
+msgid "Show Blacklisted Apps in Main Tab"
 msgstr ""
 
 #: data/ui/general_settings.glade:31
@@ -261,7 +265,7 @@ msgstr "Prevzorkovač"
 msgid "State"
 msgstr "Stav"
 
-#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:122
 msgid "Blacklist"
 msgstr "Čierny List"
 
@@ -1654,11 +1658,11 @@ msgstr "Otvoriť"
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: src/app_info_ui.cpp:89
+#: src/app_info_ui.cpp:97
 msgid "paused"
 msgstr "pozastavené"
 
-#: src/app_info_ui.cpp:91
+#: src/app_info_ui.cpp:99
 msgid "playing"
 msgstr "hrá"
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-28 22:40+0200\n"
+"POT-Creation-Date: 2020-06-13 20:34+0200\n"
 "PO-Revision-Date: 2017-10-14 10:20+0200\n"
 "Last-Translator: Patrik Nilsson <translation_AT_hembas.se>\n"
 "Language-Team: \n"
@@ -171,12 +171,16 @@ msgstr "Ta bort profil"
 msgid "Name"
 msgstr "Namn"
 
-#: data/ui/blacklist_settings.glade:132
+#: data/ui/blacklist_settings.glade:85
 msgid "Reconnect the microphone to apply new changes made to the blacklist"
 msgstr ""
 
 #: data/ui/blacklist_settings.glade:239
 msgid "Restart the player to apply new changes made to the blacklist"
+msgstr ""
+
+#: data/ui/blacklist_settings.glade:273
+msgid "Show Blacklisted Apps in Main Tab"
 msgstr ""
 
 #: data/ui/general_settings.glade:31
@@ -260,7 +264,7 @@ msgstr "Resampler"
 msgid "State"
 msgstr ""
 
-#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:95
+#: data/ui/app_info.glade:323 src/blacklist_settings_ui.cpp:122
 msgid "Blacklist"
 msgstr ""
 
@@ -1691,11 +1695,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Ljudförstärkare"
 
-#: src/app_info_ui.cpp:89
+#: src/app_info_ui.cpp:97
 msgid "paused"
 msgstr ""
 
-#: src/app_info_ui.cpp:91
+#: src/app_info_ui.cpp:99
 msgid "playing"
 msgstr ""
 

--- a/src/effects_base_ui.cpp
+++ b/src/effects_base_ui.cpp
@@ -45,25 +45,6 @@ EffectsBaseUi::~EffectsBaseUi() {
   }
 }
 
-void EffectsBaseUi::on_app_added(std::shared_ptr<AppInfo> app_info) {
-  for (const auto& a : apps_list) {
-    if (a->app_info->index == app_info->index) {
-      // do not add the same app two times in the interface
-      return;
-    }
-  }
-
-  auto builder = Gtk::Builder::create_from_resource("/com/github/wwmm/pulseeffects/ui/app_info.glade");
-
-  AppInfoUi* appui = nullptr;
-
-  builder->get_widget_derived("widgets_grid", appui, app_info, pm);
-
-  apps_box->add(*appui);
-
-  apps_list.emplace_back(appui);
-}
-
 void EffectsBaseUi::on_app_changed(const std::shared_ptr<AppInfo>& app_info) {
   for (auto it = apps_list.begin(); it != apps_list.end(); it++) {
     auto n = it - apps_list.begin();

--- a/src/pulse_manager.cpp
+++ b/src/pulse_manager.cpp
@@ -769,7 +769,7 @@ void PulseManager::find_sources() {
   pa_threaded_mainloop_unlock(main_loop);
 }
 
-void PulseManager::move_sink_input_to_pulseeffects(const std::string& name, uint idx) {
+auto PulseManager::move_sink_input_to_pulseeffects(const std::string& name, uint idx) -> bool {
   struct Data {
     std::string name;
     uint idx;
@@ -777,6 +777,8 @@ void PulseManager::move_sink_input_to_pulseeffects(const std::string& name, uint
   };
 
   Data data = {name, idx, this};
+
+  bool added_successfully = false;
 
   pa_threaded_mainloop_lock(main_loop);
 
@@ -802,14 +804,18 @@ void PulseManager::move_sink_input_to_pulseeffects(const std::string& name, uint
     }
 
     pa_operation_unref(o);
+
+    added_successfully = true;
   } else {
     util::critical(log_tag + "failed to move sink input: " + name + ", idx = " + std::to_string(idx) + " to PE");
   }
 
   pa_threaded_mainloop_unlock(main_loop);
+
+  return added_successfully;
 }
 
-void PulseManager::remove_sink_input_from_pulseeffects(const std::string& name, uint idx) {
+auto PulseManager::remove_sink_input_from_pulseeffects(const std::string& name, uint idx) -> bool {
   struct Data {
     std::string name;
     uint idx;
@@ -817,6 +823,8 @@ void PulseManager::remove_sink_input_from_pulseeffects(const std::string& name, 
   };
 
   Data data = {name, idx, this};
+
+  bool removed_successfully = false;
 
   pa_threaded_mainloop_lock(main_loop);
 
@@ -843,14 +851,18 @@ void PulseManager::remove_sink_input_from_pulseeffects(const std::string& name, 
     }
 
     pa_operation_unref(o);
+
+    removed_successfully = true;
   } else {
     util::critical(log_tag + "failed to remove sink input: " + name + ", idx = " + std::to_string(idx) + " from PE");
   }
 
   pa_threaded_mainloop_unlock(main_loop);
+
+  return removed_successfully;
 }
 
-void PulseManager::move_source_output_to_pulseeffects(const std::string& name, uint idx) {
+auto PulseManager::move_source_output_to_pulseeffects(const std::string& name, uint idx) -> bool {
   struct Data {
     std::string name;
     uint idx;
@@ -858,6 +870,8 @@ void PulseManager::move_source_output_to_pulseeffects(const std::string& name, u
   };
 
   Data data = {name, idx, this};
+
+  bool added_successfully = false;
 
   pa_threaded_mainloop_lock(main_loop);
 
@@ -883,14 +897,18 @@ void PulseManager::move_source_output_to_pulseeffects(const std::string& name, u
     }
 
     pa_operation_unref(o);
+
+    added_successfully = true;
   } else {
     util::critical(log_tag + "failed to move source output: " + name + ", idx = " + std::to_string(idx) + " to PE");
   }
 
   pa_threaded_mainloop_unlock(main_loop);
+
+  return added_successfully;
 }
 
-void PulseManager::remove_source_output_from_pulseeffects(const std::string& name, uint idx) {
+auto PulseManager::remove_source_output_from_pulseeffects(const std::string& name, uint idx) -> bool {
   struct Data {
     std::string name;
     uint idx;
@@ -898,6 +916,8 @@ void PulseManager::remove_source_output_from_pulseeffects(const std::string& nam
   };
 
   Data data = {name, idx, this};
+
+  bool removed_successfully = false;
 
   pa_threaded_mainloop_lock(main_loop);
 
@@ -922,11 +942,15 @@ void PulseManager::remove_source_output_from_pulseeffects(const std::string& nam
     }
 
     pa_operation_unref(o);
+
+    removed_successfully = true;
   } else {
     util::critical(log_tag + "failed to remove source output: " + name + ", idx = " + std::to_string(idx) + " from PE");
   }
 
   pa_threaded_mainloop_unlock(main_loop);
+
+  return removed_successfully;
 }
 
 void PulseManager::set_sink_input_volume(const std::string& name, uint idx, uint8_t channels, uint value) {

--- a/src/sink_input_effects.cpp
+++ b/src/sink_input_effects.cpp
@@ -173,7 +173,7 @@ SinkInputEffects::~SinkInputEffects() {
 void SinkInputEffects::on_app_added(const std::shared_ptr<AppInfo>& app_info) {
   PipelineBase::on_app_added(app_info);
 
-  bool forbidden_app = false;
+  bool forbidden_app = false, success = false;
   auto* blacklist = g_settings_get_strv(settings, "blacklist-out");
 
   for (std::size_t i = 0; blacklist[i] != nullptr; i++) {
@@ -186,13 +186,21 @@ void SinkInputEffects::on_app_added(const std::shared_ptr<AppInfo>& app_info) {
 
   if (app_info->connected) {
     if (forbidden_app) {
-      pm->remove_sink_input_from_pulseeffects(app_info->name, app_info->index);
+      success = pm->remove_sink_input_from_pulseeffects(app_info->name, app_info->index);
+
+      if (success) {
+        app_info->connected = false;
+      }
     }
   } else {
     auto enable_all = g_settings_get_boolean(settings, "enable-all-sinkinputs");
 
     if (!forbidden_app && enable_all != 0) {
-      pm->move_sink_input_to_pulseeffects(app_info->name, app_info->index);
+      success = pm->move_sink_input_to_pulseeffects(app_info->name, app_info->index);
+
+      if (success) {
+        app_info->connected = true;
+      }
     }
   }
 

--- a/src/sink_input_effects_ui.cpp
+++ b/src/sink_input_effects_ui.cpp
@@ -137,6 +137,39 @@ auto SinkInputEffectsUi::add_to_stack(Gtk::Stack* stack, SinkInputEffects* sie_p
   return ui;
 }
 
+void SinkInputEffectsUi::on_app_added(std::shared_ptr<AppInfo> app_info) {
+  // Blacklist check
+  auto forbidden_app = BlacklistSettingsUi::app_is_blacklisted(app_info->name, PresetType::output);
+
+  if (forbidden_app) {
+    app_info->visible = BlacklistSettingsUi::get_blacklisted_apps_visibility();
+
+    if (!app_info->visible) {
+        return;
+    }
+  } else {
+    app_info->visible = true;
+  }
+
+  // Duplicate entry check
+  for (const auto& a : apps_list) {
+    if (a->app_info->index == app_info->index) {
+      // do not add the same app two times in the interface
+      return;
+    }
+  }
+
+  auto builder = Gtk::Builder::create_from_resource("/com/github/wwmm/pulseeffects/ui/app_info.glade");
+
+  AppInfoUi* appui = nullptr;
+
+  builder->get_widget_derived("widgets_grid", appui, app_info, pm);
+
+  apps_box->add(*appui);
+
+  apps_list.emplace_back(appui);
+}
+
 void SinkInputEffectsUi::level_meters_connections() {
   // limiter level meters connections
 

--- a/src/source_output_effects.cpp
+++ b/src/source_output_effects.cpp
@@ -123,7 +123,7 @@ SourceOutputEffects::~SourceOutputEffects() {
 void SourceOutputEffects::on_app_added(const std::shared_ptr<AppInfo>& app_info) {
   PipelineBase::on_app_added(app_info);
 
-  bool forbidden_app = false;
+  bool forbidden_app = false, success = false;
   auto* blacklist = g_settings_get_strv(settings, "blacklist-in");
 
   for (std::size_t i = 0; blacklist[i] != nullptr; i++) {
@@ -136,13 +136,21 @@ void SourceOutputEffects::on_app_added(const std::shared_ptr<AppInfo>& app_info)
 
   if (app_info->connected) {
     if (forbidden_app) {
-      pm->remove_source_output_from_pulseeffects(app_info->name, app_info->index);
+      success = pm->remove_source_output_from_pulseeffects(app_info->name, app_info->index);
+
+      if (success) {
+        app_info->connected = false;
+      }
     }
   } else {
     auto enable_all = g_settings_get_boolean(settings, "enable-all-sourceoutputs");
 
     if (!forbidden_app && (enable_all != 0)) {
-      pm->move_source_output_to_pulseeffects(app_info->name, app_info->index);
+      success = pm->move_source_output_to_pulseeffects(app_info->name, app_info->index);
+
+      if (success) {
+        app_info->connected = true;
+      }
     }
   }
 

--- a/src/source_output_effects_ui.cpp
+++ b/src/source_output_effects_ui.cpp
@@ -112,6 +112,39 @@ auto SourceOutputEffectsUi::add_to_stack(Gtk::Stack* stack, SourceOutputEffects*
   return ui;
 }
 
+void SourceOutputEffectsUi::on_app_added(std::shared_ptr<AppInfo> app_info) {
+  // Blacklist check
+  auto forbidden_app = BlacklistSettingsUi::app_is_blacklisted(app_info->name, PresetType::input);
+
+  if (forbidden_app) {
+    app_info->visible = BlacklistSettingsUi::get_blacklisted_apps_visibility();
+
+    if (!app_info->visible) {
+        return;
+    }
+  } else {
+    app_info->visible = true;
+  }
+
+  // Duplicate entry check
+  for (const auto& a : apps_list) {
+    if (a->app_info->index == app_info->index) {
+      // do not add the same app two times in the interface
+      return;
+    }
+  }
+
+  auto builder = Gtk::Builder::create_from_resource("/com/github/wwmm/pulseeffects/ui/app_info.glade");
+
+  AppInfoUi* appui = nullptr;
+
+  builder->get_widget_derived("widgets_grid", appui, app_info, pm);
+
+  apps_box->add(*appui);
+
+  apps_list.emplace_back(appui);
+}
+
 void SourceOutputEffectsUi::level_meters_connections() {
   // limiter level meters connections
 


### PR DESCRIPTION
Added a switch to show/hide blacklisted apps in Applications List.

Other things fixed, blacklist management methods made static, updated Italian translation and Spectrum config UI centered vertically like other config tabs.

Successfully compiled and tested on my system.

@wwmm, this needs to be installed overriding existing files otherwise new gsetting config won't be detected.