### PR TITLE
Various optimizations

### DIFF
--- a/include/blacklist_settings_ui.hpp
+++ b/include/blacklist_settings_ui.hpp
@@ -40,12 +40,16 @@ class BlacklistSettingsUi : public Gtk::Grid {
   Gtk::Entry *blacklist_in_name = nullptr, *blacklist_out_name = nullptr;
   Gtk::ScrolledWindow *blacklist_in_scrolled_window = nullptr, *blacklist_out_scrolled_window = nullptr;
 
+  Glib::RefPtr<Gio::Settings> settings;
+
+  // singleton pointer used to access settings from static methods
+  // needed because Gio::Settings instance can't be made static
+  static BlacklistSettingsUi* thisPtr;
+
   static std::vector<sigc::connection> connections;
 
   static void populate_blacklist_in_listbox();
-
   static void populate_blacklist_out_listbox();
-
   static auto on_listbox_sort(Gtk::ListBoxRow* row1, Gtk::ListBoxRow* row2) -> int;
 };
 

--- a/include/pipeline_common.hpp
+++ b/include/pipeline_common.hpp
@@ -77,7 +77,7 @@ auto check_update(gpointer user_data) -> bool {
   if (update) {
     std::string list;
 
-    for (auto name : l->plugins_order) {
+    for (const auto& name : l->plugins_order) {
       list += name + ",";
     }
 

--- a/src/application_ui.cpp
+++ b/src/application_ui.cpp
@@ -126,7 +126,7 @@ ApplicationUi::ApplicationUi(BaseObjectType* cobject,
 }
 
 ApplicationUi::~ApplicationUi() {
-  for (auto c : connections) {
+  for (auto& c : connections) {
     c.disconnect();
   }
 

--- a/src/blacklist_settings_ui.cpp
+++ b/src/blacklist_settings_ui.cpp
@@ -215,7 +215,7 @@ void BlacklistSettingsUi::populate_blacklist_out_listbox() {
 
   auto children = blacklist_out_listbox->get_children();
 
-  for (auto* c : children) {
+  for (const auto& c : children) {
     blacklist_out_listbox->remove(*c);
   }
 

--- a/src/blacklist_settings_ui.cpp
+++ b/src/blacklist_settings_ui.cpp
@@ -54,7 +54,7 @@ BlacklistSettingsUi::BlacklistSettingsUi(BaseObjectType* cobject, const Glib::Re
 }
 
 BlacklistSettingsUi::~BlacklistSettingsUi() {
-  for (auto c : connections) {
+  for (auto& c : connections) {
     c.disconnect();
   }
 

--- a/src/convolver_ui.cpp
+++ b/src/convolver_ui.cpp
@@ -220,7 +220,7 @@ auto ConvolverUi::on_listbox_sort(Gtk::ListBoxRow* row1, Gtk::ListBoxRow* row2) 
 void ConvolverUi::populate_irs_listbox() {
   auto children = irs_listbox->get_children();
 
-  for (auto c : children) {
+  for (const auto& c : children) {
     irs_listbox->remove(*c);
   }
 

--- a/src/crystalizer_ui.cpp
+++ b/src/crystalizer_ui.cpp
@@ -69,7 +69,7 @@ void CrystalizerUi::reset() {
 }
 
 void CrystalizerUi::build_bands(const int& nbands) {
-  for (auto c : bands_grid->get_children()) {
+  for (const auto& c : bands_grid->get_children()) {
     bands_grid->remove(*c);
 
     delete c;

--- a/src/effects_base_ui.cpp
+++ b/src/effects_base_ui.cpp
@@ -40,7 +40,7 @@ EffectsBaseUi::EffectsBaseUi(const Glib::RefPtr<Gtk::Builder>& builder,
 }
 
 EffectsBaseUi::~EffectsBaseUi() {
-  for (auto c : connections) {
+  for (auto& c : connections) {
     c.disconnect();
   }
 }

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -225,7 +225,7 @@ EqualizerUi::EqualizerUi(BaseObjectType* cobject,
   presets_listbox->set_sort_func(sigc::ptr_fun(&EqualizerUi::on_listbox_sort));
 
   connections.emplace_back(settings->signal_changed("split-channels").connect([&](auto key) {
-    for (auto c : connections_bands) {
+    for (auto& c : connections_bands) {
       c.disconnect();
     }
 
@@ -262,7 +262,7 @@ EqualizerUi::EqualizerUi(BaseObjectType* cobject,
 }
 
 EqualizerUi::~EqualizerUi() {
-  for (auto c : connections_bands) {
+  for (auto& c : connections_bands) {
     c.disconnect();
   }
 
@@ -270,7 +270,7 @@ EqualizerUi::~EqualizerUi() {
 }
 
 void EqualizerUi::on_nbands_changed() {
-  for (auto c : connections_bands) {
+  for (auto& c : connections_bands) {
     c.disconnect();
   }
 

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -287,7 +287,7 @@ void EqualizerUi::on_nbands_changed() {
 }
 
 void EqualizerUi::build_bands(Gtk::Grid* bands_grid, const Glib::RefPtr<Gio::Settings>& cfg, const int& nbands) {
-  for (auto* c : bands_grid->get_children()) {
+  for (const auto& c : bands_grid->get_children()) {
     bands_grid->remove(*c);
 
     delete c;
@@ -405,13 +405,13 @@ void EqualizerUi::build_bands(Gtk::Grid* bands_grid, const Glib::RefPtr<Gio::Set
 }
 
 void EqualizerUi::build_unified_bands(const int& nbands) {
-  for (auto c : bands_grid_left->get_children()) {
+  for (const auto& c : bands_grid_left->get_children()) {
     bands_grid_left->remove(*c);
 
     delete c;
   }
 
-  for (auto* c : bands_grid_right->get_children()) {
+  for (const auto& c : bands_grid_right->get_children()) {
     bands_grid_right->remove(*c);
 
     delete c;
@@ -716,7 +716,7 @@ auto EqualizerUi::on_listbox_sort(Gtk::ListBoxRow* row1, Gtk::ListBoxRow* row2) 
 void EqualizerUi::populate_presets_listbox() {
   auto children = presets_listbox->get_children();
 
-  for (auto* c : children) {
+  for (const auto& c : children) {
     presets_listbox->remove(*c);
   }
 

--- a/src/general_settings_ui.cpp
+++ b/src/general_settings_ui.cpp
@@ -107,7 +107,7 @@ GeneralSettingsUi::GeneralSettingsUi(BaseObjectType* cobject,
 }
 
 GeneralSettingsUi::~GeneralSettingsUi() {
-  for (auto c : connections) {
+  for (auto& c : connections) {
     c.disconnect();
   }
 

--- a/src/plugin_ui_base.cpp
+++ b/src/plugin_ui_base.cpp
@@ -35,7 +35,7 @@ PluginUiBase::PluginUiBase(const Glib::RefPtr<Gtk::Builder>& builder, const std:
 }
 
 PluginUiBase::~PluginUiBase() {
-  for (auto c : connections) {
+  for (auto& c : connections) {
     c.disconnect();
   }
 

--- a/src/presets_menu_ui.cpp
+++ b/src/presets_menu_ui.cpp
@@ -40,7 +40,7 @@ PresetsMenuUi::PresetsMenuUi(BaseObjectType* cobject,
 }
 
 PresetsMenuUi::~PresetsMenuUi() {
-  for (auto c : connections) {
+  for (auto& c : connections) {
     c.disconnect();
   }
 

--- a/src/pulse_info_ui.cpp
+++ b/src/pulse_info_ui.cpp
@@ -81,7 +81,7 @@ PulseInfoUi::PulseInfoUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builde
 }
 
 PulseInfoUi::~PulseInfoUi() {
-  for (auto c : connections) {
+  for (auto& c : connections) {
     c.disconnect();
   }
 

--- a/src/pulse_settings_ui.cpp
+++ b/src/pulse_settings_ui.cpp
@@ -132,7 +132,7 @@ PulseSettingsUi::PulseSettingsUi(BaseObjectType* cobject,
 }
 
 PulseSettingsUi::~PulseSettingsUi() {
-  for (auto c : connections) {
+  for (auto& c : connections) {
     c.disconnect();
   }
 

--- a/src/spectrum_settings_ui.cpp
+++ b/src/spectrum_settings_ui.cpp
@@ -128,7 +128,7 @@ SpectrumSettingsUi::SpectrumSettingsUi(BaseObjectType* cobject,
 }
 
 SpectrumSettingsUi::~SpectrumSettingsUi() {
-  for (auto c : connections) {
+  for (auto& c : connections) {
     c.disconnect();
   }
 

--- a/src/spectrum_ui.cpp
+++ b/src/spectrum_ui.cpp
@@ -40,7 +40,7 @@ SpectrumUi::SpectrumUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>
 }
 
 SpectrumUi::~SpectrumUi() {
-  for (auto c : connections) {
+  for (auto& c : connections) {
     c.disconnect();
   }
 


### PR DESCRIPTION
Implemented a pointer to BlacklistSettingUI for accessing settings local attribute from static methods avoiding to construct and deconstruct the object every time the static method is accessed. The `g_object_set_qdata_full` issue is not showing.

Other optimizations on references in loops.

Successfully compiled and tested.