### PR TITLE
New parameters in Limiter and Gate

### DIFF
--- a/data/schemas/com.github.wwmm.pulseeffects.sinkinputs.gate.gschema.xml
+++ b/data/schemas/com.github.wwmm.pulseeffects.sinkinputs.gate.gschema.xml
@@ -44,6 +44,10 @@
             <range min="0" max="18"/>
             <default>9</default>
         </key>
+        <key name="input" type="d">
+            <range min="-36" max="36"/>
+            <default>0.0</default>
+        </key>
         <key name="makeup" type="d">
             <range min="0" max="36"/>
             <default>0.0</default>

--- a/data/schemas/com.github.wwmm.pulseeffects.sinkinputs.limiter.gschema.xml
+++ b/data/schemas/com.github.wwmm.pulseeffects.sinkinputs.limiter.gschema.xml
@@ -13,11 +13,15 @@
             <default>true</default>
         </key>
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1"/>
+            <range min="-36.0" max="36.0"/>
+            <default>0.0</default>
+        </key>
+        <key name="output-gain" type="d">
+            <range min="-36.0" max="36.0"/>
             <default>0.0</default>
         </key>
         <key name="limit" type="d">
-            <range min="-24.1" max="0.0"/>
+            <range min="-24.0" max="0.0"/>
             <default>0.0</default>
         </key>
         <key name="lookahead" type="d">
@@ -27,6 +31,9 @@
         <key name="release" type="d">
             <range min="1" max="1000"/>
             <default>50.0</default>
+        </key>
+        <key name="auto-level" type="b">
+          <default>false</default>
         </key>
         <key name="asc" type="b">
             <default>false</default>

--- a/data/schemas/com.github.wwmm.pulseeffects.sourceoutputs.gate.gschema.xml
+++ b/data/schemas/com.github.wwmm.pulseeffects.sourceoutputs.gate.gschema.xml
@@ -44,6 +44,10 @@
             <range min="0" max="18"/>
             <default>9</default>
         </key>
+        <key name="input" type="d">
+            <range min="-36" max="36"/>
+            <default>0.0</default>
+        </key>
         <key name="makeup" type="d">
             <range min="0" max="36"/>
             <default>0.0</default>

--- a/data/schemas/com.github.wwmm.pulseeffects.sourceoutputs.limiter.gschema.xml
+++ b/data/schemas/com.github.wwmm.pulseeffects.sourceoutputs.limiter.gschema.xml
@@ -13,11 +13,15 @@
             <default>true</default>
         </key>
         <key name="input-gain" type="d">
-            <range min="-36.1" max="36.1"/>
+            <range min="-36.0" max="36.0"/>
+            <default>0.0</default>
+        </key>
+        <key name="output-gain" type="d">
+            <range min="-36.0" max="36.0"/>
             <default>0.0</default>
         </key>
         <key name="limit" type="d">
-            <range min="-24.1" max="0.0"/>
+            <range min="-24.0" max="0.0"/>
             <default>0.0</default>
         </key>
         <key name="lookahead" type="d">
@@ -27,6 +31,9 @@
         <key name="release" type="d">
             <range min="1" max="1000"/>
             <default>50.0</default>
+        </key>
+        <key name="auto-level" type="b">
+          <default>false</default>
         </key>
         <key name="asc" type="b">
             <default>false</default>
@@ -38,25 +45,6 @@
         <key name="oversampling" type="i">
             <range min="1" max="4"/>
             <default>1</default>
-        </key>
-        <key name="autovolume-state" type="b">
-            <default>false</default>
-        </key>
-        <key name="autovolume-window" type="d">
-            <range min="1" max="1000"/>
-            <default>1000.00</default>
-        </key>
-        <key name="autovolume-target" type="i">
-            <range min="-99" max="-4"/>
-            <default>-12</default>
-        </key>
-        <key name="autovolume-tolerance" type="i">
-            <range min="1" max="4"/>
-            <default>1</default>
-        </key>
-        <key name="autovolume-threshold" type="i">
-            <range min="-99" max="0"/>
-            <default>-50</default>
         </key>
     </schema>
 </schemalist>

--- a/data/ui/crossfeed.glade
+++ b/data/ui/crossfeed.glade
@@ -45,13 +45,15 @@
                 <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="label" translatable="yes">Presets</property>
+                <property name="justify">center</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
               </object>
               <packing>
-                <property name="left_attach">1</property>
+                <property name="left_attach">0</property>
                 <property name="top_attach">0</property>
+                <property name="width">3</property>
               </packing>
             </child>
             <child>
@@ -92,12 +94,6 @@
                 <property name="left_attach">0</property>
                 <property name="top_attach">1</property>
               </packing>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
             </child>
           </object>
           <packing>
@@ -198,7 +194,6 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -213,12 +208,11 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
                 <property name="height">2</property>
               </packing>
             </child>
@@ -240,6 +234,7 @@
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">0</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
@@ -259,7 +254,7 @@
               <packing>
                 <property name="left_attach">3</property>
                 <property name="top_attach">0</property>
-                <property name="height">4</property>
+                <property name="height">5</property>
               </packing>
             </child>
             <child>
@@ -268,6 +263,7 @@
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">1</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
@@ -299,7 +295,7 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
               </packing>
             </child>
             <child>
@@ -311,7 +307,7 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">3</property>
+                <property name="top_attach">4</property>
               </packing>
             </child>
             <child>
@@ -319,13 +315,15 @@
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">0</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
                 <property name="height">2</property>
               </packing>
             </child>
@@ -334,14 +332,41 @@
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">1</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
               </object>
               <packing>
                 <property name="left_attach">4</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
                 <property name="height">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">6</property>
+                <property name="activate_on_single_click">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">4</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">6</property>
+                <property name="activate_on_single_click">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+                <property name="width">3</property>
               </packing>
             </child>
           </object>

--- a/data/ui/deesser.glade
+++ b/data/ui/deesser.glade
@@ -564,7 +564,6 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -579,12 +578,11 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
                 <property name="height">2</property>
               </packing>
             </child>
@@ -606,6 +604,7 @@
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">0</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
@@ -625,7 +624,7 @@
               <packing>
                 <property name="left_attach">3</property>
                 <property name="top_attach">0</property>
-                <property name="height">4</property>
+                <property name="height">5</property>
               </packing>
             </child>
             <child>
@@ -634,6 +633,7 @@
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">1</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
@@ -665,7 +665,7 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
               </packing>
             </child>
             <child>
@@ -677,7 +677,7 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">3</property>
+                <property name="top_attach">4</property>
               </packing>
             </child>
             <child>
@@ -685,13 +685,15 @@
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">0</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
                 <property name="height">2</property>
               </packing>
             </child>
@@ -700,13 +702,15 @@
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">1</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
               </object>
               <packing>
                 <property name="left_attach">4</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
                 <property name="height">2</property>
               </packing>
             </child>
@@ -715,12 +719,11 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
-                <property name="margin_top">4</property>
                 <property name="hexpand">True</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">5</property>
+                <property name="top_attach">8</property>
               </packing>
             </child>
             <child>
@@ -728,13 +731,15 @@
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">0</property>
                 <property name="width_chars">2</property>
                 <property name="max_width_chars">2</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
-                <property name="top_attach">5</property>
+                <property name="top_attach">8</property>
                 <property name="width">3</property>
               </packing>
             </child>
@@ -744,12 +749,11 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Reduction</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">5</property>
+                <property name="top_attach">8</property>
               </packing>
             </child>
             <child>
@@ -758,12 +762,11 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Detected</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">4</property>
+                <property name="top_attach">6</property>
               </packing>
             </child>
             <child>
@@ -771,12 +774,11 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
-                <property name="margin_top">4</property>
                 <property name="hexpand">True</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">4</property>
+                <property name="top_attach">6</property>
               </packing>
             </child>
             <child>
@@ -784,14 +786,67 @@
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">0</property>
                 <property name="width_chars">2</property>
                 <property name="max_width_chars">2</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
-                <property name="top_attach">4</property>
+                <property name="top_attach">6</property>
                 <property name="width">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">6</property>
+                <property name="activate_on_single_click">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">4</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">6</property>
+                <property name="activate_on_single_click">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+                <property name="width">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">6</property>
+                <property name="activate_on_single_click">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">5</property>
+                <property name="width">5</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">6</property>
+                <property name="activate_on_single_click">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">7</property>
+                <property name="width">5</property>
               </packing>
             </child>
           </object>

--- a/data/ui/gate.glade
+++ b/data/ui/gate.glade
@@ -527,8 +527,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
-                <property name="valign">end</property>
-                <property name="margin_end">3</property>
+                <property name="valign">center</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -542,13 +541,12 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
-                <property name="valign">end</property>
-                <property name="margin_end">3</property>
+                <property name="valign">center</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
                 <property name="height">2</property>
               </packing>
             </child>
@@ -570,7 +568,7 @@
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
-                <property name="valign">end</property>
+                <property name="valign">center</property>
                 <property name="label">0</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
@@ -590,7 +588,7 @@
               <packing>
                 <property name="left_attach">3</property>
                 <property name="top_attach">0</property>
-                <property name="height">4</property>
+                <property name="height">5</property>
               </packing>
             </child>
             <child>
@@ -599,7 +597,7 @@
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
-                <property name="valign">end</property>
+                <property name="valign">center</property>
                 <property name="label">1</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
@@ -627,12 +625,11 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
-                <property name="margin_top">4</property>
                 <property name="hexpand">True</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
               </packing>
             </child>
             <child>
@@ -644,7 +641,7 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">3</property>
+                <property name="top_attach">4</property>
               </packing>
             </child>
             <child>
@@ -652,14 +649,15 @@
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
-                <property name="valign">end</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">0</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
                 <property name="height">2</property>
               </packing>
             </child>
@@ -668,14 +666,15 @@
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
-                <property name="valign">end</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">1</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
               </object>
               <packing>
                 <property name="left_attach">4</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
                 <property name="height">2</property>
               </packing>
             </child>
@@ -684,12 +683,12 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
-                <property name="margin_top">8</property>
+                <property name="margin_top">1</property>
                 <property name="hexpand">True</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">4</property>
+                <property name="top_attach">6</property>
               </packing>
             </child>
             <child>
@@ -697,15 +696,15 @@
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
-                <property name="valign">end</property>
-                <property name="margin_top">4</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">0</property>
                 <property name="width_chars">2</property>
                 <property name="max_width_chars">2</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
-                <property name="top_attach">4</property>
+                <property name="top_attach">6</property>
                 <property name="width">3</property>
               </packing>
             </child>
@@ -714,14 +713,50 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
-                <property name="valign">end</property>
-                <property name="margin_end">3</property>
-                <property name="margin_top">4</property>
+                <property name="valign">center</property>
                 <property name="label" translatable="yes">Gating</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">4</property>
+                <property name="top_attach">6</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">6</property>
+                <property name="activate_on_single_click">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+                <property name="width">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">6</property>
+                <property name="activate_on_single_click">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">5</property>
+                <property name="width">5</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">6</property>
+                <property name="activate_on_single_click">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">4</property>
+                <property name="top_attach">2</property>
               </packing>
             </child>
           </object>

--- a/data/ui/gate.glade
+++ b/data/ui/gate.glade
@@ -7,7 +7,7 @@
     <property name="upper">2000</property>
     <property name="value">20</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.01</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkImage" id="image1">
     <property name="visible">True</property>
@@ -87,11 +87,17 @@
       </packing>
     </child>
   </object>
+  <object class="GtkAdjustment" id="input">
+    <property name="lower">-36</property>
+    <property name="upper">36</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">1</property>
+  </object>
   <object class="GtkAdjustment" id="knee">
     <property name="upper">18</property>
     <property name="value">9</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">1</property>
+    <property name="page_increment">0.1</property>
     <signal name="value-changed" handler="on_knee_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="makeup">
@@ -112,14 +118,14 @@
     <property name="upper">20</property>
     <property name="value">2</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.01</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkAdjustment" id="release">
     <property name="lower">0.01</property>
     <property name="upper">2000</property>
     <property name="value">250</property>
     <property name="step_increment">0.01</property>
-    <property name="page_increment">0.01</property>
+    <property name="page_increment">0.1</property>
   </object>
   <object class="GtkAdjustment" id="threshold">
     <property name="lower">-60</property>
@@ -159,12 +165,12 @@
                     <property name="can_focus">False</property>
                     <property name="halign">center</property>
                     <property name="valign">center</property>
+                    <property name="margin_start">56</property>
                     <property name="label" translatable="yes">Detection</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
                     <property name="top_attach">0</property>
-                    <property name="width">2</property>
                   </packing>
                 </child>
                 <child>
@@ -173,12 +179,12 @@
                     <property name="can_focus">False</property>
                     <property name="halign">center</property>
                     <property name="valign">center</property>
+                    <property name="margin_end">56</property>
                     <property name="label" translatable="yes">Stereo Link</property>
                   </object>
                   <packing>
-                    <property name="left_attach">3</property>
+                    <property name="left_attach">2</property>
                     <property name="top_attach">0</property>
-                    <property name="width">2</property>
                   </packing>
                 </child>
                 <child>
@@ -190,7 +196,7 @@
                     <property name="label" translatable="yes">Gain Reduction</property>
                   </object>
                   <packing>
-                    <property name="left_attach">2</property>
+                    <property name="left_attach">1</property>
                     <property name="top_attach">0</property>
                   </packing>
                 </child>
@@ -198,6 +204,9 @@
                   <object class="GtkSpinButton">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
+                    <property name="width_chars">8</property>
                     <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
                     <property name="secondary_icon_activatable">False</property>
                     <property name="input_purpose">number</property>
@@ -206,7 +215,7 @@
                     <property name="update_policy">if-valid</property>
                   </object>
                   <packing>
-                    <property name="left_attach">2</property>
+                    <property name="left_attach">1</property>
                     <property name="top_attach">1</property>
                   </packing>
                 </child>
@@ -215,6 +224,8 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">center</property>
+                    <property name="valign">center</property>
+                    <property name="margin_start">56</property>
                     <items>
                       <item translatable="yes">RMS</item>
                       <item translatable="yes">Peak</item>
@@ -223,7 +234,6 @@
                   <packing>
                     <property name="left_attach">0</property>
                     <property name="top_attach">1</property>
-                    <property name="width">2</property>
                   </packing>
                 </child>
                 <child>
@@ -231,15 +241,16 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">center</property>
+                    <property name="valign">center</property>
+                    <property name="margin_end">56</property>
                     <items>
                       <item translatable="yes">Average</item>
                       <item translatable="yes">Maximum</item>
                     </items>
                   </object>
                   <packing>
-                    <property name="left_attach">3</property>
+                    <property name="left_attach">2</property>
                     <property name="top_attach">1</property>
-                    <property name="width">2</property>
                   </packing>
                 </child>
               </object>
@@ -265,7 +276,7 @@
                     <property name="label" translatable="yes">Attack</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
+                    <property name="left_attach">1</property>
                     <property name="top_attach">0</property>
                   </packing>
                 </child>
@@ -286,7 +297,7 @@
                     <property name="update_policy">if-valid</property>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
+                    <property name="left_attach">1</property>
                     <property name="top_attach">1</property>
                   </packing>
                 </child>
@@ -299,7 +310,7 @@
                     <property name="label" translatable="yes">Release</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
+                    <property name="left_attach">2</property>
                     <property name="top_attach">0</property>
                   </packing>
                 </child>
@@ -320,7 +331,7 @@
                     <property name="update_policy">if-valid</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
+                    <property name="left_attach">2</property>
                     <property name="top_attach">1</property>
                   </packing>
                 </child>
@@ -333,7 +344,7 @@
                     <property name="label" translatable="yes">Threshold</property>
                   </object>
                   <packing>
-                    <property name="left_attach">2</property>
+                    <property name="left_attach">3</property>
                     <property name="top_attach">0</property>
                   </packing>
                 </child>
@@ -353,7 +364,7 @@
                     <property name="update_policy">if-valid</property>
                   </object>
                   <packing>
-                    <property name="left_attach">2</property>
+                    <property name="left_attach">3</property>
                     <property name="top_attach">1</property>
                   </packing>
                 </child>
@@ -366,7 +377,7 @@
                     <property name="label" translatable="yes">Ratio</property>
                   </object>
                   <packing>
-                    <property name="left_attach">3</property>
+                    <property name="left_attach">4</property>
                     <property name="top_attach">0</property>
                   </packing>
                 </child>
@@ -385,7 +396,7 @@
                     <property name="update_policy">if-valid</property>
                   </object>
                   <packing>
-                    <property name="left_attach">3</property>
+                    <property name="left_attach">4</property>
                     <property name="top_attach">1</property>
                   </packing>
                 </child>
@@ -398,7 +409,7 @@
                     <property name="label" translatable="yes">Knee</property>
                   </object>
                   <packing>
-                    <property name="left_attach">4</property>
+                    <property name="left_attach">5</property>
                     <property name="top_attach">0</property>
                   </packing>
                 </child>
@@ -419,7 +430,7 @@
                     <property name="update_policy">if-valid</property>
                   </object>
                   <packing>
-                    <property name="left_attach">4</property>
+                    <property name="left_attach">5</property>
                     <property name="top_attach">1</property>
                   </packing>
                 </child>
@@ -432,7 +443,7 @@
                     <property name="label" translatable="yes">Makeup</property>
                   </object>
                   <packing>
-                    <property name="left_attach">5</property>
+                    <property name="left_attach">6</property>
                     <property name="top_attach">0</property>
                   </packing>
                 </child>
@@ -442,7 +453,6 @@
                     <property name="can_focus">True</property>
                     <property name="halign">center</property>
                     <property name="valign">center</property>
-                    <property name="hexpand">True</property>
                     <property name="width_chars">10</property>
                     <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
                     <property name="primary_icon_activatable">False</property>
@@ -454,8 +464,43 @@
                     <property name="update_policy">if-valid</property>
                   </object>
                   <packing>
-                    <property name="left_attach">5</property>
+                    <property name="left_attach">6</property>
                     <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
+                    <property name="width_chars">10</property>
+                    <property name="text" translatable="yes">0</property>
+                    <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
+                    <property name="primary_icon_activatable">False</property>
+                    <property name="secondary_icon_activatable">False</property>
+                    <property name="input_purpose">number</property>
+                    <property name="orientation">vertical</property>
+                    <property name="adjustment">input</property>
+                    <property name="numeric">True</property>
+                    <property name="update_policy">if-valid</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
+                    <property name="label" translatable="yes">Input</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
                   </packing>
                 </child>
               </object>
@@ -482,7 +527,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
-                <property name="valign">center</property>
+                <property name="valign">end</property>
                 <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
@@ -497,7 +542,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
-                <property name="valign">center</property>
+                <property name="valign">end</property>
                 <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
@@ -525,6 +570,7 @@
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
+                <property name="valign">end</property>
                 <property name="label">0</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
@@ -553,6 +599,7 @@
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
+                <property name="valign">end</property>
                 <property name="label">1</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
@@ -580,6 +627,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
+                <property name="margin_top">4</property>
                 <property name="hexpand">True</property>
               </object>
               <packing>
@@ -604,6 +652,7 @@
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
+                <property name="valign">end</property>
                 <property name="label">0</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
@@ -619,6 +668,7 @@
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
+                <property name="valign">end</property>
                 <property name="label">1</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
@@ -634,7 +684,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
-                <property name="margin_top">4</property>
+                <property name="margin_top">8</property>
                 <property name="hexpand">True</property>
               </object>
               <packing>
@@ -647,6 +697,8 @@
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
+                <property name="valign">end</property>
+                <property name="margin_top">4</property>
                 <property name="label">0</property>
                 <property name="width_chars">2</property>
                 <property name="max_width_chars">2</property>
@@ -658,12 +710,13 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel">
+              <object class="GtkLabel" id="gating_name_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
-                <property name="valign">center</property>
+                <property name="valign">end</property>
                 <property name="margin_end">3</property>
+                <property name="margin_top">4</property>
                 <property name="label" translatable="yes">Gating</property>
               </object>
               <packing>

--- a/data/ui/gate.glade
+++ b/data/ui/gate.glade
@@ -475,7 +475,7 @@
                     <property name="halign">center</property>
                     <property name="valign">center</property>
                     <property name="width_chars">10</property>
-                    <property name="text" translatable="yes">0</property>
+                    <property name="text">0</property>
                     <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
                     <property name="primary_icon_activatable">False</property>
                     <property name="secondary_icon_activatable">False</property>
@@ -496,7 +496,7 @@
                     <property name="can_focus">False</property>
                     <property name="halign">center</property>
                     <property name="valign">center</property>
-                    <property name="label" translatable="yes">Input</property>
+                    <property name="label" translatable="yes">Input Level</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>

--- a/data/ui/limiter.glade
+++ b/data/ui/limiter.glade
@@ -441,42 +441,12 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">0</property>
                 <property name="height">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
-                <property name="valign">center</property>
-                <property name="margin_end">3</property>
-                <property name="label" translatable="yes">Output</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
-                <property name="height">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
-                <property name="valign">center</property>
-                <property name="margin_end">3</property>
-                <property name="label" translatable="yes">Attenuation</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">4</property>
               </packing>
             </child>
             <child>
@@ -497,6 +467,7 @@
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">0</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
@@ -516,7 +487,7 @@
               <packing>
                 <property name="left_attach">3</property>
                 <property name="top_attach">0</property>
-                <property name="height">4</property>
+                <property name="height">5</property>
               </packing>
             </child>
             <child>
@@ -525,6 +496,7 @@
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">1</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
@@ -548,7 +520,37 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="output_level_left">
+              <object class="GtkLabel" id="output_level_right_label">
+                <property name="visible">True</property>
+                <property name="sensitive">False</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
+                <property name="label">1</property>
+                <property name="width_chars">3</property>
+                <property name="max_width_chars">3</property>
+              </object>
+              <packing>
+                <property name="left_attach">4</property>
+                <property name="top_attach">3</property>
+                <property name="height">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">end</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes">Attenuation</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">6</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLevelBar" id="attenuation">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -556,11 +558,54 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">6</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="attenuation_label">
+                <property name="visible">True</property>
+                <property name="sensitive">False</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
+                <property name="label">0</property>
+                <property name="width_chars">2</property>
+                <property name="max_width_chars">2</property>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">6</property>
+                <property name="width">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">end</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes">Output</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">3</property>
+                <property name="height">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkLevelBar" id="output_level_right">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="valign">center</property>
+                <property name="hexpand">True</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">4</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLevelBar" id="output_level_left">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
@@ -576,57 +621,54 @@
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">0</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
                 <property name="height">2</property>
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="output_level_right_label">
+              <object class="GtkFlowBox">
                 <property name="visible">True</property>
-                <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
-                <property name="label">1</property>
-                <property name="width_chars">3</property>
-                <property name="max_width_chars">3</property>
+                <property name="margin_top">6</property>
+                <property name="activate_on_single_click">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+                <property name="width">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">6</property>
+                <property name="activate_on_single_click">False</property>
               </object>
               <packing>
                 <property name="left_attach">4</property>
                 <property name="top_attach">2</property>
-                <property name="height">2</property>
               </packing>
             </child>
             <child>
-              <object class="GtkLevelBar" id="attenuation">
+              <object class="GtkFlowBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="valign">center</property>
-                <property name="margin_top">4</property>
-                <property name="hexpand">True</property>
+                <property name="margin_top">6</property>
+                <property name="activate_on_single_click">False</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">4</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="attenuation_label">
-                <property name="visible">True</property>
-                <property name="sensitive">False</property>
-                <property name="can_focus">False</property>
-                <property name="label">0</property>
-                <property name="width_chars">2</property>
-                <property name="max_width_chars">2</property>
-              </object>
-              <packing>
-                <property name="left_attach">2</property>
-                <property name="top_attach">4</property>
-                <property name="width">3</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">5</property>
+                <property name="width">5</property>
               </packing>
             </child>
           </object>

--- a/data/ui/limiter.glade
+++ b/data/ui/limiter.glade
@@ -106,6 +106,12 @@
     <property name="step_increment">0.1</property>
     <property name="page_increment">0.1</property>
   </object>
+  <object class="GtkAdjustment" id="output_gain">
+    <property name="lower">-36</property>
+    <property name="upper">36</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">1</property>
+  </object>
   <object class="GtkAdjustment" id="oversampling">
     <property name="lower">1</property>
     <property name="upper">4</property>
@@ -134,12 +140,53 @@
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
+          <object class="GtkGrid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="column_spacing">80</property>
+            <property name="column_homogeneous">True</property>
+            <child>
+              <object class="GtkToggleButton" id="asc">
+                <property name="label" translatable="yes">Automatic Smoothing Control</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkToggleButton" id="auto-level">
+                <property name="label" translatable="yes">Automatic Leveling</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="halign">end</property>
+                <property name="valign">center</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkGrid" id="limiter_controls">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="halign">center</property>
             <property name="row_spacing">6</property>
-            <property name="column_spacing">60</property>
+            <property name="column_spacing">40</property>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
@@ -330,16 +377,49 @@
               </packing>
             </child>
             <child>
-              <object class="GtkToggleButton" id="asc">
-                <property name="label" translatable="yes">ASC</property>
+              <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
+                <property name="can_focus">False</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
+                <property name="label" translatable="yes">ASC</property>
               </object>
               <packing>
                 <property name="left_attach">5</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSpinButton">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
+                <property name="width_chars">10</property>
+                <property name="text" translatable="yes">0</property>
+                <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
+                <property name="secondary_icon_activatable">False</property>
+                <property name="input_purpose">number</property>
+                <property name="orientation">vertical</property>
+                <property name="adjustment">output_gain</property>
+                <property name="numeric">True</property>
+                <property name="update_policy">if-valid</property>
+              </object>
+              <packing>
+                <property name="left_attach">6</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes">Output Gain</property>
+              </object>
+              <packing>
+                <property name="left_attach">6</property>
                 <property name="top_attach">0</property>
               </packing>
             </child>
@@ -347,7 +427,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">0</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
@@ -553,7 +633,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
         <child>
@@ -593,7 +673,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/data/ui/limiter.glade
+++ b/data/ui/limiter.glade
@@ -396,7 +396,7 @@
                 <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="width_chars">10</property>
-                <property name="text" translatable="yes">0</property>
+                <property name="text">0</property>
                 <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
                 <property name="secondary_icon_activatable">False</property>
                 <property name="input_purpose">number</property>

--- a/data/ui/loudness.glade
+++ b/data/ui/loudness.glade
@@ -82,13 +82,13 @@
   </object>
   <object class="GtkAdjustment" id="link">
     <property name="lower">-100</property>
-    <property name="value">-9.10</property>
+    <property name="value">-9.1</property>
     <property name="step_increment">0.01</property>
     <property name="page_increment">0.01</property>
   </object>
   <object class="GtkAdjustment" id="loudness">
     <property name="lower">-100</property>
-    <property name="value">-3.10</property>
+    <property name="value">-3.1</property>
     <property name="step_increment">0.01</property>
     <property name="page_increment">0.01</property>
   </object>
@@ -215,7 +215,7 @@
                 <property name="digits">2</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
-                <property name="value">4.50</property>
+                <property name="value">4.5</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
@@ -258,7 +258,7 @@
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
                 <property name="height">2</property>
               </packing>
             </child>
@@ -280,6 +280,7 @@
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">0</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
@@ -299,7 +300,7 @@
               <packing>
                 <property name="left_attach">3</property>
                 <property name="top_attach">0</property>
-                <property name="height">4</property>
+                <property name="height">5</property>
               </packing>
             </child>
             <child>
@@ -308,6 +309,7 @@
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">1</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
@@ -339,7 +341,7 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
               </packing>
             </child>
             <child>
@@ -351,7 +353,7 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">3</property>
+                <property name="top_attach">4</property>
               </packing>
             </child>
             <child>
@@ -359,13 +361,15 @@
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">0</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
                 <property name="height">2</property>
               </packing>
             </child>
@@ -374,14 +378,41 @@
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">1</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
               </object>
               <packing>
                 <property name="left_attach">4</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
                 <property name="height">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">6</property>
+                <property name="activate_on_single_click">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">4</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">6</property>
+                <property name="activate_on_single_click">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+                <property name="width">3</property>
               </packing>
             </child>
           </object>

--- a/data/ui/maximizer.glade
+++ b/data/ui/maximizer.glade
@@ -235,7 +235,6 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Input</property>
               </object>
               <packing>
@@ -250,12 +249,11 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Output</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
                 <property name="height">2</property>
               </packing>
             </child>
@@ -265,12 +263,11 @@
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="margin_end">3</property>
                 <property name="label" translatable="yes">Gain Reduction</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">4</property>
+                <property name="top_attach">6</property>
               </packing>
             </child>
             <child>
@@ -291,6 +288,7 @@
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">0</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
@@ -310,7 +308,7 @@
               <packing>
                 <property name="left_attach">3</property>
                 <property name="top_attach">0</property>
-                <property name="height">4</property>
+                <property name="height">5</property>
               </packing>
             </child>
             <child>
@@ -319,6 +317,7 @@
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">1</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
@@ -350,7 +349,7 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
               </packing>
             </child>
             <child>
@@ -362,7 +361,7 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">3</property>
+                <property name="top_attach">4</property>
               </packing>
             </child>
             <child>
@@ -370,13 +369,15 @@
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">0</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
                 <property name="height">2</property>
               </packing>
             </child>
@@ -385,13 +386,15 @@
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">1</property>
                 <property name="width_chars">3</property>
                 <property name="max_width_chars">3</property>
               </object>
               <packing>
                 <property name="left_attach">4</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
                 <property name="height">2</property>
               </packing>
             </child>
@@ -400,13 +403,15 @@
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
                 <property name="label">0</property>
                 <property name="width_chars">2</property>
                 <property name="max_width_chars">2</property>
               </object>
               <packing>
                 <property name="left_attach">2</property>
-                <property name="top_attach">4</property>
+                <property name="top_attach">6</property>
                 <property name="width">3</property>
               </packing>
             </child>
@@ -415,13 +420,50 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">center</property>
-                <property name="margin_top">4</property>
                 <property name="hexpand">True</property>
                 <property name="max_value">40</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">4</property>
+                <property name="top_attach">6</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">6</property>
+                <property name="activate_on_single_click">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">4</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">6</property>
+                <property name="activate_on_single_click">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+                <property name="width">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFlowBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">6</property>
+                <property name="activate_on_single_click">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">5</property>
+                <property name="width">5</property>
               </packing>
             </child>
           </object>

--- a/data/ui/pitch.glade
+++ b/data/ui/pitch.glade
@@ -138,34 +138,6 @@
             <property name="row_spacing">18</property>
             <property name="column_spacing">60</property>
             <child>
-              <object class="GtkToggleButton" id="faster">
-                <property name="label" translatable="yes">Faster</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkToggleButton" id="formant_preserving">
-                <property name="label" translatable="yes">Preserve Formant</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkGrid">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
@@ -298,7 +270,48 @@
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkGrid">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="column_spacing">60</property>
+                <property name="column_homogeneous">True</property>
+                <child>
+                  <object class="GtkToggleButton" id="faster">
+                    <property name="label" translatable="yes">Faster</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="halign">end</property>
+                    <property name="valign">center</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkToggleButton" id="formant_preserving">
+                    <property name="label" translatable="yes">Preserve Formant</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="halign">start</property>
+                    <property name="valign">center</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
               </packing>
             </child>
           </object>

--- a/help/it_IT/it_IT.po
+++ b/help/it_IT/it_IT.po
@@ -1835,12 +1835,13 @@ msgstr "Più Veloce"
 #. (itstool) path: title/em
 #: C/pitch.page:26
 msgid "Preserve Formant"
-msgstr "Preserva Formato"
+msgstr "Preserva Formante"
 
 #. (itstool) path: item/p
 #: C/pitch.page:28
 msgid "Enable formant preservation when pitch shifting."
-msgstr "Abilita la preservazione del formato durante il cambio di intonazione."
+msgstr ""
+"Abilita la preservazione della formante durante il cambio di intonazione."
 
 #. (itstool) path: title/em
 #: C/pitch.page:34

--- a/include/gate_ui.hpp
+++ b/include/gate_ui.hpp
@@ -19,7 +19,7 @@ class GateUi : public Gtk::Grid, public PluginUiBase {
   void reset() override;
 
  private:
-  Glib::RefPtr<Gtk::Adjustment> attack, release, threshold, knee, ratio, range, makeup;
+  Glib::RefPtr<Gtk::Adjustment> attack, release, threshold, knee, ratio, range, input, makeup;
   Gtk::LevelBar* gating = nullptr;
   Gtk::Label* gating_label = nullptr;
   Gtk::ComboBoxText *detection = nullptr, *stereo_link = nullptr;

--- a/include/limiter_ui.hpp
+++ b/include/limiter_ui.hpp
@@ -19,9 +19,9 @@ class LimiterUi : public Gtk::Grid, public PluginUiBase {
   void reset() override;
 
  private:
-  Glib::RefPtr<Gtk::Adjustment> input_gain, limit, lookahead, release, oversampling;
-  Gtk::ToggleButton* asc = nullptr;
-  Glib::RefPtr<Gtk::Adjustment> asc_level;
+  Glib::RefPtr<Gtk::Adjustment> input_gain, limit, lookahead, release, oversampling, asc_level, output_gain;
+
+  Gtk::ToggleButton *auto_level = nullptr , *asc = nullptr;
 
   Gtk::LevelBar* attenuation = nullptr;
   Gtk::Label* attenuation_label = nullptr;

--- a/po/cs.po
+++ b/po/cs.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-21 17:09+0200\n"
+"POT-Creation-Date: 2020-07-22 20:34+0200\n"
 "PO-Revision-Date: 2019-08-25 21:29+0200\n"
 "Last-Translator: Pavel Fric <pavelfric@seznam.cz>\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
@@ -186,14 +186,14 @@ msgid "Use Dark Theme"
 msgstr "Použít tmavý vzhled"
 
 #: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
-#: data/ui/limiter.glade:635 data/ui/compressor.glade:1335
+#: data/ui/limiter.glade:715 data/ui/compressor.glade:1335
 #: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
 #: data/ui/equalizer.glade:763 data/ui/equalizer_band.glade:183
 #: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
 #: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
 #: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
 #: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
-#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/gate.glade:809 data/ui/multiband_gate.glade:2368
 #: data/ui/deesser.glade:879 data/ui/convolver.glade:698
 #: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
 #: data/ui/webrtc.glade:850 data/ui/delay.glade:469
@@ -353,13 +353,13 @@ msgid "Weights"
 msgstr "Váhy"
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:948
+#: data/ui/limiter.glade:445 data/ui/compressor.glade:948
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
 #: data/ui/equalizer.glade:501 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:243 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:532
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
 #: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
@@ -368,7 +368,7 @@ msgid "Input"
 msgstr "Vstup"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:962
+#: data/ui/limiter.glade:460 data/ui/compressor.glade:962
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
@@ -378,7 +378,7 @@ msgstr "Vstup"
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:547
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
@@ -414,48 +414,61 @@ msgstr ""
 msgid "Limiter"
 msgstr "Omezovač"
 
-#: data/ui/limiter.glade:149
+#: data/ui/limiter.glade:150
+msgid "Automatic Smoothing Control"
+msgstr ""
+
+#: data/ui/limiter.glade:164
+msgid "Automatic Leveling"
+msgstr ""
+
+#: data/ui/limiter.glade:196
 msgid "Input Gain"
 msgstr "Vstupní zesílení"
 
-#: data/ui/limiter.glade:182
+#: data/ui/limiter.glade:229
 msgid "Limit"
 msgstr "Omezení"
 
-#: data/ui/limiter.glade:237 data/ui/compressor.glade:400
+#: data/ui/limiter.glade:284 data/ui/compressor.glade:400
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
 #: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
-#: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
+#: data/ui/gate.glade:310 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
 msgid "Release"
 msgstr "Uvolnění"
 
-#: data/ui/limiter.glade:250 data/ui/compressor.glade:594
+#: data/ui/limiter.glade:297 data/ui/compressor.glade:594
 msgid "Lookahead"
 msgstr "Výhled"
 
-#: data/ui/limiter.glade:285
+#: data/ui/limiter.glade:332
 msgid "Oversampling"
 msgstr "Převzorkování"
 
-#: data/ui/limiter.glade:334
+#: data/ui/limiter.glade:385
 msgid "ASC"
 msgstr "ASC"
 
-#: data/ui/limiter.glade:395
+#: data/ui/limiter.glade:419
+#, fuzzy
+msgid "Output Gain"
+msgstr "Vstupní zesílení"
+
+#: data/ui/limiter.glade:475
 msgid "Attenuation"
 msgstr "Tlumení"
 
-#: data/ui/limiter.glade:569 data/ui/compressor.glade:1270
+#: data/ui/limiter.glade:649 data/ui/compressor.glade:1270
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
 #: data/ui/equalizer.glade:698 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
-#: data/ui/gate.glade:691 data/ui/multiband_gate.glade:2303
+#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:2303
 #: data/ui/deesser.glade:814 data/ui/pitch.glade:517 data/ui/webrtc.glade:785
 #: data/ui/delay.glade:404
 msgid "Provided by"
@@ -470,7 +483,7 @@ msgstr "Kompresor"
 #: data/ui/multiband_compressor.glade:942
 #: data/ui/multiband_compressor.glade:1320
 #: data/ui/multiband_compressor.glade:1698 data/ui/maximizer.glade:126
-#: data/ui/gate.glade:333 data/ui/multiband_gate.glade:588
+#: data/ui/gate.glade:344 data/ui/multiband_gate.glade:588
 #: data/ui/multiband_gate.glade:995 data/ui/multiband_gate.glade:1405
 #: data/ui/multiband_gate.glade:1815 data/ui/deesser.glade:458
 msgid "Threshold"
@@ -479,7 +492,7 @@ msgstr "Práh"
 #: data/ui/compressor.glade:299 data/ui/multiband_compressor.glade:601
 #: data/ui/multiband_compressor.glade:976
 #: data/ui/multiband_compressor.glade:1354
-#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:366
+#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:377
 #: data/ui/multiband_gate.glade:621 data/ui/multiband_gate.glade:1029
 #: data/ui/multiband_gate.glade:1439 data/ui/multiband_gate.glade:1849
 #: data/ui/deesser.glade:491
@@ -489,7 +502,7 @@ msgstr "Poměr"
 #: data/ui/compressor.glade:331 data/ui/multiband_compressor.glade:633
 #: data/ui/multiband_compressor.glade:1009
 #: data/ui/multiband_compressor.glade:1387
-#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:398
+#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:409
 #: data/ui/multiband_gate.glade:653 data/ui/multiband_gate.glade:1062
 #: data/ui/multiband_gate.glade:1472 data/ui/multiband_gate.glade:1882
 msgid "Knee"
@@ -498,7 +511,7 @@ msgstr "Přechod"
 #: data/ui/compressor.glade:365 data/ui/multiband_compressor.glade:667
 #: data/ui/multiband_compressor.glade:1044
 #: data/ui/multiband_compressor.glade:1422
-#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:432
+#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:443
 #: data/ui/multiband_gate.glade:687 data/ui/multiband_gate.glade:1097
 #: data/ui/multiband_gate.glade:1507 data/ui/multiband_gate.glade:1917
 #: data/ui/deesser.glade:522
@@ -508,7 +521,7 @@ msgstr "Pozvednutí"
 #: data/ui/compressor.glade:413 data/ui/multiband_compressor.glade:500
 #: data/ui/multiband_compressor.glade:872
 #: data/ui/multiband_compressor.glade:1250
-#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:265
+#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:276
 #: data/ui/multiband_gate.glade:520 data/ui/multiband_gate.glade:925
 #: data/ui/multiband_gate.glade:1335 data/ui/multiband_gate.glade:1745
 msgid "Attack"
@@ -554,7 +567,7 @@ msgstr "Typ"
 #: data/ui/compressor.glade:636 data/ui/multiband_compressor.glade:473
 #: data/ui/multiband_compressor.glade:845
 #: data/ui/multiband_compressor.glade:1223
-#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:220
+#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:231
 #: data/ui/multiband_gate.glade:493 data/ui/multiband_gate.glade:898
 #: data/ui/multiband_gate.glade:1308 data/ui/multiband_gate.glade:1718
 #: data/ui/deesser.glade:218 data/ui/deesser.glade:328
@@ -564,7 +577,7 @@ msgstr "Vrchol"
 #: data/ui/compressor.glade:637 data/ui/multiband_compressor.glade:472
 #: data/ui/multiband_compressor.glade:844
 #: data/ui/multiband_compressor.glade:1222
-#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:219
+#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:230
 #: data/ui/multiband_gate.glade:492 data/ui/multiband_gate.glade:897
 #: data/ui/multiband_gate.glade:1307 data/ui/multiband_gate.glade:1717
 #: data/ui/deesser.glade:217
@@ -1162,7 +1175,7 @@ msgstr "Prolínání kanálů"
 msgid "Maximizer"
 msgstr "Zvětšovač"
 
-#: data/ui/maximizer.glade:269 data/ui/gate.glade:190
+#: data/ui/maximizer.glade:269 data/ui/gate.glade:196
 msgid "Gain Reduction"
 msgstr "Zmenšení zesílení"
 
@@ -1174,23 +1187,28 @@ msgstr "Spojení"
 msgid "Gate"
 msgstr "Brána"
 
-#: data/ui/gate.glade:162 data/ui/deesser.glade:190
+#: data/ui/gate.glade:169 data/ui/deesser.glade:190
 msgid "Detection"
 msgstr "Zjištění"
 
-#: data/ui/gate.glade:176
+#: data/ui/gate.glade:183
 msgid "Stereo Link"
 msgstr "Spojení sterea"
 
-#: data/ui/gate.glade:235
+#: data/ui/gate.glade:247
 msgid "Average"
 msgstr "Průměr"
 
-#: data/ui/gate.glade:236
+#: data/ui/gate.glade:248
 msgid "Maximum"
 msgstr "Nejvýše"
 
-#: data/ui/gate.glade:667 data/ui/multiband_gate.glade:766
+#: data/ui/gate.glade:499
+#, fuzzy
+msgid "Input Level"
+msgstr "Omezovač vstupu"
+
+#: data/ui/gate.glade:720 data/ui/multiband_gate.glade:766
 #: data/ui/multiband_gate.glade:1175 data/ui/multiband_gate.glade:1585
 #: data/ui/multiband_gate.glade:1995
 msgid "Gating"
@@ -1787,10 +1805,6 @@ msgstr "nekonečno"
 #, fuzzy
 #~ msgid "Output Device"
 #~ msgstr "Omezovač výstupu"
-
-#, fuzzy
-#~ msgid "Input Device"
-#~ msgstr "Omezovač vstupu"
 
 #~ msgid "Meters"
 #~ msgstr "Metry"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PulseEffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-21 17:09+0200\n"
+"POT-Creation-Date: 2020-07-22 20:34+0200\n"
 "PO-Revision-Date: 2020-01-12 17:49+0100\n"
 "Last-Translator: David Keller <blobcodes@protonmail.com>\n"
 "Language-Team: \n"
@@ -185,14 +185,14 @@ msgid "Use Dark Theme"
 msgstr "Benutze dunkles Thema"
 
 #: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
-#: data/ui/limiter.glade:635 data/ui/compressor.glade:1335
+#: data/ui/limiter.glade:715 data/ui/compressor.glade:1335
 #: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
 #: data/ui/equalizer.glade:763 data/ui/equalizer_band.glade:183
 #: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
 #: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
 #: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
 #: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
-#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/gate.glade:809 data/ui/multiband_gate.glade:2368
 #: data/ui/deesser.glade:879 data/ui/convolver.glade:698
 #: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
 #: data/ui/webrtc.glade:850 data/ui/delay.glade:469
@@ -349,13 +349,13 @@ msgid "Weights"
 msgstr "Gewichte"
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:948
+#: data/ui/limiter.glade:445 data/ui/compressor.glade:948
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
 #: data/ui/equalizer.glade:501 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:243 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:532
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
 #: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
@@ -364,7 +364,7 @@ msgid "Input"
 msgstr "Eingang"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:962
+#: data/ui/limiter.glade:460 data/ui/compressor.glade:962
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
@@ -374,7 +374,7 @@ msgstr "Eingang"
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:547
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
@@ -410,48 +410,61 @@ msgstr ""
 msgid "Limiter"
 msgstr "Limiter"
 
-#: data/ui/limiter.glade:149
+#: data/ui/limiter.glade:150
+msgid "Automatic Smoothing Control"
+msgstr ""
+
+#: data/ui/limiter.glade:164
+msgid "Automatic Leveling"
+msgstr ""
+
+#: data/ui/limiter.glade:196
 msgid "Input Gain"
 msgstr "Eingabeverstärkung"
 
-#: data/ui/limiter.glade:182
+#: data/ui/limiter.glade:229
 msgid "Limit"
 msgstr "Grenze"
 
-#: data/ui/limiter.glade:237 data/ui/compressor.glade:400
+#: data/ui/limiter.glade:284 data/ui/compressor.glade:400
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
 #: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
-#: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
+#: data/ui/gate.glade:310 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
 msgid "Release"
 msgstr "Ausklingzeit"
 
-#: data/ui/limiter.glade:250 data/ui/compressor.glade:594
+#: data/ui/limiter.glade:297 data/ui/compressor.glade:594
 msgid "Lookahead"
 msgstr "Ausblick"
 
-#: data/ui/limiter.glade:285
+#: data/ui/limiter.glade:332
 msgid "Oversampling"
 msgstr "Überabtastung"
 
-#: data/ui/limiter.glade:334
+#: data/ui/limiter.glade:385
 msgid "ASC"
 msgstr "ASC"
 
-#: data/ui/limiter.glade:395
+#: data/ui/limiter.glade:419
+#, fuzzy
+msgid "Output Gain"
+msgstr "Eingabeverstärkung"
+
+#: data/ui/limiter.glade:475
 msgid "Attenuation"
 msgstr "Dämpfung"
 
-#: data/ui/limiter.glade:569 data/ui/compressor.glade:1270
+#: data/ui/limiter.glade:649 data/ui/compressor.glade:1270
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
 #: data/ui/equalizer.glade:698 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
-#: data/ui/gate.glade:691 data/ui/multiband_gate.glade:2303
+#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:2303
 #: data/ui/deesser.glade:814 data/ui/pitch.glade:517 data/ui/webrtc.glade:785
 #: data/ui/delay.glade:404
 msgid "Provided by"
@@ -466,7 +479,7 @@ msgstr "Kompressor"
 #: data/ui/multiband_compressor.glade:942
 #: data/ui/multiband_compressor.glade:1320
 #: data/ui/multiband_compressor.glade:1698 data/ui/maximizer.glade:126
-#: data/ui/gate.glade:333 data/ui/multiband_gate.glade:588
+#: data/ui/gate.glade:344 data/ui/multiband_gate.glade:588
 #: data/ui/multiband_gate.glade:995 data/ui/multiband_gate.glade:1405
 #: data/ui/multiband_gate.glade:1815 data/ui/deesser.glade:458
 msgid "Threshold"
@@ -475,7 +488,7 @@ msgstr "Schwelle"
 #: data/ui/compressor.glade:299 data/ui/multiband_compressor.glade:601
 #: data/ui/multiband_compressor.glade:976
 #: data/ui/multiband_compressor.glade:1354
-#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:366
+#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:377
 #: data/ui/multiband_gate.glade:621 data/ui/multiband_gate.glade:1029
 #: data/ui/multiband_gate.glade:1439 data/ui/multiband_gate.glade:1849
 #: data/ui/deesser.glade:491
@@ -485,7 +498,7 @@ msgstr "Verhältnis"
 #: data/ui/compressor.glade:331 data/ui/multiband_compressor.glade:633
 #: data/ui/multiband_compressor.glade:1009
 #: data/ui/multiband_compressor.glade:1387
-#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:398
+#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:409
 #: data/ui/multiband_gate.glade:653 data/ui/multiband_gate.glade:1062
 #: data/ui/multiband_gate.glade:1472 data/ui/multiband_gate.glade:1882
 msgid "Knee"
@@ -494,7 +507,7 @@ msgstr "Übergang"
 #: data/ui/compressor.glade:365 data/ui/multiband_compressor.glade:667
 #: data/ui/multiband_compressor.glade:1044
 #: data/ui/multiband_compressor.glade:1422
-#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:432
+#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:443
 #: data/ui/multiband_gate.glade:687 data/ui/multiband_gate.glade:1097
 #: data/ui/multiband_gate.glade:1507 data/ui/multiband_gate.glade:1917
 #: data/ui/deesser.glade:522
@@ -504,7 +517,7 @@ msgstr "Hebung"
 #: data/ui/compressor.glade:413 data/ui/multiband_compressor.glade:500
 #: data/ui/multiband_compressor.glade:872
 #: data/ui/multiband_compressor.glade:1250
-#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:265
+#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:276
 #: data/ui/multiband_gate.glade:520 data/ui/multiband_gate.glade:925
 #: data/ui/multiband_gate.glade:1335 data/ui/multiband_gate.glade:1745
 msgid "Attack"
@@ -550,7 +563,7 @@ msgstr "Typ"
 #: data/ui/compressor.glade:636 data/ui/multiband_compressor.glade:473
 #: data/ui/multiband_compressor.glade:845
 #: data/ui/multiband_compressor.glade:1223
-#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:220
+#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:231
 #: data/ui/multiband_gate.glade:493 data/ui/multiband_gate.glade:898
 #: data/ui/multiband_gate.glade:1308 data/ui/multiband_gate.glade:1718
 #: data/ui/deesser.glade:218 data/ui/deesser.glade:328
@@ -560,7 +573,7 @@ msgstr "Hochpunkt"
 #: data/ui/compressor.glade:637 data/ui/multiband_compressor.glade:472
 #: data/ui/multiband_compressor.glade:844
 #: data/ui/multiband_compressor.glade:1222
-#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:219
+#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:230
 #: data/ui/multiband_gate.glade:492 data/ui/multiband_gate.glade:897
 #: data/ui/multiband_gate.glade:1307 data/ui/multiband_gate.glade:1717
 #: data/ui/deesser.glade:217
@@ -1158,7 +1171,7 @@ msgstr "Crossfeed"
 msgid "Maximizer"
 msgstr "Maximierer"
 
-#: data/ui/maximizer.glade:269 data/ui/gate.glade:190
+#: data/ui/maximizer.glade:269 data/ui/gate.glade:196
 msgid "Gain Reduction"
 msgstr "Amplitudenreduktion"
 
@@ -1170,23 +1183,28 @@ msgstr "Verknüpfung"
 msgid "Gate"
 msgstr "Gate"
 
-#: data/ui/gate.glade:162 data/ui/deesser.glade:190
+#: data/ui/gate.glade:169 data/ui/deesser.glade:190
 msgid "Detection"
 msgstr "Erkennung"
 
-#: data/ui/gate.glade:176
+#: data/ui/gate.glade:183
 msgid "Stereo Link"
 msgstr "Stereoverbindung"
 
-#: data/ui/gate.glade:235
+#: data/ui/gate.glade:247
 msgid "Average"
 msgstr "Durchschnitt"
 
-#: data/ui/gate.glade:236
+#: data/ui/gate.glade:248
 msgid "Maximum"
 msgstr "Maximum"
 
-#: data/ui/gate.glade:667 data/ui/multiband_gate.glade:766
+#: data/ui/gate.glade:499
+#, fuzzy
+msgid "Input Level"
+msgstr "Limiter"
+
+#: data/ui/gate.glade:720 data/ui/multiband_gate.glade:766
 #: data/ui/multiband_gate.glade:1175 data/ui/multiband_gate.glade:1585
 #: data/ui/multiband_gate.glade:1995
 msgid "Gating"
@@ -1772,10 +1790,6 @@ msgstr "Unendlich"
 
 #, fuzzy
 #~ msgid "Output Device"
-#~ msgstr "Limiter"
-
-#, fuzzy
-#~ msgid "Input Device"
 #~ msgstr "Limiter"
 
 #, fuzzy

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-21 17:09+0200\n"
+"POT-Creation-Date: 2020-07-22 20:34+0200\n"
 "PO-Revision-Date: 2017-08-29 11:00+0200\n"
 "Last-Translator: Nathan Graule <solarliner@gmail.com>\n"
 "Language-Team: \n"
@@ -198,14 +198,14 @@ msgid "Use Dark Theme"
 msgstr "Utiliser thème sombre"
 
 #: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
-#: data/ui/limiter.glade:635 data/ui/compressor.glade:1335
+#: data/ui/limiter.glade:715 data/ui/compressor.glade:1335
 #: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
 #: data/ui/equalizer.glade:763 data/ui/equalizer_band.glade:183
 #: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
 #: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
 #: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
 #: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
-#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/gate.glade:809 data/ui/multiband_gate.glade:2368
 #: data/ui/deesser.glade:879 data/ui/convolver.glade:698
 #: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
 #: data/ui/webrtc.glade:850 data/ui/delay.glade:469
@@ -367,13 +367,13 @@ msgid "Weights"
 msgstr ""
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:948
+#: data/ui/limiter.glade:445 data/ui/compressor.glade:948
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
 #: data/ui/equalizer.glade:501 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:243 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:532
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
 #: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
@@ -382,7 +382,7 @@ msgid "Input"
 msgstr "Entrée"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:962
+#: data/ui/limiter.glade:460 data/ui/compressor.glade:962
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
@@ -392,7 +392,7 @@ msgstr "Entrée"
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:547
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
@@ -430,51 +430,64 @@ msgstr ""
 msgid "Limiter"
 msgstr "Limite [dB]"
 
-#: data/ui/limiter.glade:149
+#: data/ui/limiter.glade:150
+msgid "Automatic Smoothing Control"
+msgstr ""
+
+#: data/ui/limiter.glade:164
+msgid "Automatic Leveling"
+msgstr ""
+
+#: data/ui/limiter.glade:196
 #, fuzzy
 msgid "Input Gain"
 msgstr "Gain d'entrée [dB]"
 
-#: data/ui/limiter.glade:182
+#: data/ui/limiter.glade:229
 #, fuzzy
 msgid "Limit"
 msgstr "Limite [dB]"
 
-#: data/ui/limiter.glade:237 data/ui/compressor.glade:400
+#: data/ui/limiter.glade:284 data/ui/compressor.glade:400
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
 #: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
-#: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
+#: data/ui/gate.glade:310 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
 #, fuzzy
 msgid "Release"
 msgstr "Relâche [s]"
 
-#: data/ui/limiter.glade:250 data/ui/compressor.glade:594
+#: data/ui/limiter.glade:297 data/ui/compressor.glade:594
 msgid "Lookahead"
 msgstr ""
 
-#: data/ui/limiter.glade:285
+#: data/ui/limiter.glade:332
 msgid "Oversampling"
 msgstr ""
 
-#: data/ui/limiter.glade:334
+#: data/ui/limiter.glade:385
 msgid "ASC"
 msgstr ""
 
-#: data/ui/limiter.glade:395
+#: data/ui/limiter.glade:419
+#, fuzzy
+msgid "Output Gain"
+msgstr "Gain d'entrée [dB]"
+
+#: data/ui/limiter.glade:475
 msgid "Attenuation"
 msgstr "Atténuation"
 
-#: data/ui/limiter.glade:569 data/ui/compressor.glade:1270
+#: data/ui/limiter.glade:649 data/ui/compressor.glade:1270
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
 #: data/ui/equalizer.glade:698 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
-#: data/ui/gate.glade:691 data/ui/multiband_gate.glade:2303
+#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:2303
 #: data/ui/deesser.glade:814 data/ui/pitch.glade:517 data/ui/webrtc.glade:785
 #: data/ui/delay.glade:404
 msgid "Provided by"
@@ -489,7 +502,7 @@ msgstr "Compresseur"
 #: data/ui/multiband_compressor.glade:942
 #: data/ui/multiband_compressor.glade:1320
 #: data/ui/multiband_compressor.glade:1698 data/ui/maximizer.glade:126
-#: data/ui/gate.glade:333 data/ui/multiband_gate.glade:588
+#: data/ui/gate.glade:344 data/ui/multiband_gate.glade:588
 #: data/ui/multiband_gate.glade:995 data/ui/multiband_gate.glade:1405
 #: data/ui/multiband_gate.glade:1815 data/ui/deesser.glade:458
 #, fuzzy
@@ -499,7 +512,7 @@ msgstr "Seuil [dB]"
 #: data/ui/compressor.glade:299 data/ui/multiband_compressor.glade:601
 #: data/ui/multiband_compressor.glade:976
 #: data/ui/multiband_compressor.glade:1354
-#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:366
+#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:377
 #: data/ui/multiband_gate.glade:621 data/ui/multiband_gate.glade:1029
 #: data/ui/multiband_gate.glade:1439 data/ui/multiband_gate.glade:1849
 #: data/ui/deesser.glade:491
@@ -510,7 +523,7 @@ msgstr "Ratio [n:1]"
 #: data/ui/compressor.glade:331 data/ui/multiband_compressor.glade:633
 #: data/ui/multiband_compressor.glade:1009
 #: data/ui/multiband_compressor.glade:1387
-#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:398
+#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:409
 #: data/ui/multiband_gate.glade:653 data/ui/multiband_gate.glade:1062
 #: data/ui/multiband_gate.glade:1472 data/ui/multiband_gate.glade:1882
 #, fuzzy
@@ -520,7 +533,7 @@ msgstr "Coudée [dB]"
 #: data/ui/compressor.glade:365 data/ui/multiband_compressor.glade:667
 #: data/ui/multiband_compressor.glade:1044
 #: data/ui/multiband_compressor.glade:1422
-#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:432
+#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:443
 #: data/ui/multiband_gate.glade:687 data/ui/multiband_gate.glade:1097
 #: data/ui/multiband_gate.glade:1507 data/ui/multiband_gate.glade:1917
 #: data/ui/deesser.glade:522
@@ -531,7 +544,7 @@ msgstr "Gain de remise [dB]"
 #: data/ui/compressor.glade:413 data/ui/multiband_compressor.glade:500
 #: data/ui/multiband_compressor.glade:872
 #: data/ui/multiband_compressor.glade:1250
-#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:265
+#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:276
 #: data/ui/multiband_gate.glade:520 data/ui/multiband_gate.glade:925
 #: data/ui/multiband_gate.glade:1335 data/ui/multiband_gate.glade:1745
 #, fuzzy
@@ -581,7 +594,7 @@ msgstr ""
 #: data/ui/compressor.glade:636 data/ui/multiband_compressor.glade:473
 #: data/ui/multiband_compressor.glade:845
 #: data/ui/multiband_compressor.glade:1223
-#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:220
+#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:231
 #: data/ui/multiband_gate.glade:493 data/ui/multiband_gate.glade:898
 #: data/ui/multiband_gate.glade:1308 data/ui/multiband_gate.glade:1718
 #: data/ui/deesser.glade:218 data/ui/deesser.glade:328
@@ -591,7 +604,7 @@ msgstr ""
 #: data/ui/compressor.glade:637 data/ui/multiband_compressor.glade:472
 #: data/ui/multiband_compressor.glade:844
 #: data/ui/multiband_compressor.glade:1222
-#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:219
+#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:230
 #: data/ui/multiband_gate.glade:492 data/ui/multiband_gate.glade:897
 #: data/ui/multiband_gate.glade:1307 data/ui/multiband_gate.glade:1717
 #: data/ui/deesser.glade:217
@@ -1222,7 +1235,7 @@ msgstr ""
 msgid "Maximizer"
 msgstr ""
 
-#: data/ui/maximizer.glade:269 data/ui/gate.glade:190
+#: data/ui/maximizer.glade:269 data/ui/gate.glade:196
 msgid "Gain Reduction"
 msgstr "Réduction de gain"
 
@@ -1234,25 +1247,30 @@ msgstr ""
 msgid "Gate"
 msgstr ""
 
-#: data/ui/gate.glade:162 data/ui/deesser.glade:190
+#: data/ui/gate.glade:169 data/ui/deesser.glade:190
 #, fuzzy
 msgid "Detection"
 msgstr "Atténuation"
 
-#: data/ui/gate.glade:176
+#: data/ui/gate.glade:183
 #, fuzzy
 msgid "Stereo Link"
 msgstr "Amélioration audio"
 
-#: data/ui/gate.glade:235
+#: data/ui/gate.glade:247
 msgid "Average"
 msgstr ""
 
-#: data/ui/gate.glade:236
+#: data/ui/gate.glade:248
 msgid "Maximum"
 msgstr ""
 
-#: data/ui/gate.glade:667 data/ui/multiband_gate.glade:766
+#: data/ui/gate.glade:499
+#, fuzzy
+msgid "Input Level"
+msgstr "Limiteur d'entrée"
+
+#: data/ui/gate.glade:720 data/ui/multiband_gate.glade:766
 #: data/ui/multiband_gate.glade:1175 data/ui/multiband_gate.glade:1585
 #: data/ui/multiband_gate.glade:1995
 msgid "Gating"
@@ -1819,10 +1837,6 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Output Device"
-#~ msgstr "Limiteur d'entrée"
-
-#, fuzzy
-#~ msgid "Input Device"
 #~ msgstr "Limiteur d'entrée"
 
 #, fuzzy

--- a/po/hr.po
+++ b/po/hr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PulseEffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-21 17:09+0200\n"
+"POT-Creation-Date: 2020-07-22 20:34+0200\n"
 "PO-Revision-Date: 2018-11-22 20:12+0200\n"
 "Last-Translator: flipwise <tyx027@gmail.com>\n"
 "Language-Team: Croatian\n"
@@ -196,14 +196,14 @@ msgid "Use Dark Theme"
 msgstr "Koristi tamnu temu"
 
 #: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
-#: data/ui/limiter.glade:635 data/ui/compressor.glade:1335
+#: data/ui/limiter.glade:715 data/ui/compressor.glade:1335
 #: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
 #: data/ui/equalizer.glade:763 data/ui/equalizer_band.glade:183
 #: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
 #: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
 #: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
 #: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
-#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/gate.glade:809 data/ui/multiband_gate.glade:2368
 #: data/ui/deesser.glade:879 data/ui/convolver.glade:698
 #: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
 #: data/ui/webrtc.glade:850 data/ui/delay.glade:469
@@ -372,13 +372,13 @@ msgid "Weights"
 msgstr "Otežanja"
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:948
+#: data/ui/limiter.glade:445 data/ui/compressor.glade:948
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
 #: data/ui/equalizer.glade:501 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:243 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:532
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
 #: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
@@ -387,7 +387,7 @@ msgid "Input"
 msgstr "Ulaz"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:962
+#: data/ui/limiter.glade:460 data/ui/compressor.glade:962
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
@@ -397,7 +397,7 @@ msgstr "Ulaz"
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:547
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
@@ -433,48 +433,61 @@ msgstr ""
 msgid "Limiter"
 msgstr "Graničnik"
 
-#: data/ui/limiter.glade:149
+#: data/ui/limiter.glade:150
+msgid "Automatic Smoothing Control"
+msgstr ""
+
+#: data/ui/limiter.glade:164
+msgid "Automatic Leveling"
+msgstr ""
+
+#: data/ui/limiter.glade:196
 msgid "Input Gain"
 msgstr "Pojačanje ulaza"
 
-#: data/ui/limiter.glade:182
+#: data/ui/limiter.glade:229
 msgid "Limit"
 msgstr "Granica"
 
-#: data/ui/limiter.glade:237 data/ui/compressor.glade:400
+#: data/ui/limiter.glade:284 data/ui/compressor.glade:400
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
 #: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
-#: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
+#: data/ui/gate.glade:310 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
 msgid "Release"
 msgstr "Vrijeme prijelaza"
 
-#: data/ui/limiter.glade:250 data/ui/compressor.glade:594
+#: data/ui/limiter.glade:297 data/ui/compressor.glade:594
 msgid "Lookahead"
 msgstr "Preduhvatiti"
 
-#: data/ui/limiter.glade:285
+#: data/ui/limiter.glade:332
 msgid "Oversampling"
 msgstr "Jači sampling"
 
-#: data/ui/limiter.glade:334
+#: data/ui/limiter.glade:385
 msgid "ASC"
 msgstr "ASC"
 
-#: data/ui/limiter.glade:395
+#: data/ui/limiter.glade:419
+#, fuzzy
+msgid "Output Gain"
+msgstr "Pojačanje ulaza"
+
+#: data/ui/limiter.glade:475
 msgid "Attenuation"
 msgstr "Prigušenje"
 
-#: data/ui/limiter.glade:569 data/ui/compressor.glade:1270
+#: data/ui/limiter.glade:649 data/ui/compressor.glade:1270
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
 #: data/ui/equalizer.glade:698 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
-#: data/ui/gate.glade:691 data/ui/multiband_gate.glade:2303
+#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:2303
 #: data/ui/deesser.glade:814 data/ui/pitch.glade:517 data/ui/webrtc.glade:785
 #: data/ui/delay.glade:404
 msgid "Provided by"
@@ -489,7 +502,7 @@ msgstr "Kompresor"
 #: data/ui/multiband_compressor.glade:942
 #: data/ui/multiband_compressor.glade:1320
 #: data/ui/multiband_compressor.glade:1698 data/ui/maximizer.glade:126
-#: data/ui/gate.glade:333 data/ui/multiband_gate.glade:588
+#: data/ui/gate.glade:344 data/ui/multiband_gate.glade:588
 #: data/ui/multiband_gate.glade:995 data/ui/multiband_gate.glade:1405
 #: data/ui/multiband_gate.glade:1815 data/ui/deesser.glade:458
 msgid "Threshold"
@@ -498,7 +511,7 @@ msgstr "Prag"
 #: data/ui/compressor.glade:299 data/ui/multiband_compressor.glade:601
 #: data/ui/multiband_compressor.glade:976
 #: data/ui/multiband_compressor.glade:1354
-#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:366
+#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:377
 #: data/ui/multiband_gate.glade:621 data/ui/multiband_gate.glade:1029
 #: data/ui/multiband_gate.glade:1439 data/ui/multiband_gate.glade:1849
 #: data/ui/deesser.glade:491
@@ -508,7 +521,7 @@ msgstr "Omjer"
 #: data/ui/compressor.glade:331 data/ui/multiband_compressor.glade:633
 #: data/ui/multiband_compressor.glade:1009
 #: data/ui/multiband_compressor.glade:1387
-#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:398
+#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:409
 #: data/ui/multiband_gate.glade:653 data/ui/multiband_gate.glade:1062
 #: data/ui/multiband_gate.glade:1472 data/ui/multiband_gate.glade:1882
 #, fuzzy
@@ -518,7 +531,7 @@ msgstr "Koljeno"
 #: data/ui/compressor.glade:365 data/ui/multiband_compressor.glade:667
 #: data/ui/multiband_compressor.glade:1044
 #: data/ui/multiband_compressor.glade:1422
-#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:432
+#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:443
 #: data/ui/multiband_gate.glade:687 data/ui/multiband_gate.glade:1097
 #: data/ui/multiband_gate.glade:1507 data/ui/multiband_gate.glade:1917
 #: data/ui/deesser.glade:522
@@ -529,7 +542,7 @@ msgstr "Dorada"
 #: data/ui/compressor.glade:413 data/ui/multiband_compressor.glade:500
 #: data/ui/multiband_compressor.glade:872
 #: data/ui/multiband_compressor.glade:1250
-#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:265
+#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:276
 #: data/ui/multiband_gate.glade:520 data/ui/multiband_gate.glade:925
 #: data/ui/multiband_gate.glade:1335 data/ui/multiband_gate.glade:1745
 msgid "Attack"
@@ -578,7 +591,7 @@ msgstr ""
 #: data/ui/compressor.glade:636 data/ui/multiband_compressor.glade:473
 #: data/ui/multiband_compressor.glade:845
 #: data/ui/multiband_compressor.glade:1223
-#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:220
+#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:231
 #: data/ui/multiband_gate.glade:493 data/ui/multiband_gate.glade:898
 #: data/ui/multiband_gate.glade:1308 data/ui/multiband_gate.glade:1718
 #: data/ui/deesser.glade:218 data/ui/deesser.glade:328
@@ -588,7 +601,7 @@ msgstr "Vrhunac"
 #: data/ui/compressor.glade:637 data/ui/multiband_compressor.glade:472
 #: data/ui/multiband_compressor.glade:844
 #: data/ui/multiband_compressor.glade:1222
-#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:219
+#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:230
 #: data/ui/multiband_gate.glade:492 data/ui/multiband_gate.glade:897
 #: data/ui/multiband_gate.glade:1307 data/ui/multiband_gate.glade:1717
 #: data/ui/deesser.glade:217
@@ -1220,7 +1233,7 @@ msgstr "Križno spajanje"
 msgid "Maximizer"
 msgstr "Maksimizer"
 
-#: data/ui/maximizer.glade:269 data/ui/gate.glade:190
+#: data/ui/maximizer.glade:269 data/ui/gate.glade:196
 msgid "Gain Reduction"
 msgstr "Ograničenje pojačanja"
 
@@ -1232,25 +1245,30 @@ msgstr "Veza"
 msgid "Gate"
 msgstr "Vrata"
 
-#: data/ui/gate.glade:162 data/ui/deesser.glade:190
+#: data/ui/gate.glade:169 data/ui/deesser.glade:190
 msgid "Detection"
 msgstr "Detekcija"
 
-#: data/ui/gate.glade:176
+#: data/ui/gate.glade:183
 msgid "Stereo Link"
 msgstr "Stereo veza"
 
-#: data/ui/gate.glade:235
+#: data/ui/gate.glade:247
 #, fuzzy
 msgid "Average"
 msgstr "Prosjek"
 
-#: data/ui/gate.glade:236
+#: data/ui/gate.glade:248
 #, fuzzy
 msgid "Maximum"
 msgstr "Maksimum"
 
-#: data/ui/gate.glade:667 data/ui/multiband_gate.glade:766
+#: data/ui/gate.glade:499
+#, fuzzy
+msgid "Input Level"
+msgstr "Ulazni uređaj"
+
+#: data/ui/gate.glade:720 data/ui/multiband_gate.glade:766
 #: data/ui/multiband_gate.glade:1175 data/ui/multiband_gate.glade:1585
 #: data/ui/multiband_gate.glade:1995
 msgid "Gating"
@@ -1882,9 +1900,6 @@ msgstr ""
 
 #~ msgid "Output Device"
 #~ msgstr "Izlazni uređaj"
-
-#~ msgid "Input Device"
-#~ msgstr "Ulazni uređaj"
 
 #~ msgid "Meters"
 #~ msgstr "Metri"

--- a/po/id_ID.po
+++ b/po/id_ID.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pulseeffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-21 17:09+0200\n"
+"POT-Creation-Date: 2020-07-22 20:34+0200\n"
 "PO-Revision-Date: 2019-01-17 18:30+0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -189,14 +189,14 @@ msgid "Use Dark Theme"
 msgstr "Gunakan Tema Gelap"
 
 #: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
-#: data/ui/limiter.glade:635 data/ui/compressor.glade:1335
+#: data/ui/limiter.glade:715 data/ui/compressor.glade:1335
 #: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
 #: data/ui/equalizer.glade:763 data/ui/equalizer_band.glade:183
 #: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
 #: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
 #: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
 #: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
-#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/gate.glade:809 data/ui/multiband_gate.glade:2368
 #: data/ui/deesser.glade:879 data/ui/convolver.glade:698
 #: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
 #: data/ui/webrtc.glade:850 data/ui/delay.glade:469
@@ -361,13 +361,13 @@ msgid "Weights"
 msgstr "Tinggi"
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:948
+#: data/ui/limiter.glade:445 data/ui/compressor.glade:948
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
 #: data/ui/equalizer.glade:501 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:243 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:532
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
 #: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
@@ -376,7 +376,7 @@ msgid "Input"
 msgstr "Masukan"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:962
+#: data/ui/limiter.glade:460 data/ui/compressor.glade:962
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
@@ -386,7 +386,7 @@ msgstr "Masukan"
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:547
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
@@ -422,48 +422,61 @@ msgstr ""
 msgid "Limiter"
 msgstr "Pembatas"
 
-#: data/ui/limiter.glade:149
+#: data/ui/limiter.glade:150
+msgid "Automatic Smoothing Control"
+msgstr ""
+
+#: data/ui/limiter.glade:164
+msgid "Automatic Leveling"
+msgstr ""
+
+#: data/ui/limiter.glade:196
 msgid "Input Gain"
 msgstr "Gain Input"
 
-#: data/ui/limiter.glade:182
+#: data/ui/limiter.glade:229
 msgid "Limit"
 msgstr "Batas"
 
-#: data/ui/limiter.glade:237 data/ui/compressor.glade:400
+#: data/ui/limiter.glade:284 data/ui/compressor.glade:400
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
 #: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
-#: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
+#: data/ui/gate.glade:310 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
 msgid "Release"
 msgstr "Rilis"
 
-#: data/ui/limiter.glade:250 data/ui/compressor.glade:594
+#: data/ui/limiter.glade:297 data/ui/compressor.glade:594
 msgid "Lookahead"
 msgstr "Lookahead"
 
-#: data/ui/limiter.glade:285
+#: data/ui/limiter.glade:332
 msgid "Oversampling"
 msgstr "Peningkat Sampling"
 
-#: data/ui/limiter.glade:334
+#: data/ui/limiter.glade:385
 msgid "ASC"
 msgstr "ASC"
 
-#: data/ui/limiter.glade:395
+#: data/ui/limiter.glade:419
+#, fuzzy
+msgid "Output Gain"
+msgstr "Gain Input"
+
+#: data/ui/limiter.glade:475
 msgid "Attenuation"
 msgstr "Atenuasi"
 
-#: data/ui/limiter.glade:569 data/ui/compressor.glade:1270
+#: data/ui/limiter.glade:649 data/ui/compressor.glade:1270
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
 #: data/ui/equalizer.glade:698 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
-#: data/ui/gate.glade:691 data/ui/multiband_gate.glade:2303
+#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:2303
 #: data/ui/deesser.glade:814 data/ui/pitch.glade:517 data/ui/webrtc.glade:785
 #: data/ui/delay.glade:404
 msgid "Provided by"
@@ -478,7 +491,7 @@ msgstr "Kompresor"
 #: data/ui/multiband_compressor.glade:942
 #: data/ui/multiband_compressor.glade:1320
 #: data/ui/multiband_compressor.glade:1698 data/ui/maximizer.glade:126
-#: data/ui/gate.glade:333 data/ui/multiband_gate.glade:588
+#: data/ui/gate.glade:344 data/ui/multiband_gate.glade:588
 #: data/ui/multiband_gate.glade:995 data/ui/multiband_gate.glade:1405
 #: data/ui/multiband_gate.glade:1815 data/ui/deesser.glade:458
 msgid "Threshold"
@@ -487,7 +500,7 @@ msgstr "Ambang Batas"
 #: data/ui/compressor.glade:299 data/ui/multiband_compressor.glade:601
 #: data/ui/multiband_compressor.glade:976
 #: data/ui/multiband_compressor.glade:1354
-#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:366
+#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:377
 #: data/ui/multiband_gate.glade:621 data/ui/multiband_gate.glade:1029
 #: data/ui/multiband_gate.glade:1439 data/ui/multiband_gate.glade:1849
 #: data/ui/deesser.glade:491
@@ -497,7 +510,7 @@ msgstr "Rasio"
 #: data/ui/compressor.glade:331 data/ui/multiband_compressor.glade:633
 #: data/ui/multiband_compressor.glade:1009
 #: data/ui/multiband_compressor.glade:1387
-#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:398
+#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:409
 #: data/ui/multiband_gate.glade:653 data/ui/multiband_gate.glade:1062
 #: data/ui/multiband_gate.glade:1472 data/ui/multiband_gate.glade:1882
 msgid "Knee"
@@ -506,7 +519,7 @@ msgstr "Knee"
 #: data/ui/compressor.glade:365 data/ui/multiband_compressor.glade:667
 #: data/ui/multiband_compressor.glade:1044
 #: data/ui/multiband_compressor.glade:1422
-#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:432
+#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:443
 #: data/ui/multiband_gate.glade:687 data/ui/multiband_gate.glade:1097
 #: data/ui/multiband_gate.glade:1507 data/ui/multiband_gate.glade:1917
 #: data/ui/deesser.glade:522
@@ -516,7 +529,7 @@ msgstr "Penguatan"
 #: data/ui/compressor.glade:413 data/ui/multiband_compressor.glade:500
 #: data/ui/multiband_compressor.glade:872
 #: data/ui/multiband_compressor.glade:1250
-#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:265
+#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:276
 #: data/ui/multiband_gate.glade:520 data/ui/multiband_gate.glade:925
 #: data/ui/multiband_gate.glade:1335 data/ui/multiband_gate.glade:1745
 msgid "Attack"
@@ -565,7 +578,7 @@ msgstr "Tipe"
 #: data/ui/compressor.glade:636 data/ui/multiband_compressor.glade:473
 #: data/ui/multiband_compressor.glade:845
 #: data/ui/multiband_compressor.glade:1223
-#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:220
+#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:231
 #: data/ui/multiband_gate.glade:493 data/ui/multiband_gate.glade:898
 #: data/ui/multiband_gate.glade:1308 data/ui/multiband_gate.glade:1718
 #: data/ui/deesser.glade:218 data/ui/deesser.glade:328
@@ -575,7 +588,7 @@ msgstr "Peak"
 #: data/ui/compressor.glade:637 data/ui/multiband_compressor.glade:472
 #: data/ui/multiband_compressor.glade:844
 #: data/ui/multiband_compressor.glade:1222
-#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:219
+#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:230
 #: data/ui/multiband_gate.glade:492 data/ui/multiband_gate.glade:897
 #: data/ui/multiband_gate.glade:1307 data/ui/multiband_gate.glade:1717
 #: data/ui/deesser.glade:217
@@ -1176,7 +1189,7 @@ msgstr "Crossfeed"
 msgid "Maximizer"
 msgstr "Pemaksimal Gain"
 
-#: data/ui/maximizer.glade:269 data/ui/gate.glade:190
+#: data/ui/maximizer.glade:269 data/ui/gate.glade:196
 msgid "Gain Reduction"
 msgstr "Pengurangan Kuatan"
 
@@ -1188,23 +1201,28 @@ msgstr "Penautan"
 msgid "Gate"
 msgstr "Gate"
 
-#: data/ui/gate.glade:162 data/ui/deesser.glade:190
+#: data/ui/gate.glade:169 data/ui/deesser.glade:190
 msgid "Detection"
 msgstr "Deteksi"
 
-#: data/ui/gate.glade:176
+#: data/ui/gate.glade:183
 msgid "Stereo Link"
 msgstr "Penautan Stereo"
 
-#: data/ui/gate.glade:235
+#: data/ui/gate.glade:247
 msgid "Average"
 msgstr "Rata-Rata"
 
-#: data/ui/gate.glade:236
+#: data/ui/gate.glade:248
 msgid "Maximum"
 msgstr "Maksimal"
 
-#: data/ui/gate.glade:667 data/ui/multiband_gate.glade:766
+#: data/ui/gate.glade:499
+#, fuzzy
+msgid "Input Level"
+msgstr "Pembatas Masukan"
+
+#: data/ui/gate.glade:720 data/ui/multiband_gate.glade:766
 #: data/ui/multiband_gate.glade:1175 data/ui/multiband_gate.glade:1585
 #: data/ui/multiband_gate.glade:1995
 msgid "Gating"

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -1316,7 +1316,7 @@ msgstr "Più Veloce"
 
 #: data/ui/pitch.glade:156
 msgid "Preserve Formant"
-msgstr "Preserva Formato"
+msgstr "Preserva Formante"
 
 #: data/ui/pitch.glade:180
 msgid "Cents"

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-21 17:09+0200\n"
+"POT-Creation-Date: 2020-07-22 20:34+0200\n"
 "PO-Revision-Date: 2019-03-28 17:38+0100\n"
 "Last-Translator: Gianluca Boiano <morf3089@gmail.com>\n"
 "Language-Team: \n"
@@ -189,14 +189,14 @@ msgid "Use Dark Theme"
 msgstr "Usa Tema Scuro"
 
 #: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
-#: data/ui/limiter.glade:635 data/ui/compressor.glade:1335
+#: data/ui/limiter.glade:715 data/ui/compressor.glade:1335
 #: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
 #: data/ui/equalizer.glade:763 data/ui/equalizer_band.glade:183
 #: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
 #: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
 #: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
 #: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
-#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/gate.glade:809 data/ui/multiband_gate.glade:2368
 #: data/ui/deesser.glade:879 data/ui/convolver.glade:698
 #: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
 #: data/ui/webrtc.glade:850 data/ui/delay.glade:469
@@ -353,13 +353,13 @@ msgid "Weights"
 msgstr "Ampiezze"
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:948
+#: data/ui/limiter.glade:445 data/ui/compressor.glade:948
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
 #: data/ui/equalizer.glade:501 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:243 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:532
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
 #: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
@@ -368,7 +368,7 @@ msgid "Input"
 msgstr "Ingresso"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:962
+#: data/ui/limiter.glade:460 data/ui/compressor.glade:962
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
@@ -378,7 +378,7 @@ msgstr "Ingresso"
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:547
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
@@ -414,48 +414,60 @@ msgstr "Basato su"
 msgid "Limiter"
 msgstr "Limitatore"
 
-#: data/ui/limiter.glade:149
+#: data/ui/limiter.glade:150
+msgid "Automatic Smoothing Control"
+msgstr "Controllo Smussamento Automatico"
+
+#: data/ui/limiter.glade:164
+msgid "Automatic Leveling"
+msgstr "Livellamento Automatico"
+
+#: data/ui/limiter.glade:196
 msgid "Input Gain"
 msgstr "Guadagno in Ingresso"
 
-#: data/ui/limiter.glade:182
+#: data/ui/limiter.glade:229
 msgid "Limit"
 msgstr "Limite"
 
-#: data/ui/limiter.glade:237 data/ui/compressor.glade:400
+#: data/ui/limiter.glade:284 data/ui/compressor.glade:400
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
 #: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
-#: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
+#: data/ui/gate.glade:310 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
 msgid "Release"
 msgstr "Rilascio"
 
-#: data/ui/limiter.glade:250 data/ui/compressor.glade:594
+#: data/ui/limiter.glade:297 data/ui/compressor.glade:594
 msgid "Lookahead"
 msgstr "Lookahead"
 
-#: data/ui/limiter.glade:285
+#: data/ui/limiter.glade:332
 msgid "Oversampling"
 msgstr "Sovracampionamento"
 
-#: data/ui/limiter.glade:334
+#: data/ui/limiter.glade:385
 msgid "ASC"
 msgstr "ASC"
 
-#: data/ui/limiter.glade:395
+#: data/ui/limiter.glade:419
+msgid "Output Gain"
+msgstr "Guadagno in Uscita"
+
+#: data/ui/limiter.glade:475
 msgid "Attenuation"
 msgstr "Attenuazione"
 
-#: data/ui/limiter.glade:569 data/ui/compressor.glade:1270
+#: data/ui/limiter.glade:649 data/ui/compressor.glade:1270
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
 #: data/ui/equalizer.glade:698 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
-#: data/ui/gate.glade:691 data/ui/multiband_gate.glade:2303
+#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:2303
 #: data/ui/deesser.glade:814 data/ui/pitch.glade:517 data/ui/webrtc.glade:785
 #: data/ui/delay.glade:404
 msgid "Provided by"
@@ -470,7 +482,7 @@ msgstr "Compressore"
 #: data/ui/multiband_compressor.glade:942
 #: data/ui/multiband_compressor.glade:1320
 #: data/ui/multiband_compressor.glade:1698 data/ui/maximizer.glade:126
-#: data/ui/gate.glade:333 data/ui/multiband_gate.glade:588
+#: data/ui/gate.glade:344 data/ui/multiband_gate.glade:588
 #: data/ui/multiband_gate.glade:995 data/ui/multiband_gate.glade:1405
 #: data/ui/multiband_gate.glade:1815 data/ui/deesser.glade:458
 msgid "Threshold"
@@ -479,7 +491,7 @@ msgstr "Soglia"
 #: data/ui/compressor.glade:299 data/ui/multiband_compressor.glade:601
 #: data/ui/multiband_compressor.glade:976
 #: data/ui/multiband_compressor.glade:1354
-#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:366
+#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:377
 #: data/ui/multiband_gate.glade:621 data/ui/multiband_gate.glade:1029
 #: data/ui/multiband_gate.glade:1439 data/ui/multiband_gate.glade:1849
 #: data/ui/deesser.glade:491
@@ -489,7 +501,7 @@ msgstr "Rapporto"
 #: data/ui/compressor.glade:331 data/ui/multiband_compressor.glade:633
 #: data/ui/multiband_compressor.glade:1009
 #: data/ui/multiband_compressor.glade:1387
-#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:398
+#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:409
 #: data/ui/multiband_gate.glade:653 data/ui/multiband_gate.glade:1062
 #: data/ui/multiband_gate.glade:1472 data/ui/multiband_gate.glade:1882
 msgid "Knee"
@@ -498,7 +510,7 @@ msgstr "Curvatura"
 #: data/ui/compressor.glade:365 data/ui/multiband_compressor.glade:667
 #: data/ui/multiband_compressor.glade:1044
 #: data/ui/multiband_compressor.glade:1422
-#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:432
+#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:443
 #: data/ui/multiband_gate.glade:687 data/ui/multiband_gate.glade:1097
 #: data/ui/multiband_gate.glade:1507 data/ui/multiband_gate.glade:1917
 #: data/ui/deesser.glade:522
@@ -508,7 +520,7 @@ msgstr "Guadagno"
 #: data/ui/compressor.glade:413 data/ui/multiband_compressor.glade:500
 #: data/ui/multiband_compressor.glade:872
 #: data/ui/multiband_compressor.glade:1250
-#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:265
+#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:276
 #: data/ui/multiband_gate.glade:520 data/ui/multiband_gate.glade:925
 #: data/ui/multiband_gate.glade:1335 data/ui/multiband_gate.glade:1745
 msgid "Attack"
@@ -554,7 +566,7 @@ msgstr "Tipologia"
 #: data/ui/compressor.glade:636 data/ui/multiband_compressor.glade:473
 #: data/ui/multiband_compressor.glade:845
 #: data/ui/multiband_compressor.glade:1223
-#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:220
+#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:231
 #: data/ui/multiband_gate.glade:493 data/ui/multiband_gate.glade:898
 #: data/ui/multiband_gate.glade:1308 data/ui/multiband_gate.glade:1718
 #: data/ui/deesser.glade:218 data/ui/deesser.glade:328
@@ -564,7 +576,7 @@ msgstr "Picco"
 #: data/ui/compressor.glade:637 data/ui/multiband_compressor.glade:472
 #: data/ui/multiband_compressor.glade:844
 #: data/ui/multiband_compressor.glade:1222
-#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:219
+#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:230
 #: data/ui/multiband_gate.glade:492 data/ui/multiband_gate.glade:897
 #: data/ui/multiband_gate.glade:1307 data/ui/multiband_gate.glade:1717
 #: data/ui/deesser.glade:217
@@ -650,7 +662,6 @@ msgid "24 dB/oct"
 msgstr "24 dB/ott"
 
 #: data/ui/compressor.glade:867 data/ui/compressor.glade:884
-#, fuzzy
 msgid "36 dB/oct"
 msgstr "36 dB/ott"
 
@@ -1155,7 +1166,7 @@ msgstr "Crossfeed"
 msgid "Maximizer"
 msgstr "Maximizer"
 
-#: data/ui/maximizer.glade:269 data/ui/gate.glade:190
+#: data/ui/maximizer.glade:269 data/ui/gate.glade:196
 msgid "Gain Reduction"
 msgstr "Riduzione Guadagno"
 
@@ -1167,23 +1178,27 @@ msgstr "Link"
 msgid "Gate"
 msgstr "Gate"
 
-#: data/ui/gate.glade:162 data/ui/deesser.glade:190
+#: data/ui/gate.glade:169 data/ui/deesser.glade:190
 msgid "Detection"
 msgstr "Rilevamento"
 
-#: data/ui/gate.glade:176
+#: data/ui/gate.glade:183
 msgid "Stereo Link"
 msgstr "Relazione Canali"
 
-#: data/ui/gate.glade:235
+#: data/ui/gate.glade:247
 msgid "Average"
 msgstr "Media"
 
-#: data/ui/gate.glade:236
+#: data/ui/gate.glade:248
 msgid "Maximum"
 msgstr "Massima"
 
-#: data/ui/gate.glade:667 data/ui/multiband_gate.glade:766
+#: data/ui/gate.glade:499
+msgid "Input Level"
+msgstr "Livello in Ingresso"
+
+#: data/ui/gate.glade:720 data/ui/multiband_gate.glade:766
 #: data/ui/multiband_gate.glade:1175 data/ui/multiband_gate.glade:1585
 #: data/ui/multiband_gate.glade:1995
 msgid "Gating"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PulseEffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-21 17:09+0200\n"
+"POT-Creation-Date: 2020-07-22 20:34+0200\n"
 "PO-Revision-Date: 2018-06-21 21:34+0200\n"
 "Last-Translator: Piotr Komur, pkomur@gmail.com\n"
 "Language-Team: \n"
@@ -191,14 +191,14 @@ msgid "Use Dark Theme"
 msgstr "Używaj ciemnego motywu"
 
 #: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
-#: data/ui/limiter.glade:635 data/ui/compressor.glade:1335
+#: data/ui/limiter.glade:715 data/ui/compressor.glade:1335
 #: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
 #: data/ui/equalizer.glade:763 data/ui/equalizer_band.glade:183
 #: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
 #: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
 #: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
 #: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
-#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/gate.glade:809 data/ui/multiband_gate.glade:2368
 #: data/ui/deesser.glade:879 data/ui/convolver.glade:698
 #: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
 #: data/ui/webrtc.glade:850 data/ui/delay.glade:469
@@ -368,13 +368,13 @@ msgid "Weights"
 msgstr "Wysokość"
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:948
+#: data/ui/limiter.glade:445 data/ui/compressor.glade:948
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
 #: data/ui/equalizer.glade:501 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:243 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:532
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
 #: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
@@ -383,7 +383,7 @@ msgid "Input"
 msgstr "Wejście"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:962
+#: data/ui/limiter.glade:460 data/ui/compressor.glade:962
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
@@ -393,7 +393,7 @@ msgstr "Wejście"
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:547
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
@@ -429,50 +429,63 @@ msgstr ""
 msgid "Limiter"
 msgstr "Limiter"
 
-#: data/ui/limiter.glade:149
+#: data/ui/limiter.glade:150
+msgid "Automatic Smoothing Control"
+msgstr ""
+
+#: data/ui/limiter.glade:164
+msgid "Automatic Leveling"
+msgstr ""
+
+#: data/ui/limiter.glade:196
 msgid "Input Gain"
 msgstr "Wzmocnienie wej."
 
-#: data/ui/limiter.glade:182
+#: data/ui/limiter.glade:229
 msgid "Limit"
 msgstr "Limit"
 
-#: data/ui/limiter.glade:237 data/ui/compressor.glade:400
+#: data/ui/limiter.glade:284 data/ui/compressor.glade:400
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
 #: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
-#: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
+#: data/ui/gate.glade:310 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
 msgid "Release"
 msgstr "Wyzwolenie"
 
 # Podgląd, albo "patrz w przód", zapas
-#: data/ui/limiter.glade:250 data/ui/compressor.glade:594
+#: data/ui/limiter.glade:297 data/ui/compressor.glade:594
 msgid "Lookahead"
 msgstr "Lookahead"
 
-#: data/ui/limiter.glade:285
+#: data/ui/limiter.glade:332
 msgid "Oversampling"
 msgstr "Nadpróbkowanie"
 
-#: data/ui/limiter.glade:334
+#: data/ui/limiter.glade:385
 msgid "ASC"
 msgstr "ASC"
 
+#: data/ui/limiter.glade:419
+#, fuzzy
+msgid "Output Gain"
+msgstr "Wzmocnienie wej."
+
 # Tłumienie?
-#: data/ui/limiter.glade:395
+#: data/ui/limiter.glade:475
 msgid "Attenuation"
 msgstr "Tłumienie"
 
-#: data/ui/limiter.glade:569 data/ui/compressor.glade:1270
+#: data/ui/limiter.glade:649 data/ui/compressor.glade:1270
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
 #: data/ui/equalizer.glade:698 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
-#: data/ui/gate.glade:691 data/ui/multiband_gate.glade:2303
+#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:2303
 #: data/ui/deesser.glade:814 data/ui/pitch.glade:517 data/ui/webrtc.glade:785
 #: data/ui/delay.glade:404
 msgid "Provided by"
@@ -487,7 +500,7 @@ msgstr "Kompresor"
 #: data/ui/multiband_compressor.glade:942
 #: data/ui/multiband_compressor.glade:1320
 #: data/ui/multiband_compressor.glade:1698 data/ui/maximizer.glade:126
-#: data/ui/gate.glade:333 data/ui/multiband_gate.glade:588
+#: data/ui/gate.glade:344 data/ui/multiband_gate.glade:588
 #: data/ui/multiband_gate.glade:995 data/ui/multiband_gate.glade:1405
 #: data/ui/multiband_gate.glade:1815 data/ui/deesser.glade:458
 msgid "Threshold"
@@ -496,7 +509,7 @@ msgstr "Próg"
 #: data/ui/compressor.glade:299 data/ui/multiband_compressor.glade:601
 #: data/ui/multiband_compressor.glade:976
 #: data/ui/multiband_compressor.glade:1354
-#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:366
+#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:377
 #: data/ui/multiband_gate.glade:621 data/ui/multiband_gate.glade:1029
 #: data/ui/multiband_gate.glade:1439 data/ui/multiband_gate.glade:1849
 #: data/ui/deesser.glade:491
@@ -506,7 +519,7 @@ msgstr "Stosunek"
 #: data/ui/compressor.glade:331 data/ui/multiband_compressor.glade:633
 #: data/ui/multiband_compressor.glade:1009
 #: data/ui/multiband_compressor.glade:1387
-#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:398
+#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:409
 #: data/ui/multiband_gate.glade:653 data/ui/multiband_gate.glade:1062
 #: data/ui/multiband_gate.glade:1472 data/ui/multiband_gate.glade:1882
 msgid "Knee"
@@ -517,7 +530,7 @@ msgstr "Kolano"
 #: data/ui/compressor.glade:365 data/ui/multiband_compressor.glade:667
 #: data/ui/multiband_compressor.glade:1044
 #: data/ui/multiband_compressor.glade:1422
-#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:432
+#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:443
 #: data/ui/multiband_gate.glade:687 data/ui/multiband_gate.glade:1097
 #: data/ui/multiband_gate.glade:1507 data/ui/multiband_gate.glade:1917
 #: data/ui/deesser.glade:522
@@ -527,7 +540,7 @@ msgstr "Wzmocnienie"
 #: data/ui/compressor.glade:413 data/ui/multiband_compressor.glade:500
 #: data/ui/multiband_compressor.glade:872
 #: data/ui/multiband_compressor.glade:1250
-#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:265
+#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:276
 #: data/ui/multiband_gate.glade:520 data/ui/multiband_gate.glade:925
 #: data/ui/multiband_gate.glade:1335 data/ui/multiband_gate.glade:1745
 msgid "Attack"
@@ -578,7 +591,7 @@ msgstr ""
 #: data/ui/compressor.glade:636 data/ui/multiband_compressor.glade:473
 #: data/ui/multiband_compressor.glade:845
 #: data/ui/multiband_compressor.glade:1223
-#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:220
+#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:231
 #: data/ui/multiband_gate.glade:493 data/ui/multiband_gate.glade:898
 #: data/ui/multiband_gate.glade:1308 data/ui/multiband_gate.glade:1718
 #: data/ui/deesser.glade:218 data/ui/deesser.glade:328
@@ -588,7 +601,7 @@ msgstr "Szczyt"
 #: data/ui/compressor.glade:637 data/ui/multiband_compressor.glade:472
 #: data/ui/multiband_compressor.glade:844
 #: data/ui/multiband_compressor.glade:1222
-#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:219
+#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:230
 #: data/ui/multiband_gate.glade:492 data/ui/multiband_gate.glade:897
 #: data/ui/multiband_gate.glade:1307 data/ui/multiband_gate.glade:1717
 #: data/ui/deesser.glade:217
@@ -1212,7 +1225,7 @@ msgstr "Crossfeed"
 msgid "Maximizer"
 msgstr "Maximizer"
 
-#: data/ui/maximizer.glade:269 data/ui/gate.glade:190
+#: data/ui/maximizer.glade:269 data/ui/gate.glade:196
 msgid "Gain Reduction"
 msgstr "Redukcja wzmocnienia"
 
@@ -1224,23 +1237,28 @@ msgstr ""
 msgid "Gate"
 msgstr "Bramka"
 
-#: data/ui/gate.glade:162 data/ui/deesser.glade:190
+#: data/ui/gate.glade:169 data/ui/deesser.glade:190
 msgid "Detection"
 msgstr "Wykrycie"
 
-#: data/ui/gate.glade:176
+#: data/ui/gate.glade:183
 msgid "Stereo Link"
 msgstr "Powiązanie stereo"
 
-#: data/ui/gate.glade:235
+#: data/ui/gate.glade:247
 msgid "Average"
 msgstr "Średnia"
 
-#: data/ui/gate.glade:236
+#: data/ui/gate.glade:248
 msgid "Maximum"
 msgstr "Maksimum"
 
-#: data/ui/gate.glade:667 data/ui/multiband_gate.glade:766
+#: data/ui/gate.glade:499
+#, fuzzy
+msgid "Input Level"
+msgstr "Urządzenie wejściowe"
+
+#: data/ui/gate.glade:720 data/ui/multiband_gate.glade:766
 #: data/ui/multiband_gate.glade:1175 data/ui/multiband_gate.glade:1585
 #: data/ui/multiband_gate.glade:1995
 msgid "Gating"
@@ -1789,9 +1807,6 @@ msgstr ""
 
 #~ msgid "Output Device"
 #~ msgstr "Urządzenie wyjściowe"
-
-#~ msgid "Input Device"
-#~ msgstr "Urządzenie wejściowe"
 
 #~ msgid "Tolerance"
 #~ msgstr "Tolerancja"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PulseEffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-21 17:09+0200\n"
+"POT-Creation-Date: 2020-07-22 20:34+0200\n"
 "PO-Revision-Date: 2019-09-10 12:56-0300\n"
 "Last-Translator: Patrik Nilsson <translation_AT_hembas.se>\n"
 "Language-Team: Portuguese <>\n"
@@ -188,14 +188,14 @@ msgid "Use Dark Theme"
 msgstr "Usar Tema Escuro"
 
 #: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
-#: data/ui/limiter.glade:635 data/ui/compressor.glade:1335
+#: data/ui/limiter.glade:715 data/ui/compressor.glade:1335
 #: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
 #: data/ui/equalizer.glade:763 data/ui/equalizer_band.glade:183
 #: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
 #: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
 #: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
 #: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
-#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/gate.glade:809 data/ui/multiband_gate.glade:2368
 #: data/ui/deesser.glade:879 data/ui/convolver.glade:698
 #: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
 #: data/ui/webrtc.glade:850 data/ui/delay.glade:469
@@ -353,13 +353,13 @@ msgid "Weights"
 msgstr "Pesos"
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:948
+#: data/ui/limiter.glade:445 data/ui/compressor.glade:948
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
 #: data/ui/equalizer.glade:501 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:243 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:532
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
 #: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
@@ -368,7 +368,7 @@ msgid "Input"
 msgstr "Entrada"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:962
+#: data/ui/limiter.glade:460 data/ui/compressor.glade:962
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
@@ -378,7 +378,7 @@ msgstr "Entrada"
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:547
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
@@ -414,48 +414,61 @@ msgstr ""
 msgid "Limiter"
 msgstr "Limitador"
 
-#: data/ui/limiter.glade:149
+#: data/ui/limiter.glade:150
+msgid "Automatic Smoothing Control"
+msgstr ""
+
+#: data/ui/limiter.glade:164
+msgid "Automatic Leveling"
+msgstr ""
+
+#: data/ui/limiter.glade:196
 msgid "Input Gain"
 msgstr "Ganho de Entrada"
 
-#: data/ui/limiter.glade:182
+#: data/ui/limiter.glade:229
 msgid "Limit"
 msgstr "Limite"
 
-#: data/ui/limiter.glade:237 data/ui/compressor.glade:400
+#: data/ui/limiter.glade:284 data/ui/compressor.glade:400
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
 #: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
-#: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
+#: data/ui/gate.glade:310 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
 msgid "Release"
 msgstr "Liberação"
 
-#: data/ui/limiter.glade:250 data/ui/compressor.glade:594
+#: data/ui/limiter.glade:297 data/ui/compressor.glade:594
 msgid "Lookahead"
 msgstr "Lookahead"
 
-#: data/ui/limiter.glade:285
+#: data/ui/limiter.glade:332
 msgid "Oversampling"
 msgstr "Oversampling"
 
-#: data/ui/limiter.glade:334
+#: data/ui/limiter.glade:385
 msgid "ASC"
 msgstr "ASC"
 
-#: data/ui/limiter.glade:395
+#: data/ui/limiter.glade:419
+#, fuzzy
+msgid "Output Gain"
+msgstr "Ganho de Entrada"
+
+#: data/ui/limiter.glade:475
 msgid "Attenuation"
 msgstr "Atenuação"
 
-#: data/ui/limiter.glade:569 data/ui/compressor.glade:1270
+#: data/ui/limiter.glade:649 data/ui/compressor.glade:1270
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
 #: data/ui/equalizer.glade:698 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
-#: data/ui/gate.glade:691 data/ui/multiband_gate.glade:2303
+#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:2303
 #: data/ui/deesser.glade:814 data/ui/pitch.glade:517 data/ui/webrtc.glade:785
 #: data/ui/delay.glade:404
 msgid "Provided by"
@@ -470,7 +483,7 @@ msgstr "Compressor"
 #: data/ui/multiband_compressor.glade:942
 #: data/ui/multiband_compressor.glade:1320
 #: data/ui/multiband_compressor.glade:1698 data/ui/maximizer.glade:126
-#: data/ui/gate.glade:333 data/ui/multiband_gate.glade:588
+#: data/ui/gate.glade:344 data/ui/multiband_gate.glade:588
 #: data/ui/multiband_gate.glade:995 data/ui/multiband_gate.glade:1405
 #: data/ui/multiband_gate.glade:1815 data/ui/deesser.glade:458
 msgid "Threshold"
@@ -479,7 +492,7 @@ msgstr "Limiar"
 #: data/ui/compressor.glade:299 data/ui/multiband_compressor.glade:601
 #: data/ui/multiband_compressor.glade:976
 #: data/ui/multiband_compressor.glade:1354
-#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:366
+#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:377
 #: data/ui/multiband_gate.glade:621 data/ui/multiband_gate.glade:1029
 #: data/ui/multiband_gate.glade:1439 data/ui/multiband_gate.glade:1849
 #: data/ui/deesser.glade:491
@@ -489,7 +502,7 @@ msgstr "Razão"
 #: data/ui/compressor.glade:331 data/ui/multiband_compressor.glade:633
 #: data/ui/multiband_compressor.glade:1009
 #: data/ui/multiband_compressor.glade:1387
-#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:398
+#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:409
 #: data/ui/multiband_gate.glade:653 data/ui/multiband_gate.glade:1062
 #: data/ui/multiband_gate.glade:1472 data/ui/multiband_gate.glade:1882
 msgid "Knee"
@@ -498,7 +511,7 @@ msgstr "Joelho"
 #: data/ui/compressor.glade:365 data/ui/multiband_compressor.glade:667
 #: data/ui/multiband_compressor.glade:1044
 #: data/ui/multiband_compressor.glade:1422
-#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:432
+#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:443
 #: data/ui/multiband_gate.glade:687 data/ui/multiband_gate.glade:1097
 #: data/ui/multiband_gate.glade:1507 data/ui/multiband_gate.glade:1917
 #: data/ui/deesser.glade:522
@@ -508,7 +521,7 @@ msgstr "Ganho de Saída"
 #: data/ui/compressor.glade:413 data/ui/multiband_compressor.glade:500
 #: data/ui/multiband_compressor.glade:872
 #: data/ui/multiband_compressor.glade:1250
-#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:265
+#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:276
 #: data/ui/multiband_gate.glade:520 data/ui/multiband_gate.glade:925
 #: data/ui/multiband_gate.glade:1335 data/ui/multiband_gate.glade:1745
 msgid "Attack"
@@ -554,7 +567,7 @@ msgstr "Tipo"
 #: data/ui/compressor.glade:636 data/ui/multiband_compressor.glade:473
 #: data/ui/multiband_compressor.glade:845
 #: data/ui/multiband_compressor.glade:1223
-#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:220
+#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:231
 #: data/ui/multiband_gate.glade:493 data/ui/multiband_gate.glade:898
 #: data/ui/multiband_gate.glade:1308 data/ui/multiband_gate.glade:1718
 #: data/ui/deesser.glade:218 data/ui/deesser.glade:328
@@ -564,7 +577,7 @@ msgstr "Pico"
 #: data/ui/compressor.glade:637 data/ui/multiband_compressor.glade:472
 #: data/ui/multiband_compressor.glade:844
 #: data/ui/multiband_compressor.glade:1222
-#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:219
+#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:230
 #: data/ui/multiband_gate.glade:492 data/ui/multiband_gate.glade:897
 #: data/ui/multiband_gate.glade:1307 data/ui/multiband_gate.glade:1717
 #: data/ui/deesser.glade:217
@@ -1162,7 +1175,7 @@ msgstr "Crossfeed"
 msgid "Maximizer"
 msgstr "Maximizador"
 
-#: data/ui/maximizer.glade:269 data/ui/gate.glade:190
+#: data/ui/maximizer.glade:269 data/ui/gate.glade:196
 msgid "Gain Reduction"
 msgstr "Redução de Ganho"
 
@@ -1174,23 +1187,28 @@ msgstr "Elo"
 msgid "Gate"
 msgstr "Gate"
 
-#: data/ui/gate.glade:162 data/ui/deesser.glade:190
+#: data/ui/gate.glade:169 data/ui/deesser.glade:190
 msgid "Detection"
 msgstr "Detecção"
 
-#: data/ui/gate.glade:176
+#: data/ui/gate.glade:183
 msgid "Stereo Link"
 msgstr "Elo Stereo"
 
-#: data/ui/gate.glade:235
+#: data/ui/gate.glade:247
 msgid "Average"
 msgstr "Médio"
 
-#: data/ui/gate.glade:236
+#: data/ui/gate.glade:248
 msgid "Maximum"
 msgstr "Máximo"
 
-#: data/ui/gate.glade:667 data/ui/multiband_gate.glade:766
+#: data/ui/gate.glade:499
+#, fuzzy
+msgid "Input Level"
+msgstr "Dispositivo de Entrada"
+
+#: data/ui/gate.glade:720 data/ui/multiband_gate.glade:766
 #: data/ui/multiband_gate.glade:1175 data/ui/multiband_gate.glade:1585
 #: data/ui/multiband_gate.glade:1995
 msgid "Gating"
@@ -1662,6 +1680,12 @@ msgstr "Não Foi Possível Carregar o Arquivo com o Impulso"
 #: src/equalizer_ui.cpp:342 src/equalizer_ui.cpp:466
 msgid "infinity"
 msgstr "infinito"
+
+#, fuzzy
+#~ msgid "0"
+#~ msgstr ""
+#~ "0 - Desativa a ressincronização de fase em transientes, a laminação de "
+#~ "fase e usa uma janela de processamento mais longa."
 
 #, fuzzy
 #~ msgid "Rubber Band"
@@ -2286,12 +2310,6 @@ msgstr "infinito"
 #~ "A chave que habilita/desabilita o applicativo foi movido para um local "
 #~ "mais óbvio"
 
-#, fuzzy
-#~ msgid "0"
-#~ msgstr ""
-#~ "0 - Desativa a ressincronização de fase em transientes, a laminação de "
-#~ "fase e usa uma janela de processamento mais longa."
-
 #~ msgid "Tolerance"
 #~ msgstr "Tolerância"
 
@@ -2324,9 +2342,6 @@ msgstr "infinito"
 
 #~ msgid "Output Device"
 #~ msgstr "Dispositivo de Saída"
-
-#~ msgid "Input Device"
-#~ msgstr "Dispositivo de Entrada"
 
 #~ msgid "Meters"
 #~ msgstr "Metros"

--- a/po/pulseeffects.pot
+++ b/po/pulseeffects.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pulseeffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-21 17:09+0200\n"
+"POT-Creation-Date: 2020-07-22 20:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -184,14 +184,14 @@ msgid "Use Dark Theme"
 msgstr ""
 
 #: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
-#: data/ui/limiter.glade:635 data/ui/compressor.glade:1335
+#: data/ui/limiter.glade:715 data/ui/compressor.glade:1335
 #: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
 #: data/ui/equalizer.glade:763 data/ui/equalizer_band.glade:183
 #: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
 #: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
 #: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
 #: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
-#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/gate.glade:809 data/ui/multiband_gate.glade:2368
 #: data/ui/deesser.glade:879 data/ui/convolver.glade:698
 #: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
 #: data/ui/webrtc.glade:850 data/ui/delay.glade:469
@@ -348,13 +348,13 @@ msgid "Weights"
 msgstr ""
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:948
+#: data/ui/limiter.glade:445 data/ui/compressor.glade:948
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
 #: data/ui/equalizer.glade:501 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:243 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:532
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
 #: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
@@ -363,7 +363,7 @@ msgid "Input"
 msgstr ""
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:962
+#: data/ui/limiter.glade:460 data/ui/compressor.glade:962
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
@@ -373,7 +373,7 @@ msgstr ""
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:547
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
@@ -409,48 +409,60 @@ msgstr ""
 msgid "Limiter"
 msgstr ""
 
-#: data/ui/limiter.glade:149
+#: data/ui/limiter.glade:150
+msgid "Automatic Smoothing Control"
+msgstr ""
+
+#: data/ui/limiter.glade:164
+msgid "Automatic Leveling"
+msgstr ""
+
+#: data/ui/limiter.glade:196
 msgid "Input Gain"
 msgstr ""
 
-#: data/ui/limiter.glade:182
+#: data/ui/limiter.glade:229
 msgid "Limit"
 msgstr ""
 
-#: data/ui/limiter.glade:237 data/ui/compressor.glade:400
+#: data/ui/limiter.glade:284 data/ui/compressor.glade:400
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
 #: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
-#: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
+#: data/ui/gate.glade:310 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
 msgid "Release"
 msgstr ""
 
-#: data/ui/limiter.glade:250 data/ui/compressor.glade:594
+#: data/ui/limiter.glade:297 data/ui/compressor.glade:594
 msgid "Lookahead"
 msgstr ""
 
-#: data/ui/limiter.glade:285
+#: data/ui/limiter.glade:332
 msgid "Oversampling"
 msgstr ""
 
-#: data/ui/limiter.glade:334
+#: data/ui/limiter.glade:385
 msgid "ASC"
 msgstr ""
 
-#: data/ui/limiter.glade:395
+#: data/ui/limiter.glade:419
+msgid "Output Gain"
+msgstr ""
+
+#: data/ui/limiter.glade:475
 msgid "Attenuation"
 msgstr ""
 
-#: data/ui/limiter.glade:569 data/ui/compressor.glade:1270
+#: data/ui/limiter.glade:649 data/ui/compressor.glade:1270
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
 #: data/ui/equalizer.glade:698 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
-#: data/ui/gate.glade:691 data/ui/multiband_gate.glade:2303
+#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:2303
 #: data/ui/deesser.glade:814 data/ui/pitch.glade:517 data/ui/webrtc.glade:785
 #: data/ui/delay.glade:404
 msgid "Provided by"
@@ -465,7 +477,7 @@ msgstr ""
 #: data/ui/multiband_compressor.glade:942
 #: data/ui/multiband_compressor.glade:1320
 #: data/ui/multiband_compressor.glade:1698 data/ui/maximizer.glade:126
-#: data/ui/gate.glade:333 data/ui/multiband_gate.glade:588
+#: data/ui/gate.glade:344 data/ui/multiband_gate.glade:588
 #: data/ui/multiband_gate.glade:995 data/ui/multiband_gate.glade:1405
 #: data/ui/multiband_gate.glade:1815 data/ui/deesser.glade:458
 msgid "Threshold"
@@ -474,7 +486,7 @@ msgstr ""
 #: data/ui/compressor.glade:299 data/ui/multiband_compressor.glade:601
 #: data/ui/multiband_compressor.glade:976
 #: data/ui/multiband_compressor.glade:1354
-#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:366
+#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:377
 #: data/ui/multiband_gate.glade:621 data/ui/multiband_gate.glade:1029
 #: data/ui/multiband_gate.glade:1439 data/ui/multiband_gate.glade:1849
 #: data/ui/deesser.glade:491
@@ -484,7 +496,7 @@ msgstr ""
 #: data/ui/compressor.glade:331 data/ui/multiband_compressor.glade:633
 #: data/ui/multiband_compressor.glade:1009
 #: data/ui/multiband_compressor.glade:1387
-#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:398
+#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:409
 #: data/ui/multiband_gate.glade:653 data/ui/multiband_gate.glade:1062
 #: data/ui/multiband_gate.glade:1472 data/ui/multiband_gate.glade:1882
 msgid "Knee"
@@ -493,7 +505,7 @@ msgstr ""
 #: data/ui/compressor.glade:365 data/ui/multiband_compressor.glade:667
 #: data/ui/multiband_compressor.glade:1044
 #: data/ui/multiband_compressor.glade:1422
-#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:432
+#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:443
 #: data/ui/multiband_gate.glade:687 data/ui/multiband_gate.glade:1097
 #: data/ui/multiband_gate.glade:1507 data/ui/multiband_gate.glade:1917
 #: data/ui/deesser.glade:522
@@ -503,7 +515,7 @@ msgstr ""
 #: data/ui/compressor.glade:413 data/ui/multiband_compressor.glade:500
 #: data/ui/multiband_compressor.glade:872
 #: data/ui/multiband_compressor.glade:1250
-#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:265
+#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:276
 #: data/ui/multiband_gate.glade:520 data/ui/multiband_gate.glade:925
 #: data/ui/multiband_gate.glade:1335 data/ui/multiband_gate.glade:1745
 msgid "Attack"
@@ -549,7 +561,7 @@ msgstr ""
 #: data/ui/compressor.glade:636 data/ui/multiband_compressor.glade:473
 #: data/ui/multiband_compressor.glade:845
 #: data/ui/multiband_compressor.glade:1223
-#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:220
+#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:231
 #: data/ui/multiband_gate.glade:493 data/ui/multiband_gate.glade:898
 #: data/ui/multiband_gate.glade:1308 data/ui/multiband_gate.glade:1718
 #: data/ui/deesser.glade:218 data/ui/deesser.glade:328
@@ -559,7 +571,7 @@ msgstr ""
 #: data/ui/compressor.glade:637 data/ui/multiband_compressor.glade:472
 #: data/ui/multiband_compressor.glade:844
 #: data/ui/multiband_compressor.glade:1222
-#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:219
+#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:230
 #: data/ui/multiband_gate.glade:492 data/ui/multiband_gate.glade:897
 #: data/ui/multiband_gate.glade:1307 data/ui/multiband_gate.glade:1717
 #: data/ui/deesser.glade:217
@@ -1149,7 +1161,7 @@ msgstr ""
 msgid "Maximizer"
 msgstr ""
 
-#: data/ui/maximizer.glade:269 data/ui/gate.glade:190
+#: data/ui/maximizer.glade:269 data/ui/gate.glade:196
 msgid "Gain Reduction"
 msgstr ""
 
@@ -1161,23 +1173,27 @@ msgstr ""
 msgid "Gate"
 msgstr ""
 
-#: data/ui/gate.glade:162 data/ui/deesser.glade:190
+#: data/ui/gate.glade:169 data/ui/deesser.glade:190
 msgid "Detection"
 msgstr ""
 
-#: data/ui/gate.glade:176
+#: data/ui/gate.glade:183
 msgid "Stereo Link"
 msgstr ""
 
-#: data/ui/gate.glade:235
+#: data/ui/gate.glade:247
 msgid "Average"
 msgstr ""
 
-#: data/ui/gate.glade:236
+#: data/ui/gate.glade:248
 msgid "Maximum"
 msgstr ""
 
-#: data/ui/gate.glade:667 data/ui/multiband_gate.glade:766
+#: data/ui/gate.glade:499
+msgid "Input Level"
+msgstr ""
+
+#: data/ui/gate.glade:720 data/ui/multiband_gate.glade:766
 #: data/ui/multiband_gate.glade:1175 data/ui/multiband_gate.glade:1585
 #: data/ui/multiband_gate.glade:1995
 msgid "Gating"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-21 17:09+0200\n"
+"POT-Creation-Date: 2020-07-22 20:34+0200\n"
 "PO-Revision-Date: 2018-07-18 22:14+0300\n"
 "Last-Translator: Mikhail Novosyolov <mikhailnov@dumalogiya.ru>\n"
 "Language-Team: \n"
@@ -189,14 +189,14 @@ msgid "Use Dark Theme"
 msgstr "Исп. тёмную тему"
 
 #: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
-#: data/ui/limiter.glade:635 data/ui/compressor.glade:1335
+#: data/ui/limiter.glade:715 data/ui/compressor.glade:1335
 #: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
 #: data/ui/equalizer.glade:763 data/ui/equalizer_band.glade:183
 #: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
 #: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
 #: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
 #: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
-#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/gate.glade:809 data/ui/multiband_gate.glade:2368
 #: data/ui/deesser.glade:879 data/ui/convolver.glade:698
 #: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
 #: data/ui/webrtc.glade:850 data/ui/delay.glade:469
@@ -370,13 +370,13 @@ msgstr "Вес в расчете громкости"
 # msgstr "Влияние комплексных измерений"
 # ###############################################
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:948
+#: data/ui/limiter.glade:445 data/ui/compressor.glade:948
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
 #: data/ui/equalizer.glade:501 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:243 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:532
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
 #: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
@@ -385,7 +385,7 @@ msgid "Input"
 msgstr "Вход"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:962
+#: data/ui/limiter.glade:460 data/ui/compressor.glade:962
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
@@ -395,7 +395,7 @@ msgstr "Вход"
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:547
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
@@ -432,48 +432,61 @@ msgstr ""
 msgid "Limiter"
 msgstr "Ограничитель уровня звука (лимитер)"
 
-#: data/ui/limiter.glade:149
+#: data/ui/limiter.glade:150
+msgid "Automatic Smoothing Control"
+msgstr ""
+
+#: data/ui/limiter.glade:164
+msgid "Automatic Leveling"
+msgstr ""
+
+#: data/ui/limiter.glade:196
 msgid "Input Gain"
 msgstr "Уровень предусиления"
 
-#: data/ui/limiter.glade:182
+#: data/ui/limiter.glade:229
 msgid "Limit"
 msgstr "Ограничение"
 
-#: data/ui/limiter.glade:237 data/ui/compressor.glade:400
+#: data/ui/limiter.glade:284 data/ui/compressor.glade:400
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
 #: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
-#: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
+#: data/ui/gate.glade:310 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
 msgid "Release"
 msgstr "Восстановление"
 
-#: data/ui/limiter.glade:250 data/ui/compressor.glade:594
+#: data/ui/limiter.glade:297 data/ui/compressor.glade:594
 msgid "Lookahead"
 msgstr "Задержка (lookahead)"
 
-#: data/ui/limiter.glade:285
+#: data/ui/limiter.glade:332
 msgid "Oversampling"
 msgstr "Передискретизация"
 
-#: data/ui/limiter.glade:334
+#: data/ui/limiter.glade:385
 msgid "ASC"
 msgstr "Адаптивное управление наклоном"
 
-#: data/ui/limiter.glade:395
+#: data/ui/limiter.glade:419
+#, fuzzy
+msgid "Output Gain"
+msgstr "Уровень предусиления"
+
+#: data/ui/limiter.glade:475
 msgid "Attenuation"
 msgstr "Затухание"
 
-#: data/ui/limiter.glade:569 data/ui/compressor.glade:1270
+#: data/ui/limiter.glade:649 data/ui/compressor.glade:1270
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
 #: data/ui/equalizer.glade:698 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
-#: data/ui/gate.glade:691 data/ui/multiband_gate.glade:2303
+#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:2303
 #: data/ui/deesser.glade:814 data/ui/pitch.glade:517 data/ui/webrtc.glade:785
 #: data/ui/delay.glade:404
 msgid "Provided by"
@@ -488,7 +501,7 @@ msgstr "Компрессор"
 #: data/ui/multiband_compressor.glade:942
 #: data/ui/multiband_compressor.glade:1320
 #: data/ui/multiband_compressor.glade:1698 data/ui/maximizer.glade:126
-#: data/ui/gate.glade:333 data/ui/multiband_gate.glade:588
+#: data/ui/gate.glade:344 data/ui/multiband_gate.glade:588
 #: data/ui/multiband_gate.glade:995 data/ui/multiband_gate.glade:1405
 #: data/ui/multiband_gate.glade:1815 data/ui/deesser.glade:458
 msgid "Threshold"
@@ -497,7 +510,7 @@ msgstr "Порог срабатывания"
 #: data/ui/compressor.glade:299 data/ui/multiband_compressor.glade:601
 #: data/ui/multiband_compressor.glade:976
 #: data/ui/multiband_compressor.glade:1354
-#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:366
+#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:377
 #: data/ui/multiband_gate.glade:621 data/ui/multiband_gate.glade:1029
 #: data/ui/multiband_gate.glade:1439 data/ui/multiband_gate.glade:1849
 #: data/ui/deesser.glade:491
@@ -507,7 +520,7 @@ msgstr "Степень сжатия"
 #: data/ui/compressor.glade:331 data/ui/multiband_compressor.glade:633
 #: data/ui/multiband_compressor.glade:1009
 #: data/ui/multiband_compressor.glade:1387
-#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:398
+#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:409
 #: data/ui/multiband_gate.glade:653 data/ui/multiband_gate.glade:1062
 #: data/ui/multiband_gate.glade:1472 data/ui/multiband_gate.glade:1882
 msgid "Knee"
@@ -516,7 +529,7 @@ msgstr "Колено (излом)"
 #: data/ui/compressor.glade:365 data/ui/multiband_compressor.glade:667
 #: data/ui/multiband_compressor.glade:1044
 #: data/ui/multiband_compressor.glade:1422
-#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:432
+#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:443
 #: data/ui/multiband_gate.glade:687 data/ui/multiband_gate.glade:1097
 #: data/ui/multiband_gate.glade:1507 data/ui/multiband_gate.glade:1917
 #: data/ui/deesser.glade:522
@@ -526,7 +539,7 @@ msgstr "Компенсирование"
 #: data/ui/compressor.glade:413 data/ui/multiband_compressor.glade:500
 #: data/ui/multiband_compressor.glade:872
 #: data/ui/multiband_compressor.glade:1250
-#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:265
+#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:276
 #: data/ui/multiband_gate.glade:520 data/ui/multiband_gate.glade:925
 #: data/ui/multiband_gate.glade:1335 data/ui/multiband_gate.glade:1745
 msgid "Attack"
@@ -572,7 +585,7 @@ msgstr "Тип"
 #: data/ui/compressor.glade:636 data/ui/multiband_compressor.glade:473
 #: data/ui/multiband_compressor.glade:845
 #: data/ui/multiband_compressor.glade:1223
-#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:220
+#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:231
 #: data/ui/multiband_gate.glade:493 data/ui/multiband_gate.glade:898
 #: data/ui/multiband_gate.glade:1308 data/ui/multiband_gate.glade:1718
 #: data/ui/deesser.glade:218 data/ui/deesser.glade:328
@@ -582,7 +595,7 @@ msgstr "Пик"
 #: data/ui/compressor.glade:637 data/ui/multiband_compressor.glade:472
 #: data/ui/multiband_compressor.glade:844
 #: data/ui/multiband_compressor.glade:1222
-#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:219
+#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:230
 #: data/ui/multiband_gate.glade:492 data/ui/multiband_gate.glade:897
 #: data/ui/multiband_gate.glade:1307 data/ui/multiband_gate.glade:1717
 #: data/ui/deesser.glade:217
@@ -1186,7 +1199,7 @@ msgstr "Перекрестная подача"
 msgid "Maximizer"
 msgstr "Максимизатор"
 
-#: data/ui/maximizer.glade:269 data/ui/gate.glade:190
+#: data/ui/maximizer.glade:269 data/ui/gate.glade:196
 msgid "Gain Reduction"
 msgstr "Увеличение ослабления"
 
@@ -1199,24 +1212,30 @@ msgstr ""
 msgid "Gate"
 msgstr "Шумовые ворота (гейт)"
 
-#: data/ui/gate.glade:162 data/ui/deesser.glade:190
+#: data/ui/gate.glade:169 data/ui/deesser.glade:190
 msgid "Detection"
 msgstr "Определение"
 
 # В данном режиме «Компрессор» обрабатывает сигналы сразу двух каналов (стерео), уравнивая их уровни.
-#: data/ui/gate.glade:176
+#: data/ui/gate.glade:183
 msgid "Stereo Link"
 msgstr "Стереосвязка"
 
-#: data/ui/gate.glade:235
+#: data/ui/gate.glade:247
 msgid "Average"
 msgstr "Средняя"
 
-#: data/ui/gate.glade:236
+#: data/ui/gate.glade:248
 msgid "Maximum"
 msgstr "Максимум"
 
-#: data/ui/gate.glade:667 data/ui/multiband_gate.glade:766
+# #, fuzzy
+#: data/ui/gate.glade:499
+#, fuzzy
+msgid "Input Level"
+msgstr "Ограничитель ввода"
+
+#: data/ui/gate.glade:720 data/ui/multiband_gate.glade:766
 #: data/ui/multiband_gate.glade:1175 data/ui/multiband_gate.glade:1585
 #: data/ui/multiband_gate.glade:1995
 msgid "Gating"
@@ -1826,10 +1845,6 @@ msgstr ""
 
 # #, fuzzy
 #~ msgid "Output Device"
-#~ msgstr "Ограничитель ввода"
-
-# #, fuzzy
-#~ msgid "Input Device"
 #~ msgstr "Ограничитель ввода"
 
 # #, fuzzy

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-21 17:09+0200\n"
+"POT-Creation-Date: 2020-07-22 20:34+0200\n"
 "PO-Revision-Date: 2019-09-07 22:19+0200\n"
 "Last-Translator: Mlocik97\n"
 "Language-Team: \n"
@@ -196,14 +196,14 @@ msgid "Use Dark Theme"
 msgstr "Použiť Tmavú Tému"
 
 #: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
-#: data/ui/limiter.glade:635 data/ui/compressor.glade:1335
+#: data/ui/limiter.glade:715 data/ui/compressor.glade:1335
 #: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
 #: data/ui/equalizer.glade:763 data/ui/equalizer_band.glade:183
 #: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
 #: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
 #: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
 #: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
-#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/gate.glade:809 data/ui/multiband_gate.glade:2368
 #: data/ui/deesser.glade:879 data/ui/convolver.glade:698
 #: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
 #: data/ui/webrtc.glade:850 data/ui/delay.glade:469
@@ -369,13 +369,13 @@ msgid "Weights"
 msgstr "Váhy"
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:948
+#: data/ui/limiter.glade:445 data/ui/compressor.glade:948
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
 #: data/ui/equalizer.glade:501 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:243 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:532
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
 #: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
@@ -384,7 +384,7 @@ msgid "Input"
 msgstr "Vstup"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:962
+#: data/ui/limiter.glade:460 data/ui/compressor.glade:962
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
@@ -394,7 +394,7 @@ msgstr "Vstup"
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:547
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
@@ -432,51 +432,64 @@ msgstr "Na základe"
 msgid "Limiter"
 msgstr "Omedzovač"
 
-#: data/ui/limiter.glade:149
+#: data/ui/limiter.glade:150
+msgid "Automatic Smoothing Control"
+msgstr ""
+
+#: data/ui/limiter.glade:164
+msgid "Automatic Leveling"
+msgstr ""
+
+#: data/ui/limiter.glade:196
 #, fuzzy
 msgid "Input Gain"
 msgstr "Vstupné Zosilnenie"
 
-#: data/ui/limiter.glade:182
+#: data/ui/limiter.glade:229
 #, fuzzy
 msgid "Limit"
 msgstr "Obmedzenie"
 
-#: data/ui/limiter.glade:237 data/ui/compressor.glade:400
+#: data/ui/limiter.glade:284 data/ui/compressor.glade:400
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
 #: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
-#: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
+#: data/ui/gate.glade:310 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
 #, fuzzy
 msgid "Release"
 msgstr "Uvoľnenie"
 
-#: data/ui/limiter.glade:250 data/ui/compressor.glade:594
+#: data/ui/limiter.glade:297 data/ui/compressor.glade:594
 msgid "Lookahead"
 msgstr "Výhľad"
 
-#: data/ui/limiter.glade:285
+#: data/ui/limiter.glade:332
 msgid "Oversampling"
 msgstr "Prevzorkovanie"
 
-#: data/ui/limiter.glade:334
+#: data/ui/limiter.glade:385
 msgid "ASC"
 msgstr "ASC"
 
-#: data/ui/limiter.glade:395
+#: data/ui/limiter.glade:419
+#, fuzzy
+msgid "Output Gain"
+msgstr "Vstupné Zosilnenie"
+
+#: data/ui/limiter.glade:475
 msgid "Attenuation"
 msgstr "Zoslabenie"
 
-#: data/ui/limiter.glade:569 data/ui/compressor.glade:1270
+#: data/ui/limiter.glade:649 data/ui/compressor.glade:1270
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
 #: data/ui/equalizer.glade:698 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
-#: data/ui/gate.glade:691 data/ui/multiband_gate.glade:2303
+#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:2303
 #: data/ui/deesser.glade:814 data/ui/pitch.glade:517 data/ui/webrtc.glade:785
 #: data/ui/delay.glade:404
 msgid "Provided by"
@@ -491,7 +504,7 @@ msgstr "Kompresor"
 #: data/ui/multiband_compressor.glade:942
 #: data/ui/multiband_compressor.glade:1320
 #: data/ui/multiband_compressor.glade:1698 data/ui/maximizer.glade:126
-#: data/ui/gate.glade:333 data/ui/multiband_gate.glade:588
+#: data/ui/gate.glade:344 data/ui/multiband_gate.glade:588
 #: data/ui/multiband_gate.glade:995 data/ui/multiband_gate.glade:1405
 #: data/ui/multiband_gate.glade:1815 data/ui/deesser.glade:458
 #, fuzzy
@@ -501,7 +514,7 @@ msgstr "Prah"
 #: data/ui/compressor.glade:299 data/ui/multiband_compressor.glade:601
 #: data/ui/multiband_compressor.glade:976
 #: data/ui/multiband_compressor.glade:1354
-#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:366
+#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:377
 #: data/ui/multiband_gate.glade:621 data/ui/multiband_gate.glade:1029
 #: data/ui/multiband_gate.glade:1439 data/ui/multiband_gate.glade:1849
 #: data/ui/deesser.glade:491
@@ -512,7 +525,7 @@ msgstr "Pomer [n:1]"
 #: data/ui/compressor.glade:331 data/ui/multiband_compressor.glade:633
 #: data/ui/multiband_compressor.glade:1009
 #: data/ui/multiband_compressor.glade:1387
-#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:398
+#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:409
 #: data/ui/multiband_gate.glade:653 data/ui/multiband_gate.glade:1062
 #: data/ui/multiband_gate.glade:1472 data/ui/multiband_gate.glade:1882
 #, fuzzy
@@ -522,7 +535,7 @@ msgstr "Koleno"
 #: data/ui/compressor.glade:365 data/ui/multiband_compressor.glade:667
 #: data/ui/multiband_compressor.glade:1044
 #: data/ui/multiband_compressor.glade:1422
-#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:432
+#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:443
 #: data/ui/multiband_gate.glade:687 data/ui/multiband_gate.glade:1097
 #: data/ui/multiband_gate.glade:1507 data/ui/multiband_gate.glade:1917
 #: data/ui/deesser.glade:522
@@ -533,7 +546,7 @@ msgstr "Výstupné zosilnenie"
 #: data/ui/compressor.glade:413 data/ui/multiband_compressor.glade:500
 #: data/ui/multiband_compressor.glade:872
 #: data/ui/multiband_compressor.glade:1250
-#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:265
+#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:276
 #: data/ui/multiband_gate.glade:520 data/ui/multiband_gate.glade:925
 #: data/ui/multiband_gate.glade:1335 data/ui/multiband_gate.glade:1745
 #, fuzzy
@@ -582,7 +595,7 @@ msgstr "Typ"
 #: data/ui/compressor.glade:636 data/ui/multiband_compressor.glade:473
 #: data/ui/multiband_compressor.glade:845
 #: data/ui/multiband_compressor.glade:1223
-#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:220
+#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:231
 #: data/ui/multiband_gate.glade:493 data/ui/multiband_gate.glade:898
 #: data/ui/multiband_gate.glade:1308 data/ui/multiband_gate.glade:1718
 #: data/ui/deesser.glade:218 data/ui/deesser.glade:328
@@ -592,7 +605,7 @@ msgstr "Vrchol"
 #: data/ui/compressor.glade:637 data/ui/multiband_compressor.glade:472
 #: data/ui/multiband_compressor.glade:844
 #: data/ui/multiband_compressor.glade:1222
-#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:219
+#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:230
 #: data/ui/multiband_gate.glade:492 data/ui/multiband_gate.glade:897
 #: data/ui/multiband_gate.glade:1307 data/ui/multiband_gate.glade:1717
 #: data/ui/deesser.glade:217
@@ -1214,7 +1227,7 @@ msgstr "Prelínanie kanálov"
 msgid "Maximizer"
 msgstr "Zosilovač"
 
-#: data/ui/maximizer.glade:269 data/ui/gate.glade:190
+#: data/ui/maximizer.glade:269 data/ui/gate.glade:196
 msgid "Gain Reduction"
 msgstr "Redukcia zosilnenia"
 
@@ -1226,24 +1239,29 @@ msgstr "Spojenie"
 msgid "Gate"
 msgstr "Brána"
 
-#: data/ui/gate.glade:162 data/ui/deesser.glade:190
+#: data/ui/gate.glade:169 data/ui/deesser.glade:190
 #, fuzzy
 msgid "Detection"
 msgstr "Zoslabenie"
 
-#: data/ui/gate.glade:176
+#: data/ui/gate.glade:183
 msgid "Stereo Link"
 msgstr "Spojenie sterea"
 
-#: data/ui/gate.glade:235
+#: data/ui/gate.glade:247
 msgid "Average"
 msgstr "Priemerná"
 
-#: data/ui/gate.glade:236
+#: data/ui/gate.glade:248
 msgid "Maximum"
 msgstr "Maximálna"
 
-#: data/ui/gate.glade:667 data/ui/multiband_gate.glade:766
+#: data/ui/gate.glade:499
+#, fuzzy
+msgid "Input Level"
+msgstr "Vstupný obmedzovač"
+
+#: data/ui/gate.glade:720 data/ui/multiband_gate.glade:766
 #: data/ui/multiband_gate.glade:1175 data/ui/multiband_gate.glade:1585
 #: data/ui/multiband_gate.glade:1995
 msgid "Gating"
@@ -1771,10 +1789,6 @@ msgstr "Nekonečno"
 
 #, fuzzy
 #~ msgid "Output Device"
-#~ msgstr "Vstupný obmedzovač"
-
-#, fuzzy
-#~ msgid "Input Device"
 #~ msgstr "Vstupný obmedzovač"
 
 #, fuzzy

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-21 17:09+0200\n"
+"POT-Creation-Date: 2020-07-22 20:34+0200\n"
 "PO-Revision-Date: 2017-10-14 10:20+0200\n"
 "Last-Translator: Patrik Nilsson <translation_AT_hembas.se>\n"
 "Language-Team: \n"
@@ -196,14 +196,14 @@ msgid "Use Dark Theme"
 msgstr "Använd mörkt tema"
 
 #: data/ui/general_settings.glade:116 data/ui/autogain.glade:957
-#: data/ui/limiter.glade:635 data/ui/compressor.glade:1335
+#: data/ui/limiter.glade:715 data/ui/compressor.glade:1335
 #: data/ui/multiband_compressor.glade:2219 data/ui/filter.glade:629
 #: data/ui/equalizer.glade:763 data/ui/equalizer_band.glade:183
 #: data/ui/equalizer_band.glade:229 data/ui/reverb.glade:891
 #: data/ui/bass_enhancer.glade:692 data/ui/exciter.glade:696
 #: data/ui/stereo_tools.glade:1066 data/ui/crossfeed.glade:429
 #: data/ui/maximizer.glade:499 data/ui/loudness.glade:469
-#: data/ui/gate.glade:756 data/ui/multiband_gate.glade:2368
+#: data/ui/gate.glade:809 data/ui/multiband_gate.glade:2368
 #: data/ui/deesser.glade:879 data/ui/convolver.glade:698
 #: data/ui/crystalizer.glade:561 data/ui/pitch.glade:582
 #: data/ui/webrtc.glade:850 data/ui/delay.glade:469
@@ -368,13 +368,13 @@ msgid "Weights"
 msgstr ""
 
 #: data/ui/autogain.glade:378 data/ui/autogain.glade:570
-#: data/ui/limiter.glade:365 data/ui/compressor.glade:948
+#: data/ui/limiter.glade:445 data/ui/compressor.glade:948
 #: data/ui/multiband_compressor.glade:1958 data/ui/filter.glade:368
 #: data/ui/equalizer.glade:501 data/ui/reverb.glade:630
 #: data/ui/bass_enhancer.glade:479 data/ui/exciter.glade:483
 #: data/ui/stereo_tools.glade:299 data/ui/stereo_tools.glade:804
 #: data/ui/crossfeed.glade:202 data/ui/maximizer.glade:239
-#: data/ui/loudness.glade:243 data/ui/gate.glade:487
+#: data/ui/loudness.glade:243 data/ui/gate.glade:532
 #: data/ui/multiband_gate.glade:2107 data/ui/deesser.glade:568
 #: data/ui/convolver.glade:477 data/ui/crystalizer.glade:228
 #: data/ui/pitch.glade:322 data/ui/webrtc.glade:624 data/ui/delay.glade:209
@@ -383,7 +383,7 @@ msgid "Input"
 msgstr "Ingång"
 
 #: data/ui/autogain.glade:393 data/ui/autogain.glade:826
-#: data/ui/limiter.glade:380 data/ui/compressor.glade:962
+#: data/ui/limiter.glade:460 data/ui/compressor.glade:962
 #: data/ui/multiband_compressor.glade:753
 #: data/ui/multiband_compressor.glade:1130
 #: data/ui/multiband_compressor.glade:1508
@@ -393,7 +393,7 @@ msgstr "Ingång"
 #: data/ui/bass_enhancer.glade:511 data/ui/exciter.glade:515
 #: data/ui/stereo_tools.glade:776 data/ui/stereo_tools.glade:818
 #: data/ui/crossfeed.glade:217 data/ui/maximizer.glade:254
-#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:502
+#: data/ui/loudness.glade:162 data/ui/loudness.glade:257 data/ui/gate.glade:547
 #: data/ui/multiband_gate.glade:806 data/ui/multiband_gate.glade:1215
 #: data/ui/multiband_gate.glade:1625 data/ui/multiband_gate.glade:2035
 #: data/ui/multiband_gate.glade:2122 data/ui/deesser.glade:583
@@ -431,51 +431,64 @@ msgstr ""
 msgid "Limiter"
 msgstr "Gränsvärde (dB)"
 
-#: data/ui/limiter.glade:149
+#: data/ui/limiter.glade:150
+msgid "Automatic Smoothing Control"
+msgstr ""
+
+#: data/ui/limiter.glade:164
+msgid "Automatic Leveling"
+msgstr ""
+
+#: data/ui/limiter.glade:196
 #, fuzzy
 msgid "Input Gain"
 msgstr "Ingångsförstärkning (dB)"
 
-#: data/ui/limiter.glade:182
+#: data/ui/limiter.glade:229
 #, fuzzy
 msgid "Limit"
 msgstr "Gränsvärde (dB)"
 
-#: data/ui/limiter.glade:237 data/ui/compressor.glade:400
+#: data/ui/limiter.glade:284 data/ui/compressor.glade:400
 #: data/ui/multiband_compressor.glade:534
 #: data/ui/multiband_compressor.glade:907
 #: data/ui/multiband_compressor.glade:1285
 #: data/ui/multiband_compressor.glade:1663 data/ui/maximizer.glade:152
-#: data/ui/gate.glade:299 data/ui/multiband_gate.glade:554
+#: data/ui/gate.glade:310 data/ui/multiband_gate.glade:554
 #: data/ui/multiband_gate.glade:960 data/ui/multiband_gate.glade:1370
 #: data/ui/multiband_gate.glade:1780
 #, fuzzy
 msgid "Release"
 msgstr "Release (s)"
 
-#: data/ui/limiter.glade:250 data/ui/compressor.glade:594
+#: data/ui/limiter.glade:297 data/ui/compressor.glade:594
 msgid "Lookahead"
 msgstr ""
 
-#: data/ui/limiter.glade:285
+#: data/ui/limiter.glade:332
 msgid "Oversampling"
 msgstr ""
 
-#: data/ui/limiter.glade:334
+#: data/ui/limiter.glade:385
 msgid "ASC"
 msgstr ""
 
-#: data/ui/limiter.glade:395
+#: data/ui/limiter.glade:419
+#, fuzzy
+msgid "Output Gain"
+msgstr "Ingångsförstärkning (dB)"
+
+#: data/ui/limiter.glade:475
 msgid "Attenuation"
 msgstr "Försvagning"
 
-#: data/ui/limiter.glade:569 data/ui/compressor.glade:1270
+#: data/ui/limiter.glade:649 data/ui/compressor.glade:1270
 #: data/ui/multiband_compressor.glade:2154 data/ui/filter.glade:564
 #: data/ui/equalizer.glade:698 data/ui/reverb.glade:826
 #: data/ui/bass_enhancer.glade:627 data/ui/exciter.glade:631
 #: data/ui/stereo_tools.glade:1001 data/ui/crossfeed.glade:364
 #: data/ui/maximizer.glade:444 data/ui/loudness.glade:404
-#: data/ui/gate.glade:691 data/ui/multiband_gate.glade:2303
+#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:2303
 #: data/ui/deesser.glade:814 data/ui/pitch.glade:517 data/ui/webrtc.glade:785
 #: data/ui/delay.glade:404
 msgid "Provided by"
@@ -490,7 +503,7 @@ msgstr "Kompressor"
 #: data/ui/multiband_compressor.glade:942
 #: data/ui/multiband_compressor.glade:1320
 #: data/ui/multiband_compressor.glade:1698 data/ui/maximizer.glade:126
-#: data/ui/gate.glade:333 data/ui/multiband_gate.glade:588
+#: data/ui/gate.glade:344 data/ui/multiband_gate.glade:588
 #: data/ui/multiband_gate.glade:995 data/ui/multiband_gate.glade:1405
 #: data/ui/multiband_gate.glade:1815 data/ui/deesser.glade:458
 #, fuzzy
@@ -500,7 +513,7 @@ msgstr "Tröskelvärde (dB)"
 #: data/ui/compressor.glade:299 data/ui/multiband_compressor.glade:601
 #: data/ui/multiband_compressor.glade:976
 #: data/ui/multiband_compressor.glade:1354
-#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:366
+#: data/ui/multiband_compressor.glade:1732 data/ui/gate.glade:377
 #: data/ui/multiband_gate.glade:621 data/ui/multiband_gate.glade:1029
 #: data/ui/multiband_gate.glade:1439 data/ui/multiband_gate.glade:1849
 #: data/ui/deesser.glade:491
@@ -511,7 +524,7 @@ msgstr "Förhållande (n:1)"
 #: data/ui/compressor.glade:331 data/ui/multiband_compressor.glade:633
 #: data/ui/multiband_compressor.glade:1009
 #: data/ui/multiband_compressor.glade:1387
-#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:398
+#: data/ui/multiband_compressor.glade:1765 data/ui/gate.glade:409
 #: data/ui/multiband_gate.glade:653 data/ui/multiband_gate.glade:1062
 #: data/ui/multiband_gate.glade:1472 data/ui/multiband_gate.glade:1882
 #, fuzzy
@@ -521,7 +534,7 @@ msgstr "Knee-värde (dB)"
 #: data/ui/compressor.glade:365 data/ui/multiband_compressor.glade:667
 #: data/ui/multiband_compressor.glade:1044
 #: data/ui/multiband_compressor.glade:1422
-#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:432
+#: data/ui/multiband_compressor.glade:1800 data/ui/gate.glade:443
 #: data/ui/multiband_gate.glade:687 data/ui/multiband_gate.glade:1097
 #: data/ui/multiband_gate.glade:1507 data/ui/multiband_gate.glade:1917
 #: data/ui/deesser.glade:522
@@ -532,7 +545,7 @@ msgstr "Makeup (dB)"
 #: data/ui/compressor.glade:413 data/ui/multiband_compressor.glade:500
 #: data/ui/multiband_compressor.glade:872
 #: data/ui/multiband_compressor.glade:1250
-#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:265
+#: data/ui/multiband_compressor.glade:1628 data/ui/gate.glade:276
 #: data/ui/multiband_gate.glade:520 data/ui/multiband_gate.glade:925
 #: data/ui/multiband_gate.glade:1335 data/ui/multiband_gate.glade:1745
 #, fuzzy
@@ -582,7 +595,7 @@ msgstr ""
 #: data/ui/compressor.glade:636 data/ui/multiband_compressor.glade:473
 #: data/ui/multiband_compressor.glade:845
 #: data/ui/multiband_compressor.glade:1223
-#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:220
+#: data/ui/multiband_compressor.glade:1601 data/ui/gate.glade:231
 #: data/ui/multiband_gate.glade:493 data/ui/multiband_gate.glade:898
 #: data/ui/multiband_gate.glade:1308 data/ui/multiband_gate.glade:1718
 #: data/ui/deesser.glade:218 data/ui/deesser.glade:328
@@ -592,7 +605,7 @@ msgstr "Peak"
 #: data/ui/compressor.glade:637 data/ui/multiband_compressor.glade:472
 #: data/ui/multiband_compressor.glade:844
 #: data/ui/multiband_compressor.glade:1222
-#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:219
+#: data/ui/multiband_compressor.glade:1600 data/ui/gate.glade:230
 #: data/ui/multiband_gate.glade:492 data/ui/multiband_gate.glade:897
 #: data/ui/multiband_gate.glade:1307 data/ui/multiband_gate.glade:1717
 #: data/ui/deesser.glade:217
@@ -1224,7 +1237,7 @@ msgstr ""
 msgid "Maximizer"
 msgstr ""
 
-#: data/ui/maximizer.glade:269 data/ui/gate.glade:190
+#: data/ui/maximizer.glade:269 data/ui/gate.glade:196
 msgid "Gain Reduction"
 msgstr "Förstärkningsreducering"
 
@@ -1236,25 +1249,30 @@ msgstr ""
 msgid "Gate"
 msgstr ""
 
-#: data/ui/gate.glade:162 data/ui/deesser.glade:190
+#: data/ui/gate.glade:169 data/ui/deesser.glade:190
 #, fuzzy
 msgid "Detection"
 msgstr "Försvagning"
 
-#: data/ui/gate.glade:176
+#: data/ui/gate.glade:183
 #, fuzzy
 msgid "Stereo Link"
 msgstr "Ljudförstärkare"
 
-#: data/ui/gate.glade:235
+#: data/ui/gate.glade:247
 msgid "Average"
 msgstr ""
 
-#: data/ui/gate.glade:236
+#: data/ui/gate.glade:248
 msgid "Maximum"
 msgstr ""
 
-#: data/ui/gate.glade:667 data/ui/multiband_gate.glade:766
+#: data/ui/gate.glade:499
+#, fuzzy
+msgid "Input Level"
+msgstr "Ingångs-begränsning"
+
+#: data/ui/gate.glade:720 data/ui/multiband_gate.glade:766
 #: data/ui/multiband_gate.glade:1175 data/ui/multiband_gate.glade:1585
 #: data/ui/multiband_gate.glade:1995
 msgid "Gating"
@@ -1833,10 +1851,6 @@ msgstr ""
 
 #, fuzzy
 #~ msgid "Output Device"
-#~ msgstr "Ingångs-begränsning"
-
-#, fuzzy
-#~ msgid "Input Device"
 #~ msgstr "Ingångs-begränsning"
 
 #, fuzzy

--- a/src/gate.cpp
+++ b/src/gate.cpp
@@ -89,6 +89,9 @@ void Gate::bind_to_gsettings() {
   g_settings_bind_with_mapping(settings, "threshold", gate, "threshold", G_SETTINGS_BIND_DEFAULT,
                                util::db20_gain_to_linear, util::linear_gain_to_db20, nullptr, nullptr);
 
+  g_settings_bind_with_mapping(settings, "input", gate, "level-in", G_SETTINGS_BIND_DEFAULT, util::db20_gain_to_linear,
+                               util::linear_gain_to_db20, nullptr, nullptr);
+
   g_settings_bind_with_mapping(settings, "makeup", gate, "makeup", G_SETTINGS_BIND_DEFAULT, util::db20_gain_to_linear,
                                util::linear_gain_to_db20, nullptr, nullptr);
 

--- a/src/gate_preset.cpp
+++ b/src/gate_preset.cpp
@@ -25,6 +25,8 @@ void GatePreset::save(boost::property_tree::ptree& root,
 
   root.put(section + ".gate.knee", settings->get_double("knee"));
 
+  root.put(section + ".gate.input", settings->get_double("input"));
+
   root.put(section + ".gate.makeup", settings->get_double("makeup"));
 }
 
@@ -48,6 +50,8 @@ void GatePreset::load(const boost::property_tree::ptree& root,
   update_key<double>(root, settings, "ratio", section + ".gate.ratio");
 
   update_key<double>(root, settings, "knee", section + ".gate.knee");
+
+  update_key<double>(root, settings, "input", section + ".gate.input");
 
   update_key<double>(root, settings, "makeup", section + ".gate.makeup");
 }

--- a/src/gate_ui.cpp
+++ b/src/gate_ui.cpp
@@ -63,6 +63,7 @@ GateUi::GateUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& builde
 
   get_object(builder, "attack", attack);
   get_object(builder, "knee", knee);
+  get_object(builder, "input", input);
   get_object(builder, "makeup", makeup);
   get_object(builder, "range", range);
   get_object(builder, "ratio", ratio);
@@ -76,6 +77,7 @@ GateUi::GateUi(BaseObjectType* cobject, const Glib::RefPtr<Gtk::Builder>& builde
   settings->bind("installed", this, "sensitive", flag);
   settings->bind("attack", attack.get(), "value", flag);
   settings->bind("knee", knee.get(), "value", flag);
+  settings->bind("input", input.get(), "value", flag);
   settings->bind("makeup", makeup.get(), "value", flag);
   settings->bind("range", range.get(), "value", flag);
   settings->bind("ratio", ratio.get(), "value", flag);
@@ -115,6 +117,8 @@ void GateUi::reset() {
     update_default_key<double>(settings, "ratio", section + ".gate.ratio");
 
     update_default_key<double>(settings, "knee", section + ".gate.knee");
+
+    update_default_key<double>(settings, "input", section + ".gate.input");
 
     update_default_key<double>(settings, "makeup", section + ".gate.makeup");
 

--- a/src/limiter.cpp
+++ b/src/limiter.cpp
@@ -113,18 +113,23 @@ void Limiter::bind_to_gsettings() {
   g_settings_bind_with_mapping(settings, "limit", limiter, "limit", G_SETTINGS_BIND_GET, util::db20_gain_to_linear,
                                nullptr, nullptr, nullptr);
 
-  // calf limiter does automatic makeup gain by the same amount given as
-  // limit. See https://github.com/calf-studio-gear/calf/issues/162
-  // that is why we reduce the output level accordingly
+  // Calf limiter did automatic makeup gain by the same amount given as limit.
+  // See https://github.com/calf-studio-gear/calf/issues/162
+  // That is why we reduced the output level accordingly binding both limit and output-gain to the same,
+  // gsettings key, but from 0.90.2 version the "auto-level" toggle was introduced, so we expose the
+  // output gain as a separate parameter along with the automatic level button.
+  // See changelog at https://freshcode.club/projects/calf
 
-  g_settings_bind_with_mapping(settings, "limit", limiter, "level-out", G_SETTINGS_BIND_GET, util::db20_gain_to_linear,
-                               nullptr, nullptr, nullptr);
+  g_settings_bind_with_mapping(settings, "output-gain", limiter, "level-out", G_SETTINGS_BIND_GET,
+                               util::db20_gain_to_linear, util::linear_gain_to_db20, nullptr, nullptr);
 
   g_settings_bind_with_mapping(settings, "lookahead", limiter, "attack", G_SETTINGS_BIND_GET, util::double_to_float,
                                nullptr, nullptr, nullptr);
 
   g_settings_bind_with_mapping(settings, "release", limiter, "release", G_SETTINGS_BIND_GET, util::double_to_float,
                                nullptr, nullptr, nullptr);
+
+  g_settings_bind(settings, "auto-level", limiter, "auto-level", G_SETTINGS_BIND_DEFAULT);
 
   g_settings_bind(settings, "asc", limiter, "asc", G_SETTINGS_BIND_DEFAULT);
 

--- a/src/limiter_preset.cpp
+++ b/src/limiter_preset.cpp
@@ -17,11 +17,15 @@ void LimiterPreset::save(boost::property_tree::ptree& root,
 
   root.put(section + ".limiter.release", settings->get_double("release"));
 
+  root.put(section + ".limiter.auto-level", settings->get_boolean("auto-level"));
+
   root.put(section + ".limiter.asc", settings->get_boolean("asc"));
 
   root.put(section + ".limiter.asc-level", settings->get_double("asc-level"));
 
   root.put(section + ".limiter.oversampling", settings->get_int("oversampling"));
+
+  root.put(section + ".limiter.output-gain", settings->get_double("output-gain"));
 }
 
 void LimiterPreset::load(const boost::property_tree::ptree& root,
@@ -37,11 +41,15 @@ void LimiterPreset::load(const boost::property_tree::ptree& root,
 
   update_key<double>(root, settings, "release", section + ".limiter.release");
 
+  update_key<bool>(root, settings, "auto-level", section + ".limiter.auto-level");
+
   update_key<bool>(root, settings, "asc", section + ".limiter.asc");
 
   update_key<double>(root, settings, "asc-level", section + ".limiter.asc-level");
 
   update_key<int>(root, settings, "oversampling", section + ".limiter.oversampling");
+
+  update_key<double>(root, settings, "output-gain", section + ".limiter.output-gain");
 }
 
 void LimiterPreset::write(PresetType preset_type, boost::property_tree::ptree& root) {

--- a/src/limiter_ui.cpp
+++ b/src/limiter_ui.cpp
@@ -8,6 +8,7 @@ LimiterUi::LimiterUi(BaseObjectType* cobject,
 
   // loading glade widgets
 
+  builder->get_widget("auto-level", auto_level);
   builder->get_widget("asc", asc);
   builder->get_widget("attenuation", attenuation);
   builder->get_widget("attenuation_label", attenuation_label);
@@ -19,6 +20,7 @@ LimiterUi::LimiterUi(BaseObjectType* cobject,
   get_object(builder, "release", release);
   get_object(builder, "oversampling", oversampling);
   get_object(builder, "asc_level", asc_level);
+  get_object(builder, "output_gain", output_gain);
 
   // gsettings bindings
 
@@ -31,8 +33,10 @@ LimiterUi::LimiterUi(BaseObjectType* cobject,
   settings->bind("lookahead", lookahead.get(), "value", flag);
   settings->bind("release", release.get(), "value", flag);
   settings->bind("oversampling", oversampling.get(), "value", flag);
+  settings->bind("auto-level", auto_level, "active", flag);
   settings->bind("asc", asc, "active", flag);
   settings->bind("asc-level", asc_level.get(), "value", flag);
+  settings->bind("output-gain", output_gain.get(), "value", flag);
 
   // reset plugin
   reset_button->signal_clicked().connect([=]() { reset(); });
@@ -54,11 +58,15 @@ void LimiterUi::reset() {
 
     update_default_key<double>(settings, "release", section + ".limiter.release");
 
+    update_default_key<bool>(settings, "auto-level", section + ".limiter.auto-level");
+
     update_default_key<bool>(settings, "asc", section + ".limiter.asc");
 
     update_default_key<double>(settings, "asc-level", section + ".limiter.asc-level");
 
     update_default_key<int>(settings, "oversampling", section + ".limiter.oversampling");
+
+    update_default_key<double>(settings, "output-gain", section + ".limiter.output-gain");
 
     util::debug(name + " plugin: successfully reset");
   } catch (std::exception& e) {


### PR DESCRIPTION
Added `auto-level` and `output-gain` in Limiter, plus `input-gain` in Gate. Fixes #732 

@wwmm I added a margin between input and output bars in Gate. I'm seeing it good on my theme, but please check if it's showing fine on yours. If no, I'll undo the changes, otherwise it could be replicated in other plugin ui since I think that separating input from output bars is better. 