### PR TITLE
UI cleaned up and improved

### DIFF
--- a/data/ui/autogain.glade
+++ b/data/ui/autogain.glade
@@ -74,6 +74,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -107,19 +108,19 @@
   <object class="GtkAdjustment" id="input_gain">
     <property name="lower">-20</property>
     <property name="upper">20</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="output_gain">
     <property name="lower">-20</property>
     <property name="upper">20</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="target">
     <property name="lower">-100</property>
     <property name="value">-23</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="weight_i">
@@ -245,11 +246,13 @@
                     <property name="can_focus">True</property>
                     <property name="halign">center</property>
                     <property name="valign">center</property>
-                    <property name="width_chars">5</property>
+                    <property name="width_chars">7</property>
                     <property name="text">-23</property>
+                    <property name="xalign">0.5</property>
                     <property name="secondary_icon_activatable">False</property>
                     <property name="input_purpose">number</property>
                     <property name="adjustment">target</property>
+                    <property name="digits">1</property>
                     <property name="numeric">True</property>
                     <property name="update_policy">if-valid</property>
                     <property name="value">-23</property>
@@ -325,8 +328,9 @@
                     <property name="can_focus">True</property>
                     <property name="halign">center</property>
                     <property name="valign">center</property>
-                    <property name="width_chars">5</property>
+                    <property name="width_chars">4</property>
                     <property name="text">1</property>
+                    <property name="xalign">0.5</property>
                     <property name="secondary_icon_activatable">False</property>
                     <property name="input_purpose">number</property>
                     <property name="adjustment">weight_m</property>
@@ -345,8 +349,9 @@
                     <property name="can_focus">True</property>
                     <property name="halign">center</property>
                     <property name="valign">center</property>
-                    <property name="width_chars">5</property>
+                    <property name="width_chars">4</property>
                     <property name="text">1</property>
+                    <property name="xalign">0.5</property>
                     <property name="secondary_icon_activatable">False</property>
                     <property name="input_purpose">number</property>
                     <property name="adjustment">weight_s</property>
@@ -365,8 +370,9 @@
                     <property name="can_focus">True</property>
                     <property name="halign">center</property>
                     <property name="valign">center</property>
-                    <property name="width_chars">5</property>
+                    <property name="width_chars">4</property>
                     <property name="text">1</property>
+                    <property name="xalign">0.5</property>
                     <property name="secondary_icon_activatable">False</property>
                     <property name="input_purpose">number</property>
                     <property name="adjustment">weight_i</property>
@@ -577,8 +583,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">input_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>
@@ -594,8 +599,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">output_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>

--- a/data/ui/bass_enhancer.glade
+++ b/data/ui/bass_enhancer.glade
@@ -5,7 +5,7 @@
   <object class="GtkAdjustment" id="amount">
     <property name="lower">-100</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="blend">
@@ -100,6 +100,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -133,13 +134,13 @@
   <object class="GtkAdjustment" id="input_gain">
     <property name="lower">-36</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="output_gain">
     <property name="lower">-36</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="scope">
@@ -306,6 +307,7 @@
                 <property name="input_purpose">number</property>
                 <property name="orientation">vertical</property>
                 <property name="adjustment">amount</property>
+                <property name="digits">1</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
               </object>
@@ -516,8 +518,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">input_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>
@@ -548,8 +549,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">output_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>
@@ -622,15 +622,10 @@
                 <property name="max_width_chars">3</property>
               </object>
               <packing>
-                <property name="left_attach">4</property>
+                <property name="left_attach">3</property>
                 <property name="top_attach">4</property>
+                <property name="width">3</property>
               </packing>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
             </child>
           </object>
           <packing>

--- a/data/ui/calibration_mic.glade
+++ b/data/ui/calibration_mic.glade
@@ -7,7 +7,6 @@
     <property name="upper">60</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
-    <signal name="value-changed" handler="on_time_window_value_changed" swapped="no"/>
   </object>
   <object class="GtkGrid" id="widgets_grid">
     <property name="visible">True</property>

--- a/data/ui/calibration_signals.glade
+++ b/data/ui/calibration_signals.glade
@@ -6,13 +6,11 @@
     <property name="upper">20000</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
-    <signal name="value-changed" handler="on_wave1_freq_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="volume_adjustment">
     <property name="upper">1</property>
     <property name="step_increment">0.01</property>
     <property name="page_increment">0.05</property>
-    <signal name="value-changed" handler="on_wave2_volume_value_changed" swapped="no"/>
   </object>
   <object class="GtkGrid" id="widgets_grid">
     <property name="visible">True</property>

--- a/data/ui/compressor.glade
+++ b/data/ui/compressor.glade
@@ -12,7 +12,7 @@
     <property name="lower">-120</property>
     <property name="upper">-60</property>
     <property name="value">-72</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="hpf_freq">
@@ -94,6 +94,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -127,7 +128,7 @@
   <object class="GtkAdjustment" id="input_gain">
     <property name="lower">-60</property>
     <property name="upper">60</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="knee">
@@ -151,18 +152,18 @@
   <object class="GtkAdjustment" id="makeup">
     <property name="lower">-60</property>
     <property name="upper">60</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="output_gain">
     <property name="lower">-60</property>
     <property name="upper">60</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="preamp">
     <property name="upper">40</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="ratio">
@@ -187,13 +188,13 @@
   <object class="GtkAdjustment" id="release_threshold">
     <property name="lower">-200</property>
     <property name="value">-200</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="threshold">
     <property name="lower">-60</property>
     <property name="value">-12</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkGrid" id="widgets_grid">
@@ -305,6 +306,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">threshold</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                           </object>
@@ -405,6 +407,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">makeup</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                           </object>
@@ -531,6 +534,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">preamp</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                           </object>
@@ -743,6 +747,7 @@
                         <property name="input_purpose">number</property>
                         <property name="orientation">vertical</property>
                         <property name="adjustment">release_threshold</property>
+                        <property name="digits">1</property>
                         <property name="numeric">True</property>
                         <property name="update_policy">if-valid</property>
                       </object>
@@ -763,6 +768,7 @@
                         <property name="input_purpose">number</property>
                         <property name="orientation">vertical</property>
                         <property name="adjustment">boost_threshold</property>
+                        <property name="digits">1</property>
                         <property name="numeric">True</property>
                         <property name="update_policy">if-valid</property>
                       </object>
@@ -1204,8 +1210,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">input_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>
@@ -1221,8 +1226,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">output_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>

--- a/data/ui/compressor.glade
+++ b/data/ui/compressor.glade
@@ -135,7 +135,6 @@
     <property name="value">-6</property>
     <property name="step_increment">0.01</property>
     <property name="page_increment">0.1</property>
-    <signal name="value-changed" handler="on_knee_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="lookahead">
     <property name="upper">20</property>
@@ -154,7 +153,6 @@
     <property name="upper">60</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
-    <signal name="value-changed" handler="on_makeup_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="output_gain">
     <property name="lower">-60</property>
@@ -197,7 +195,6 @@
     <property name="value">-12</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
-    <signal name="value-changed" handler="on_threshold_value_changed" swapped="no"/>
   </object>
   <object class="GtkGrid" id="widgets_grid">
     <property name="visible">True</property>

--- a/data/ui/convolver.glade
+++ b/data/ui/convolver.glade
@@ -74,6 +74,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -188,7 +189,7 @@
   <object class="GtkAdjustment" id="input_gain">
     <property name="lower">-20</property>
     <property name="upper">20</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="ir_width">
@@ -200,7 +201,7 @@
   <object class="GtkAdjustment" id="output_gain">
     <property name="lower">-20</property>
     <property name="upper">20</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkGrid" id="widgets_grid">
@@ -654,7 +655,6 @@
                 <property name="hexpand">True</property>
                 <property name="adjustment">input_gain</property>
                 <property name="round_digits">1</property>
-                <property name="digits">0</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>
@@ -670,8 +670,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">output_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>

--- a/data/ui/crossfeed.glade
+++ b/data/ui/crossfeed.glade
@@ -15,7 +15,6 @@
     <property name="value">4.5</property>
     <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
-    <signal name="value-changed" handler="on_feed_value_changed" swapped="no"/>
   </object>
   <object class="GtkGrid" id="widgets_grid">
     <property name="visible">True</property>

--- a/data/ui/crossfeed.glade
+++ b/data/ui/crossfeed.glade
@@ -536,6 +536,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>

--- a/data/ui/crystalizer.glade
+++ b/data/ui/crystalizer.glade
@@ -2,30 +2,6 @@
 <!-- Generated with glade 3.36.0 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.22"/>
-  <object class="GtkAdjustment" id="freq1">
-    <property name="lower">10</property>
-    <property name="upper">20000</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
-  </object>
-  <object class="GtkAdjustment" id="freq2">
-    <property name="lower">10</property>
-    <property name="upper">20000</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
-  </object>
-  <object class="GtkAdjustment" id="freq3">
-    <property name="lower">10</property>
-    <property name="upper">20000</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
-  </object>
-  <object class="GtkAdjustment" id="freq4">
-    <property name="lower">10</property>
-    <property name="upper">20000</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
-  </object>
   <object class="GtkImage" id="image1">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -98,6 +74,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -131,40 +108,13 @@
   <object class="GtkAdjustment" id="input_gain">
     <property name="lower">-20</property>
     <property name="upper">20</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
-  </object>
-  <object class="GtkAdjustment" id="intensity_band0">
-    <property name="upper">10</property>
-    <property name="value">1</property>
-    <property name="step_increment">0.01</property>
-    <property name="page_increment">0.01</property>
-  </object>
-  <object class="GtkAdjustment" id="intensity_band1">
-    <property name="upper">10</property>
-    <property name="step_increment">0.01</property>
-    <property name="page_increment">0.01</property>
-  </object>
-  <object class="GtkAdjustment" id="intensity_band2">
-    <property name="upper">10</property>
-    <property name="step_increment">0.01</property>
-    <property name="page_increment">0.01</property>
-  </object>
-  <object class="GtkAdjustment" id="intensity_band3">
-    <property name="upper">10</property>
-    <property name="value">1</property>
-    <property name="step_increment">0.01</property>
-    <property name="page_increment">0.01</property>
-  </object>
-  <object class="GtkAdjustment" id="intensity_band4">
-    <property name="upper">10</property>
-    <property name="step_increment">0.01</property>
-    <property name="page_increment">0.01</property>
   </object>
   <object class="GtkAdjustment" id="output_gain">
     <property name="lower">-20</property>
     <property name="upper">20</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkGrid" id="widgets_grid">
@@ -404,8 +354,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">input_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>
@@ -421,8 +370,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">output_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>

--- a/data/ui/deesser.glade
+++ b/data/ui/deesser.glade
@@ -15,7 +15,6 @@
     <property name="value">1</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
-    <signal name="value-changed" handler="on_f1_level_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="f2_freq">
     <property name="lower">10</property>
@@ -30,7 +29,6 @@
     <property name="value">4</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
-    <signal name="value-changed" handler="on_f2_level_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="f2_q">
     <property name="lower">0.1</property>
@@ -152,7 +150,6 @@
     <property name="upper">36</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
-    <signal name="value-changed" handler="on_makeup_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="ratio">
     <property name="lower">1</property>
@@ -166,7 +163,6 @@
     <property name="value">-18</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
-    <signal name="value-changed" handler="on_threshold_value_changed" swapped="no"/>
   </object>
   <object class="GtkGrid" id="widgets_grid">
     <property name="visible">True</property>

--- a/data/ui/deesser.glade
+++ b/data/ui/deesser.glade
@@ -13,7 +13,7 @@
     <property name="lower">-24</property>
     <property name="upper">24</property>
     <property name="value">1</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="f2_freq">
@@ -27,7 +27,7 @@
     <property name="lower">-24</property>
     <property name="upper">24</property>
     <property name="value">4</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="f2_q">
@@ -148,7 +148,7 @@
   </object>
   <object class="GtkAdjustment" id="makeup">
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="ratio">
@@ -161,7 +161,7 @@
   <object class="GtkAdjustment" id="threshold">
     <property name="lower">-60</property>
     <property name="value">-18</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkGrid" id="widgets_grid">
@@ -281,7 +281,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
-                <property name="label" translatable="yes">Split</property>
+                <property name="label" translatable="yes">F1 Split</property>
               </object>
               <packing>
                 <property name="left_attach">4</property>
@@ -314,7 +314,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
-                <property name="label" translatable="yes">Gain</property>
+                <property name="label" translatable="yes">F1 Gain</property>
               </object>
               <packing>
                 <property name="left_attach">5</property>
@@ -333,6 +333,7 @@
                 <property name="input_purpose">number</property>
                 <property name="orientation">vertical</property>
                 <property name="adjustment">f1_level</property>
+                <property name="digits">1</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
               </object>
@@ -347,7 +348,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
-                <property name="label" translatable="yes">Peak</property>
+                <property name="label" translatable="yes">F2 Peak</property>
               </object>
               <packing>
                 <property name="left_attach">6</property>
@@ -386,6 +387,7 @@
                 <property name="input_purpose">number</property>
                 <property name="orientation">vertical</property>
                 <property name="adjustment">f2_level</property>
+                <property name="digits">1</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
               </object>
@@ -400,7 +402,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
-                <property name="label" translatable="yes">Level</property>
+                <property name="label" translatable="yes">F2 Level</property>
               </object>
               <packing>
                 <property name="left_attach">7</property>
@@ -413,7 +415,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
-                <property name="label" translatable="yes">Peak Q</property>
+                <property name="label" translatable="yes">F2 Peak Q</property>
               </object>
               <packing>
                 <property name="left_attach">8</property>
@@ -495,6 +497,7 @@
                 <property name="input_purpose">number</property>
                 <property name="orientation">vertical</property>
                 <property name="adjustment">threshold</property>
+                <property name="digits">1</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
               </object>
@@ -559,6 +562,7 @@
                 <property name="input_purpose">number</property>
                 <property name="orientation">vertical</property>
                 <property name="adjustment">makeup</property>
+                <property name="digits">1</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
               </object>

--- a/data/ui/deesser.glade
+++ b/data/ui/deesser.glade
@@ -109,6 +109,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>

--- a/data/ui/delay.glade
+++ b/data/ui/delay.glade
@@ -74,6 +74,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -107,13 +108,13 @@
   <object class="GtkAdjustment" id="input_gain">
     <property name="lower">-20</property>
     <property name="upper">20</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="output_gain">
     <property name="lower">-20</property>
     <property name="upper">20</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="time_l">
@@ -384,8 +385,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">input_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>
@@ -401,8 +401,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">output_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>

--- a/data/ui/equalizer.glade
+++ b/data/ui/equalizer.glade
@@ -27,6 +27,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>

--- a/data/ui/exciter.glade
+++ b/data/ui/exciter.glade
@@ -5,7 +5,7 @@
   <object class="GtkAdjustment" id="amount">
     <property name="lower">-100</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="blend">
@@ -100,6 +100,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -133,13 +134,13 @@
   <object class="GtkAdjustment" id="input_gain">
     <property name="lower">-36</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="output_gain">
     <property name="lower">-36</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="scope">
@@ -310,6 +311,7 @@
                 <property name="input_purpose">number</property>
                 <property name="orientation">vertical</property>
                 <property name="adjustment">amount</property>
+                <property name="digits">1</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
               </object>
@@ -520,8 +522,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">input_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>
@@ -552,8 +553,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">output_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>
@@ -626,15 +626,10 @@
                 <property name="max_width_chars">3</property>
               </object>
               <packing>
-                <property name="left_attach">4</property>
+                <property name="left_attach">3</property>
                 <property name="top_attach">4</property>
+                <property name="width">3</property>
               </packing>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
             </child>
           </object>
           <packing>

--- a/data/ui/exciter.glade
+++ b/data/ui/exciter.glade
@@ -135,14 +135,12 @@
     <property name="upper">36</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
-    <signal name="value-changed" handler="on_input_gain_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="output_gain">
     <property name="lower">-36</property>
     <property name="upper">36</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
-    <signal name="value-changed" handler="on_output_gain_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="scope">
     <property name="lower">2000</property>

--- a/data/ui/filter.glade
+++ b/data/ui/filter.glade
@@ -81,6 +81,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -121,13 +122,13 @@
   <object class="GtkAdjustment" id="input_gain">
     <property name="lower">-36</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="output_gain">
     <property name="lower">-36</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkPopover" id="presets">
@@ -546,7 +547,6 @@
                 <property name="hexpand">True</property>
                 <property name="adjustment">input_gain</property>
                 <property name="round_digits">1</property>
-                <property name="digits">0</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>
@@ -562,8 +562,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">output_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>

--- a/data/ui/gate.glade
+++ b/data/ui/gate.glade
@@ -237,7 +237,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">center</property>
-                        <property name="label" translatable="yes">Gain Detection</property>
+                        <property name="label" translatable="yes">Maximum Gain Reduction</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/data/ui/gate.glade
+++ b/data/ui/gate.glade
@@ -81,6 +81,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>

--- a/data/ui/gate.glade
+++ b/data/ui/gate.glade
@@ -22,7 +22,7 @@
   <object class="GtkBox" id="listbox_control">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="spacing">10</property>
+    <property name="spacing">6</property>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>
@@ -114,7 +114,7 @@
   <object class="GtkAdjustment" id="input">
     <property name="lower">-36</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="knee">
@@ -122,20 +122,17 @@
     <property name="value">9</property>
     <property name="step_increment">0.01</property>
     <property name="page_increment">0.1</property>
-    <signal name="value-changed" handler="on_knee_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="makeup">
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
-    <signal name="value-changed" handler="on_makeup_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="range">
     <property name="lower">-95</property>
     <property name="value">-24</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
-    <signal name="value-changed" handler="on_range_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="ratio">
     <property name="lower">1</property>
@@ -154,9 +151,8 @@
   <object class="GtkAdjustment" id="threshold">
     <property name="lower">-60</property>
     <property name="value">-18</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
-    <signal name="value-changed" handler="on_threshold_value_changed" swapped="no"/>
   </object>
   <object class="GtkGrid" id="widgets_grid">
     <property name="visible">True</property>
@@ -180,103 +176,145 @@
             <property name="orientation">vertical</property>
             <property name="spacing">18</property>
             <child>
-              <object class="GtkGrid">
+              <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="row_spacing">6</property>
-                <property name="column_homogeneous">True</property>
+                <property name="halign">center</property>
+                <property name="spacing">100</property>
+                <property name="homogeneous">True</property>
                 <child>
-                  <object class="GtkLabel">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="halign">center</property>
-                    <property name="valign">center</property>
-                    <property name="margin_start">56</property>
-                    <property name="label" translatable="yes">Detection</property>
+                    <property name="halign">end</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">center</property>
+                        <property name="label" translatable="yes">Detection</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="detection">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">center</property>
+                        <items>
+                          <item translatable="yes">RMS</item>
+                          <item translatable="yes">Peak</item>
+                        </items>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">0</property>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="halign">center</property>
-                    <property name="valign">center</property>
-                    <property name="margin_end">56</property>
-                    <property name="label" translatable="yes">Stereo Link</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">center</property>
+                        <property name="label" translatable="yes">Gain Detection</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSpinButton">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="halign">center</property>
+                        <property name="width_chars">8</property>
+                        <property name="text">-24.0</property>
+                        <property name="xalign">0.5</property>
+                        <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
+                        <property name="input_purpose">number</property>
+                        <property name="adjustment">range</property>
+                        <property name="digits">1</property>
+                        <property name="numeric">True</property>
+                        <property name="update_policy">if-valid</property>
+                        <property name="value">-24</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
-                    <property name="left_attach">2</property>
-                    <property name="top_attach">0</property>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="halign">center</property>
-                    <property name="valign">center</property>
-                    <property name="label" translatable="yes">Gain Reduction</property>
+                    <property name="halign">start</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">center</property>
+                        <property name="label" translatable="yes">Stereo Link</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="stereo_link">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">center</property>
+                        <property name="valign">center</property>
+                        <items>
+                          <item translatable="yes">Average</item>
+                          <item translatable="yes">Maximum</item>
+                        </items>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkSpinButton">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="halign">center</property>
-                    <property name="valign">center</property>
-                    <property name="width_chars">8</property>
-                    <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
-                    <property name="secondary_icon_activatable">False</property>
-                    <property name="input_purpose">number</property>
-                    <property name="adjustment">range</property>
-                    <property name="numeric">True</property>
-                    <property name="update_policy">if-valid</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkComboBoxText" id="detection">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="halign">center</property>
-                    <property name="valign">center</property>
-                    <property name="margin_start">56</property>
-                    <items>
-                      <item translatable="yes">RMS</item>
-                      <item translatable="yes">Peak</item>
-                    </items>
-                  </object>
-                  <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkComboBoxText" id="stereo_link">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="halign">center</property>
-                    <property name="valign">center</property>
-                    <property name="margin_end">56</property>
-                    <items>
-                      <item translatable="yes">Average</item>
-                      <item translatable="yes">Maximum</item>
-                    </items>
-                  </object>
-                  <packing>
-                    <property name="left_attach">2</property>
-                    <property name="top_attach">1</property>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
               </object>
@@ -313,6 +351,7 @@
                     <property name="halign">center</property>
                     <property name="valign">center</property>
                     <property name="width_chars">10</property>
+                    <property name="text">20.00</property>
                     <property name="secondary_icon_name">pulseeffects-ms-symbolic</property>
                     <property name="secondary_icon_activatable">False</property>
                     <property name="input_purpose">number</property>
@@ -321,6 +360,7 @@
                     <property name="digits">2</property>
                     <property name="numeric">True</property>
                     <property name="update_policy">if-valid</property>
+                    <property name="value">20</property>
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
@@ -347,6 +387,7 @@
                     <property name="halign">center</property>
                     <property name="valign">center</property>
                     <property name="width_chars">10</property>
+                    <property name="text">250.00</property>
                     <property name="secondary_icon_name">pulseeffects-ms-symbolic</property>
                     <property name="secondary_icon_activatable">False</property>
                     <property name="input_purpose">number</property>
@@ -355,6 +396,7 @@
                     <property name="digits">2</property>
                     <property name="numeric">True</property>
                     <property name="update_policy">if-valid</property>
+                    <property name="value">250</property>
                   </object>
                   <packing>
                     <property name="left_attach">2</property>
@@ -381,13 +423,16 @@
                     <property name="halign">center</property>
                     <property name="valign">center</property>
                     <property name="width_chars">10</property>
+                    <property name="text">-18</property>
                     <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
                     <property name="secondary_icon_activatable">False</property>
                     <property name="input_purpose">number</property>
                     <property name="orientation">vertical</property>
                     <property name="adjustment">threshold</property>
+                    <property name="digits">1</property>
                     <property name="numeric">True</property>
                     <property name="update_policy">if-valid</property>
+                    <property name="value">-18</property>
                   </object>
                   <packing>
                     <property name="left_attach">3</property>
@@ -414,12 +459,14 @@
                     <property name="halign">center</property>
                     <property name="valign">center</property>
                     <property name="width_chars">10</property>
+                    <property name="text">2.00</property>
                     <property name="input_purpose">number</property>
                     <property name="orientation">vertical</property>
                     <property name="adjustment">ratio</property>
                     <property name="digits">2</property>
                     <property name="numeric">True</property>
                     <property name="update_policy">if-valid</property>
+                    <property name="value">2</property>
                   </object>
                   <packing>
                     <property name="left_attach">4</property>
@@ -446,6 +493,7 @@
                     <property name="halign">center</property>
                     <property name="valign">center</property>
                     <property name="width_chars">10</property>
+                    <property name="text">9.00</property>
                     <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
                     <property name="secondary_icon_activatable">False</property>
                     <property name="input_purpose">number</property>
@@ -454,6 +502,7 @@
                     <property name="digits">2</property>
                     <property name="numeric">True</property>
                     <property name="update_policy">if-valid</property>
+                    <property name="value">9</property>
                   </object>
                   <packing>
                     <property name="left_attach">5</property>
@@ -480,12 +529,14 @@
                     <property name="halign">center</property>
                     <property name="valign">center</property>
                     <property name="width_chars">10</property>
+                    <property name="text">0</property>
                     <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
                     <property name="primary_icon_activatable">False</property>
                     <property name="secondary_icon_activatable">False</property>
                     <property name="input_purpose">number</property>
                     <property name="orientation">vertical</property>
                     <property name="adjustment">makeup</property>
+                    <property name="digits">1</property>
                     <property name="numeric">True</property>
                     <property name="update_policy">if-valid</property>
                   </object>
@@ -501,13 +552,14 @@
                     <property name="halign">center</property>
                     <property name="valign">center</property>
                     <property name="width_chars">10</property>
-                    <property name="text">0</property>
+                    <property name="text">0.0</property>
                     <property name="secondary_icon_name">pulseeffects-db-symbolic</property>
                     <property name="primary_icon_activatable">False</property>
                     <property name="secondary_icon_activatable">False</property>
                     <property name="input_purpose">number</property>
                     <property name="orientation">vertical</property>
                     <property name="adjustment">input</property>
+                    <property name="digits">1</property>
                     <property name="numeric">True</property>
                     <property name="update_policy">if-valid</property>
                   </object>

--- a/data/ui/limiter.glade
+++ b/data/ui/limiter.glade
@@ -115,13 +115,11 @@
     <property name="upper">36</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
-    <signal name="value-changed" handler="on_input_gain_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="limit">
     <property name="lower">-24</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
-    <signal name="value-changed" handler="on_limit_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="lookahead">
     <property name="lower">0.1</property>

--- a/data/ui/limiter.glade
+++ b/data/ui/limiter.glade
@@ -80,6 +80,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -113,12 +114,12 @@
   <object class="GtkAdjustment" id="input_gain">
     <property name="lower">-36</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="limit">
     <property name="lower">-24</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="lookahead">
@@ -131,7 +132,7 @@
   <object class="GtkAdjustment" id="output_gain">
     <property name="lower">-36</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="oversampling">
@@ -236,6 +237,7 @@
                 <property name="input_purpose">number</property>
                 <property name="orientation">vertical</property>
                 <property name="adjustment">input_gain</property>
+                <property name="digits">1</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
               </object>
@@ -269,6 +271,7 @@
                 <property name="input_purpose">number</property>
                 <property name="orientation">vertical</property>
                 <property name="adjustment">limit</property>
+                <property name="digits">1</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
               </object>
@@ -392,6 +395,7 @@
                 <property name="input_purpose">number</property>
                 <property name="orientation">vertical</property>
                 <property name="adjustment">output_gain</property>
+                <property name="digits">1</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
               </object>

--- a/data/ui/loudness.glade
+++ b/data/ui/loudness.glade
@@ -107,13 +107,13 @@
   <object class="GtkAdjustment" id="input">
     <property name="lower">-60</property>
     <property name="upper">72</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="volume">
     <property name="lower">-83</property>
     <property name="upper">7</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkGrid" id="widgets_grid">
@@ -132,57 +132,12 @@
         <property name="orientation">vertical</property>
         <property name="spacing">18</property>
         <child>
-          <object class="GtkGrid">
+          <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="row_spacing">6</property>
-            <property name="column_spacing">8</property>
-            <property name="column_homogeneous">True</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes">Standard</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkComboBoxText" id="standard">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <items>
-                  <item translatable="yes">Flat</item>
-                  <item translatable="yes">ISO226-2003</item>
-                  <item translatable="yes">Fletcher-Munson</item>
-                  <item translatable="yes">Robinson-Dadson</item>
-                </items>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkToggleButton" id="reference_signal">
-                <property name="label" translatable="yes">Reference Signal</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-              </object>
-              <packing>
-                <property name="left_attach">2</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
+            <property name="halign">center</property>
+            <property name="spacing">60</property>
+            <property name="homogeneous">True</property>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
@@ -228,13 +183,97 @@
                 </child>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">0</property>
-                <property name="height">2</property>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <placeholder/>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
+                    <property name="label" translatable="yes">Standard</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBoxText" id="standard">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
+                    <items>
+                      <item translatable="yes">Flat</item>
+                      <item translatable="yes">ISO226-2003</item>
+                      <item translatable="yes">Fletcher-Munson</item>
+                      <item translatable="yes">Robinson-Dadson</item>
+                    </items>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkToggleButton" id="reference_signal">
+                    <property name="label" translatable="yes">Reference Signal</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="halign">start</property>
+                    <property name="valign">center</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
             </child>
           </object>
           <packing>
@@ -275,6 +314,7 @@
                 <property name="input_purpose">number</property>
                 <property name="orientation">vertical</property>
                 <property name="adjustment">input</property>
+                <property name="digits">1</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
               </object>
@@ -308,6 +348,7 @@
                 <property name="input_purpose">number</property>
                 <property name="orientation">vertical</property>
                 <property name="adjustment">volume</property>
+                <property name="digits">1</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
               </object>

--- a/data/ui/loudness.glade
+++ b/data/ui/loudness.glade
@@ -74,6 +74,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>

--- a/data/ui/maximizer.glade
+++ b/data/ui/maximizer.glade
@@ -4,7 +4,7 @@
   <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="ceiling">
     <property name="lower">-30</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkImage" id="image1">
@@ -79,6 +79,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -118,7 +119,7 @@
   </object>
   <object class="GtkAdjustment" id="threshold">
     <property name="lower">-30</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkGrid" id="widgets_grid">
@@ -194,6 +195,7 @@
                 <property name="input_purpose">number</property>
                 <property name="orientation">vertical</property>
                 <property name="adjustment">threshold</property>
+                <property name="digits">1</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
               </object>
@@ -235,6 +237,7 @@
                 <property name="input_purpose">number</property>
                 <property name="orientation">vertical</property>
                 <property name="adjustment">ceiling</property>
+                <property name="digits">1</property>
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
               </object>

--- a/data/ui/multiband_compressor.glade
+++ b/data/ui/multiband_compressor.glade
@@ -164,7 +164,6 @@
     <property name="value">9</property>
     <property name="step_increment">0.01</property>
     <property name="page_increment">0.1</property>
-    <signal name="value-changed" handler="on_knee_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="knee1">
     <property name="upper">18</property>
@@ -188,7 +187,6 @@
     <property name="upper">36</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
-    <signal name="value-changed" handler="on_makeup_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="makeup1">
     <property name="upper">36</property>
@@ -272,7 +270,6 @@
     <property name="value">-12</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
-    <signal name="value-changed" handler="on_threshold_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="threshold1">
     <property name="lower">-60</property>

--- a/data/ui/multiband_compressor.glade
+++ b/data/ui/multiband_compressor.glade
@@ -123,6 +123,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -156,7 +157,7 @@
   <object class="GtkAdjustment" id="input_gain">
     <property name="lower">-36</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="knee0">
@@ -185,28 +186,28 @@
   </object>
   <object class="GtkAdjustment" id="makeup0">
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="makeup1">
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="makeup2">
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="makeup3">
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="output_gain">
     <property name="lower">-36</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="ratio0">
@@ -268,25 +269,25 @@
   <object class="GtkAdjustment" id="threshold0">
     <property name="lower">-60</property>
     <property name="value">-12</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="threshold1">
     <property name="lower">-60</property>
     <property name="value">-12</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="threshold2">
     <property name="lower">-60</property>
     <property name="value">-12</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="threshold3">
     <property name="lower">-60</property>
     <property name="value">-12</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkGrid" id="widgets_grid">
@@ -622,6 +623,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">threshold0</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                           </object>
@@ -723,6 +725,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">makeup0</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                           </object>
@@ -996,6 +999,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">threshold1</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                             <property name="value">-12</property>
@@ -1100,6 +1104,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">makeup1</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                           </object>
@@ -1374,6 +1379,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">threshold2</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                             <property name="value">-12</property>
@@ -1478,6 +1484,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">makeup2</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                           </object>
@@ -1752,6 +1759,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">threshold3</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                             <property name="value">-12</property>
@@ -1856,6 +1864,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">makeup3</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                           </object>
@@ -2146,8 +2155,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">input_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>
@@ -2163,8 +2171,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">output_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>

--- a/data/ui/multiband_gate.glade
+++ b/data/ui/multiband_gate.glade
@@ -164,7 +164,6 @@
     <property name="value">9</property>
     <property name="step_increment">0.01</property>
     <property name="page_increment">0.1</property>
-    <signal name="value-changed" handler="on_knee_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="knee1">
     <property name="upper">18</property>
@@ -188,7 +187,6 @@
     <property name="upper">36</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
-    <signal name="value-changed" handler="on_makeup_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="makeup1">
     <property name="upper">36</property>
@@ -296,7 +294,6 @@
     <property name="value">-12</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
-    <signal name="value-changed" handler="on_threshold_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="threshold1">
     <property name="lower">-60</property>

--- a/data/ui/multiband_gate.glade
+++ b/data/ui/multiband_gate.glade
@@ -35,21 +35,21 @@
     <property name="upper">20000</property>
     <property name="value">120</property>
     <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
+    <property name="page_increment">100</property>
   </object>
   <object class="GtkAdjustment" id="freq1">
     <property name="lower">10</property>
     <property name="upper">20000</property>
     <property name="value">1000</property>
     <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
+    <property name="page_increment">100</property>
   </object>
   <object class="GtkAdjustment" id="freq2">
     <property name="lower">10</property>
     <property name="upper">20000</property>
     <property name="value">6000</property>
     <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
+    <property name="page_increment">100</property>
   </object>
   <object class="GtkImage" id="image1">
     <property name="visible">True</property>
@@ -123,6 +123,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -156,7 +157,7 @@
   <object class="GtkAdjustment" id="input_gain">
     <property name="lower">-36</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="knee0">
@@ -185,52 +186,52 @@
   </object>
   <object class="GtkAdjustment" id="makeup0">
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="makeup1">
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="makeup2">
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="makeup3">
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="output_gain">
     <property name="lower">-36</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="range0">
     <property name="lower">-95</property>
     <property name="value">-24</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="range1">
     <property name="lower">-95</property>
     <property name="value">-24</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="range2">
     <property name="lower">-95</property>
     <property name="value">-24</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="range3">
     <property name="lower">-95</property>
     <property name="value">-24</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="ratio0">
@@ -292,25 +293,25 @@
   <object class="GtkAdjustment" id="threshold0">
     <property name="lower">-60</property>
     <property name="value">-12</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="threshold1">
     <property name="lower">-60</property>
     <property name="value">-12</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="threshold2">
     <property name="lower">-60</property>
     <property name="value">-12</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="threshold3">
     <property name="lower">-60</property>
     <property name="value">-12</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkGrid" id="widgets_grid">
@@ -646,6 +647,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">threshold0</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                           </object>
@@ -747,6 +749,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">makeup0</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                           </object>
@@ -780,6 +783,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">range0</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                             <property name="value">300</property>
@@ -1053,6 +1057,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">threshold1</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                             <property name="value">-12</property>
@@ -1157,6 +1162,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">makeup1</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                           </object>
@@ -1177,6 +1183,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">range1</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                           </object>
@@ -1463,6 +1470,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">threshold2</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                             <property name="value">-12</property>
@@ -1567,6 +1575,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">makeup2</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                           </object>
@@ -1587,6 +1596,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">range2</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                           </object>
@@ -1873,6 +1883,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">threshold3</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                             <property name="value">-12</property>
@@ -1977,6 +1988,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">makeup3</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                           </object>
@@ -1997,6 +2009,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">range3</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                           </object>
@@ -2299,8 +2312,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">input_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>
@@ -2316,8 +2328,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">output_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>

--- a/data/ui/pitch.glade
+++ b/data/ui/pitch.glade
@@ -86,6 +86,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -119,7 +120,7 @@
   <object class="GtkAdjustment" id="input_gain">
     <property name="lower">-20</property>
     <property name="upper">20</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="octaves">
@@ -131,7 +132,7 @@
   <object class="GtkAdjustment" id="output_gain">
     <property name="lower">-20</property>
     <property name="upper">20</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="semitones">
@@ -510,8 +511,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">input_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>
@@ -527,8 +527,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">output_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>

--- a/data/ui/reverb.glade
+++ b/data/ui/reverb.glade
@@ -6,7 +6,7 @@
     <property name="lower">-100</property>
     <property name="upper">6</property>
     <property name="value">-12</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="bass_cut">
@@ -32,7 +32,7 @@
   <object class="GtkAdjustment" id="dry">
     <property name="lower">-100</property>
     <property name="upper">6</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="hf_damp">
@@ -114,6 +114,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -147,13 +148,13 @@
   <object class="GtkAdjustment" id="input_gain">
     <property name="lower">-36</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="output_gain">
     <property name="lower">-36</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="predelay">
@@ -422,6 +423,7 @@
                     <property name="input_purpose">number</property>
                     <property name="orientation">vertical</property>
                     <property name="adjustment">amount</property>
+                    <property name="digits">1</property>
                     <property name="numeric">True</property>
                     <property name="update_policy">if-valid</property>
                   </object>
@@ -454,6 +456,7 @@
                     <property name="input_purpose">number</property>
                     <property name="orientation">vertical</property>
                     <property name="adjustment">dry</property>
+                    <property name="digits">1</property>
                     <property name="numeric">True</property>
                     <property name="update_policy">if-valid</property>
                   </object>
@@ -808,7 +811,6 @@
                 <property name="hexpand">True</property>
                 <property name="adjustment">input_gain</property>
                 <property name="round_digits">1</property>
-                <property name="digits">0</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>
@@ -825,7 +827,6 @@
                 <property name="hexpand">True</property>
                 <property name="adjustment">output_gain</property>
                 <property name="round_digits">1</property>
-                <property name="digits">0</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>

--- a/data/ui/stereo_tools.glade
+++ b/data/ui/stereo_tools.glade
@@ -158,7 +158,6 @@
     <property name="value">1</property>
     <property name="step_increment">0.01</property>
     <property name="page_increment">0.1</property>
-    <signal name="value-changed" handler="on_left_gain_value_changed" swapped="no"/>
   </object>
   <object class="GtkAdjustment" id="slev">
     <property name="lower">-36</property>
@@ -176,7 +175,6 @@
     <property name="upper">360</property>
     <property name="step_increment">0.01</property>
     <property name="page_increment">0.1</property>
-    <signal name="value-changed" handler="on_right_gain_value_changed" swapped="no"/>
   </object>
   <object class="GtkGrid" id="widgets_grid">
     <property name="visible">True</property>

--- a/data/ui/stereo_tools.glade
+++ b/data/ui/stereo_tools.glade
@@ -92,6 +92,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -125,13 +126,13 @@
   <object class="GtkAdjustment" id="input_gain">
     <property name="lower">-36</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="mlev">
     <property name="lower">-36</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="mpan">
@@ -143,7 +144,7 @@
   <object class="GtkAdjustment" id="output_gain">
     <property name="lower">-36</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="sbal">
@@ -162,7 +163,7 @@
   <object class="GtkAdjustment" id="slev">
     <property name="lower">-36</property>
     <property name="upper">36</property>
-    <property name="step_increment">1</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="stereo_base">
@@ -358,6 +359,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">slev</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                           </object>
@@ -409,6 +411,7 @@
                             <property name="input_purpose">number</property>
                             <property name="orientation">vertical</property>
                             <property name="adjustment">mlev</property>
+                            <property name="digits">1</property>
                             <property name="numeric">True</property>
                             <property name="update_policy">if-valid</property>
                           </object>
@@ -929,8 +932,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">output_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>
@@ -946,8 +948,7 @@
                 <property name="valign">center</property>
                 <property name="hexpand">True</property>
                 <property name="adjustment">input_gain</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
+                <property name="round_digits">1</property>
                 <property name="value_pos">right</property>
               </object>
               <packing>

--- a/data/ui/webrtc.glade
+++ b/data/ui/webrtc.glade
@@ -80,6 +80,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
+            <property name="valign">center</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>

--- a/help/C/deesser.page
+++ b/help/C/deesser.page
@@ -47,7 +47,7 @@
         </item>
         <item>
             <title>
-                <em style="strong" its:withinText="nested">Split</em>
+                <em style="strong" its:withinText="nested">F1 Split</em>
             </title>
             <p>
                 The split frequency. All signals above this frequency will affect the gain
@@ -56,7 +56,7 @@
         </item>
         <item>
             <title>
-                <em style="strong" its:withinText="nested">Gain</em>
+                <em style="strong" its:withinText="nested">F1 Gain</em>
             </title>
             <p>
                 It shifts the volume of the higher band. In wideband mode it affects the
@@ -65,7 +65,7 @@
         </item>
         <item>
             <title>
-                <em style="strong" its:withinText="nested">Peak</em>
+                <em style="strong" its:withinText="nested">F2 Peak</em>
             </title>
             <p>
                 Center frequency of the bell filter. It allows a more precise selection of the
@@ -74,7 +74,7 @@
         </item>
         <item>
             <title>
-                <em style="strong" its:withinText="nested">Level</em>
+                <em style="strong" its:withinText="nested">F2 Level</em>
             </title>
             <p>
                 Increase or decrease the frequencies around the center bell frequency.
@@ -82,7 +82,7 @@
         </item>
         <item>
             <title>
-                <em style="strong" its:withinText="nested">Peak Q</em>
+                <em style="strong" its:withinText="nested">F2 Peak Q</em>
             </title>
             <p>
                 Set the quality of the bell. Higher values will affect a narrower frequency

--- a/help/de/de.po
+++ b/help/de/de.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2020-08-22 15:53+0200\n"
+"POT-Creation-Date: 2020-08-24 16:56+0200\n"
 "PO-Revision-Date: 2020-01-12 17:48+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -512,7 +512,8 @@ msgstr ""
 
 #. (itstool) path: title/em
 #: C/deesser.page:50
-msgid "Split"
+#, fuzzy
+msgid "F1 Split"
 msgstr "Teilen"
 
 #. (itstool) path: item/p
@@ -526,8 +527,9 @@ msgstr ""
 "der Reduktion betroffen)."
 
 #. (itstool) path: title/em
-#: C/deesser.page:59 C/autogain.page:70
-msgid "Gain"
+#: C/deesser.page:59
+#, fuzzy
+msgid "F1 Gain"
 msgstr "Verstärkung"
 
 #. (itstool) path: item/p
@@ -542,7 +544,8 @@ msgstr ""
 
 #. (itstool) path: title/em
 #: C/deesser.page:68
-msgid "Peak"
+#, fuzzy
+msgid "F2 Peak"
 msgstr "Hochpunkt"
 
 #. (itstool) path: item/p
@@ -556,7 +559,8 @@ msgstr ""
 
 #. (itstool) path: title/em
 #: C/deesser.page:77
-msgid "Level"
+#, fuzzy
+msgid "F2 Level"
 msgstr "Ebene"
 
 #. (itstool) path: item/p
@@ -566,7 +570,8 @@ msgstr "Erhöht oder verringert die Frequenzen um die mittlere Glockenfrequenz."
 
 #. (itstool) path: title/em
 #: C/deesser.page:85
-msgid "Peak Q"
+#, fuzzy
+msgid "F2 Peak Q"
 msgstr "Höchstwert Q"
 
 #. (itstool) path: item/p
@@ -2815,6 +2820,11 @@ msgstr "Umfang"
 msgid "Loudness range. Indicates how large is the material dynamic range."
 msgstr ""
 "Lautstärkebereich. Zeigt an, wie groß der Dynamikbereich des Materials ist."
+
+#. (itstool) path: title/em
+#: C/autogain.page:70
+msgid "Gain"
+msgstr "Verstärkung"
 
 #. (itstool) path: item/p
 #: C/autogain.page:72

--- a/help/it_IT/it_IT.po
+++ b/help/it_IT/it_IT.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: pulseeffects\n"
-"POT-Creation-Date: 2020-08-22 15:53+0200\n"
+"POT-Creation-Date: 2020-08-24 16:56+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Gianluca Boiano <morf3089@gmail.com>\n"
 "Language-Team: \n"
@@ -518,8 +518,8 @@ msgstr ""
 
 #. (itstool) path: title/em
 #: C/deesser.page:50
-msgid "Split"
-msgstr "Split"
+msgid "F1 Split"
+msgstr "F1 Split"
 
 #. (itstool) path: item/p
 #: C/deesser.page:52
@@ -531,9 +531,9 @@ msgstr ""
 "frequenza saranno interessati dalla riduzione in ampiezza."
 
 #. (itstool) path: title/em
-#: C/deesser.page:59 C/autogain.page:70
-msgid "Gain"
-msgstr "Guadagno"
+#: C/deesser.page:59
+msgid "F1 Gain"
+msgstr "F1 Guadagno"
 
 #. (itstool) path: item/p
 #: C/deesser.page:61
@@ -547,8 +547,8 @@ msgstr ""
 
 #. (itstool) path: title/em
 #: C/deesser.page:68
-msgid "Peak"
-msgstr "Picco"
+msgid "F2 Peak"
+msgstr "F2 Picco"
 
 #. (itstool) path: item/p
 #: C/deesser.page:70
@@ -561,8 +561,8 @@ msgstr ""
 
 #. (itstool) path: title/em
 #: C/deesser.page:77
-msgid "Level"
-msgstr "Livello"
+msgid "F2 Level"
+msgstr "F2 Livello"
 
 #. (itstool) path: item/p
 #: C/deesser.page:79
@@ -573,8 +573,8 @@ msgstr ""
 
 #. (itstool) path: title/em
 #: C/deesser.page:85
-msgid "Peak Q"
-msgstr "Picco Q"
+msgid "F2 Peak Q"
+msgstr "F2 Picco Q"
 
 #. (itstool) path: item/p
 #: C/deesser.page:87
@@ -2840,6 +2840,11 @@ msgid "Loudness range. Indicates how large is the material dynamic range."
 msgstr ""
 "Gamma della Loudness. Indica quanto è varia la gamma dinamica del segnale "
 "audio."
+
+#. (itstool) path: title/em
+#: C/autogain.page:70
+msgid "Gain"
+msgstr "Guadagno"
 
 #. (itstool) path: item/p
 #: C/autogain.page:72

--- a/help/pt_BR/pt_BR.po
+++ b/help/pt_BR/pt_BR.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: pulseeffects\n"
-"POT-Creation-Date: 2020-08-22 15:53+0200\n"
+"POT-Creation-Date: 2020-08-24 16:56+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -503,7 +503,8 @@ msgstr "Se um sinal subir acima deste nível ele afetará a redução de ganho."
 
 #. (itstool) path: title/em
 #: C/deesser.page:50
-msgid "Split"
+#, fuzzy
+msgid "F1 Split"
 msgstr "Separado"
 
 #. (itstool) path: item/p
@@ -516,8 +517,9 @@ msgstr ""
 "redução de ganho(e em modo separado eles também serão afetados pela redução)."
 
 #. (itstool) path: title/em
-#: C/deesser.page:59 C/autogain.page:70
-msgid "Gain"
+#: C/deesser.page:59
+#, fuzzy
+msgid "F1 Gain"
 msgstr "Ganho"
 
 #. (itstool) path: item/p
@@ -532,7 +534,8 @@ msgstr ""
 
 #. (itstool) path: title/em
 #: C/deesser.page:68
-msgid "Peak"
+#, fuzzy
+msgid "F2 Peak"
 msgstr "Pico"
 
 #. (itstool) path: item/p
@@ -546,7 +549,8 @@ msgstr ""
 
 #. (itstool) path: title/em
 #: C/deesser.page:77
-msgid "Level"
+#, fuzzy
+msgid "F2 Level"
 msgstr "Nível"
 
 #. (itstool) path: item/p
@@ -558,7 +562,8 @@ msgstr ""
 
 #. (itstool) path: title/em
 #: C/deesser.page:85
-msgid "Peak Q"
+#, fuzzy
+msgid "F2 Peak Q"
 msgstr "Pico Q"
 
 #. (itstool) path: item/p
@@ -2787,6 +2792,11 @@ msgstr "Alcance"
 msgid "Loudness range. Indicates how large is the material dynamic range."
 msgstr ""
 "Intervalo de sonoridade. Indica quão grande é a faixa dinâmica do material."
+
+#. (itstool) path: title/em
+#: C/autogain.page:70
+msgid "Gain"
+msgstr "Ganho"
 
 #. (itstool) path: item/p
 #: C/autogain.page:72

--- a/help/pulseeffects.pot
+++ b/help/pulseeffects.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-08-22 15:53+0200\n"
+"POT-Creation-Date: 2020-08-24 16:56+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -470,7 +470,7 @@ msgstr ""
 
 #. (itstool) path: title/em
 #: C/deesser.page:50
-msgid "Split"
+msgid "F1 Split"
 msgstr ""
 
 #. (itstool) path: item/p
@@ -480,8 +480,7 @@ msgstr ""
 
 #. (itstool) path: title/em
 #: C/deesser.page:59
-#: C/autogain.page:70
-msgid "Gain"
+msgid "F1 Gain"
 msgstr ""
 
 #. (itstool) path: item/p
@@ -491,7 +490,7 @@ msgstr ""
 
 #. (itstool) path: title/em
 #: C/deesser.page:68
-msgid "Peak"
+msgid "F2 Peak"
 msgstr ""
 
 #. (itstool) path: item/p
@@ -501,7 +500,7 @@ msgstr ""
 
 #. (itstool) path: title/em
 #: C/deesser.page:77
-msgid "Level"
+msgid "F2 Level"
 msgstr ""
 
 #. (itstool) path: item/p
@@ -511,7 +510,7 @@ msgstr ""
 
 #. (itstool) path: title/em
 #: C/deesser.page:85
-msgid "Peak Q"
+msgid "F2 Peak Q"
 msgstr ""
 
 #. (itstool) path: item/p
@@ -2246,6 +2245,11 @@ msgstr ""
 #. (itstool) path: item/p
 #: C/autogain.page:66
 msgid "Loudness range. Indicates how large is the material dynamic range."
+msgstr ""
+
+#. (itstool) path: title/em
+#: C/autogain.page:70
+msgid "Gain"
 msgstr ""
 
 #. (itstool) path: item/p

--- a/help/ru/ru.po
+++ b/help/ru/ru.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-08-22 15:53+0200\n"
+"POT-Creation-Date: 2020-08-24 16:56+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Mikhail Novosyolov <mikhailnov@dumalogiya.ru>\n"
 "MIME-Version: 1.0\n"
@@ -483,7 +483,8 @@ msgstr ""
 
 #. (itstool) path: title/em
 #: C/deesser.page:50
-msgid "Split"
+#, fuzzy
+msgid "F1 Split"
 msgstr "Частота раздела"
 
 #. (itstool) path: item/p
@@ -496,8 +497,9 @@ msgstr ""
 "будет уменьшен"
 
 #. (itstool) path: title/em
-#: C/deesser.page:59 C/autogain.page:70
-msgid "Gain"
+#: C/deesser.page:59
+#, fuzzy
+msgid "F1 Gain"
 msgstr "Усиление"
 
 #. (itstool) path: item/p
@@ -512,7 +514,8 @@ msgstr ""
 
 #. (itstool) path: title/em
 #: C/deesser.page:68
-msgid "Peak"
+#, fuzzy
+msgid "F2 Peak"
 msgstr "Пик"
 
 #. (itstool) path: item/p
@@ -526,7 +529,8 @@ msgstr ""
 
 #. (itstool) path: title/em
 #: C/deesser.page:77
-msgid "Level"
+#, fuzzy
+msgid "F2 Level"
 msgstr "Уровень"
 
 #. (itstool) path: item/p
@@ -538,7 +542,8 @@ msgstr ""
 
 #. (itstool) path: title/em
 #: C/deesser.page:85
-msgid "Peak Q"
+#, fuzzy
+msgid "F2 Peak Q"
 msgstr "Добротность (Q)"
 
 #. (itstool) path: item/p
@@ -2534,6 +2539,11 @@ msgstr ""
 #: C/autogain.page:66
 msgid "Loudness range. Indicates how large is the material dynamic range."
 msgstr ""
+
+#. (itstool) path: title/em
+#: C/autogain.page:70
+msgid "Gain"
+msgstr "Усиление"
 
 #. (itstool) path: item/p
 #: C/autogain.page:72

--- a/po/cs.po
+++ b/po/cs.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-22 15:29+0200\n"
+"POT-Creation-Date: 2020-08-24 16:51+0200\n"
 "PO-Revision-Date: 2019-08-25 21:29+0200\n"
 "Last-Translator: Mlocik97\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
@@ -84,8 +84,8 @@ msgid "Input Limiter"
 msgstr "Omezovač vstupu"
 
 #: data/com.github.wwmm.pulseeffects.appdata.xml.in:52
-#: data/ui/compressor.glade:111 data/ui/compressor.glade:494
-#: data/ui/webrtc.glade:509
+#: data/ui/compressor.glade:112 data/ui/compressor.glade:494
+#: data/ui/webrtc.glade:510
 msgid "Compressor"
 msgstr "Kompresor"
 
@@ -117,12 +117,12 @@ msgstr "Programy"
 msgid "Format"
 msgstr "Formát"
 
-#: data/ui/app_info.glade:75 data/ui/convolver.glade:283
+#: data/ui/app_info.glade:75 data/ui/convolver.glade:284
 msgid "Rate"
 msgstr "Kmitočet"
 
 #: data/ui/app_info.glade:102 data/ui/pulse_info.glade:238
-#: data/ui/stereo_tools.glade:653
+#: data/ui/stereo_tools.glade:654
 msgid "Channels"
 msgstr "Kanály"
 
@@ -160,7 +160,7 @@ msgstr "Zkušební signály"
 msgid "Global Bypass"
 msgstr "Přepustení"
 
-#: data/ui/application.glade:170 data/ui/equalizer.glade:277
+#: data/ui/application.glade:170 data/ui/equalizer.glade:278
 #: data/ui/general_settings.glade:107
 msgid "Settings"
 msgstr "Nastavení"
@@ -169,171 +169,170 @@ msgstr "Nastavení"
 msgid "Help"
 msgstr "Nápověda"
 
-#: data/ui/application.glade:215 data/ui/crossfeed.glade:49
-#: data/ui/equalizer.glade:333 data/ui/filter.glade:230
-#: data/ui/reverb.glade:310 src/presets_menu_ui.cpp:113
+#: data/ui/application.glade:215 data/ui/crossfeed.glade:48
+#: data/ui/equalizer.glade:334 data/ui/filter.glade:231
+#: data/ui/reverb.glade:311 src/presets_menu_ui.cpp:113
 #: src/presets_menu_ui.cpp:258 src/presets_menu_ui.cpp:275
 msgid "Presets"
 msgstr "Přednastavení"
 
-#: data/ui/autogain.glade:91
+#: data/ui/autogain.glade:92
 msgid "Auto Gain"
 msgstr "Automatické zesílení"
 
-#: data/ui/autogain.glade:171
+#: data/ui/autogain.glade:172
 #, fuzzy
 msgid "Reset History"
 msgstr "Vymazat Historii"
 
-#: data/ui/autogain.glade:183
+#: data/ui/autogain.glade:184
 msgid "Detect Silence"
 msgstr "Zjištění Ticha"
 
-#: data/ui/autogain.glade:195
+#: data/ui/autogain.glade:196
 #, fuzzy
 msgid "Use Geometric Mean"
 msgstr "Použít přechod"
 
-#: data/ui/autogain.glade:233
+#: data/ui/autogain.glade:234
 msgid "Target"
 msgstr "Cíl"
 
-#: data/ui/autogain.glade:283 data/ui/autogain.glade:627
+#: data/ui/autogain.glade:286 data/ui/autogain.glade:631
 msgid "Momentary"
 msgstr "Chvilkové"
 
-#: data/ui/autogain.glade:298 data/ui/autogain.glade:640
+#: data/ui/autogain.glade:301 data/ui/autogain.glade:644
 msgid "Short Term"
 msgstr "Jednorázové"
 
-#: data/ui/autogain.glade:313 data/ui/autogain.glade:653
+#: data/ui/autogain.glade:316 data/ui/autogain.glade:657
 msgid "Integrated"
 msgstr "Sjednocené"
 
-#: data/ui/autogain.glade:388
+#: data/ui/autogain.glade:394
 msgid "Weights"
 msgstr "Váhy"
 
-#: data/ui/autogain.glade:428 data/ui/autogain.glade:917
-#: data/ui/bass_enhancer.glade:504 data/ui/compressor.glade:974
-#: data/ui/convolver.glade:504 data/ui/crossfeed.glade:200
-#: data/ui/crystalizer.glade:255 data/ui/deesser.glade:593
-#: data/ui/delay.glade:236 data/ui/equalizer.glade:543
-#: data/ui/exciter.glade:510 data/ui/filter.glade:396 data/ui/gate.glade:558
-#: data/ui/limiter.glade:483 data/ui/loudness.glade:259
-#: data/ui/loudness.glade:338 data/ui/maximizer.glade:265
-#: data/ui/multiband_compressor.glade:2000 data/ui/multiband_gate.glade:2153
-#: data/ui/pitch.glade:362 data/ui/presets_menu.glade:255
-#: data/ui/reverb.glade:658 data/ui/stereo_tools.glade:323
-#: data/ui/stereo_tools.glade:829 data/ui/webrtc.glade:650
+#: data/ui/autogain.glade:434 data/ui/autogain.glade:921
+#: data/ui/bass_enhancer.glade:506 data/ui/compressor.glade:977
+#: data/ui/convolver.glade:505 data/ui/crossfeed.glade:199
+#: data/ui/crystalizer.glade:205 data/ui/deesser.glade:594
+#: data/ui/delay.glade:237 data/ui/equalizer.glade:544
+#: data/ui/exciter.glade:510 data/ui/filter.glade:397 data/ui/gate.glade:611
+#: data/ui/limiter.glade:485 data/ui/loudness.glade:299
+#: data/ui/loudness.glade:380 data/ui/maximizer.glade:268
+#: data/ui/multiband_compressor.glade:2006 data/ui/multiband_gate.glade:2163
+#: data/ui/pitch.glade:363 data/ui/presets_menu.glade:255
+#: data/ui/reverb.glade:661 data/ui/stereo_tools.glade:322
+#: data/ui/stereo_tools.glade:830 data/ui/webrtc.glade:651
 msgid "Input"
 msgstr "Vstup"
 
-#: data/ui/autogain.glade:443 data/ui/autogain.glade:862
-#: data/ui/bass_enhancer.glade:536 data/ui/compressor.glade:988
-#: data/ui/convolver.glade:519 data/ui/crossfeed.glade:214
-#: data/ui/crystalizer.glade:270 data/ui/deesser.glade:607
-#: data/ui/delay.glade:250 data/ui/equalizer.glade:557
-#: data/ui/exciter.glade:542 data/ui/filter.glade:411 data/ui/gate.glade:572
-#: data/ui/limiter.glade:626 data/ui/loudness.glade:292
-#: data/ui/loudness.glade:352 data/ui/maximizer.glade:279
+#: data/ui/autogain.glade:449 data/ui/autogain.glade:866
+#: data/ui/bass_enhancer.glade:537 data/ui/compressor.glade:991
+#: data/ui/convolver.glade:520 data/ui/crossfeed.glade:213
+#: data/ui/crystalizer.glade:220 data/ui/deesser.glade:608
+#: data/ui/delay.glade:251 data/ui/equalizer.glade:558
+#: data/ui/exciter.glade:541 data/ui/filter.glade:412 data/ui/gate.glade:625
+#: data/ui/limiter.glade:628 data/ui/loudness.glade:333
+#: data/ui/loudness.glade:394 data/ui/maximizer.glade:282
 #: data/ui/multiband_compressor.glade:794
-#: data/ui/multiband_compressor.glade:1171
-#: data/ui/multiband_compressor.glade:1549
-#: data/ui/multiband_compressor.glade:1927
-#: data/ui/multiband_compressor.glade:2015 data/ui/multiband_gate.glade:851
-#: data/ui/multiband_gate.glade:1260 data/ui/multiband_gate.glade:1670
-#: data/ui/multiband_gate.glade:2080 data/ui/multiband_gate.glade:2168
-#: data/ui/pitch.glade:376 data/ui/presets_menu.glade:146
-#: data/ui/reverb.glade:673 data/ui/stereo_tools.glade:800
-#: data/ui/stereo_tools.glade:843 data/ui/webrtc.glade:664
+#: data/ui/multiband_compressor.glade:1173
+#: data/ui/multiband_compressor.glade:1553
+#: data/ui/multiband_compressor.glade:1933
+#: data/ui/multiband_compressor.glade:2021 data/ui/multiband_gate.glade:852
+#: data/ui/multiband_gate.glade:1264 data/ui/multiband_gate.glade:1677
+#: data/ui/multiband_gate.glade:2090 data/ui/multiband_gate.glade:2178
+#: data/ui/pitch.glade:377 data/ui/presets_menu.glade:146
+#: data/ui/reverb.glade:676 data/ui/stereo_tools.glade:801
+#: data/ui/stereo_tools.glade:844 data/ui/webrtc.glade:665
 msgid "Output"
 msgstr "Výstup"
 
-#: data/ui/autogain.glade:744
+#: data/ui/autogain.glade:748
 msgid "Relative"
 msgstr "Relativní"
 
-#: data/ui/autogain.glade:757 data/ui/compressor.glade:1154
-#: data/ui/deesser.glade:321
+#: data/ui/autogain.glade:761 data/ui/compressor.glade:1157
 msgid "Gain"
 msgstr "Zesílení"
 
-#: data/ui/autogain.glade:823
+#: data/ui/autogain.glade:827
 msgid "Loudness"
 msgstr "Hlasitost"
 
-#: data/ui/autogain.glade:876
+#: data/ui/autogain.glade:880
 msgid "Range"
 msgstr "Rozsah"
 
-#: data/ui/autogain.glade:945 data/ui/bass_enhancer.glade:655
-#: data/ui/compressor.glade:1299 data/ui/convolver.glade:703
-#: data/ui/crossfeed.glade:395 data/ui/crystalizer.glade:566
-#: data/ui/deesser.glade:898 data/ui/delay.glade:434
-#: data/ui/equalizer.glade:743 data/ui/equalizer_band.glade:182
-#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:661
-#: data/ui/filter.glade:595 data/ui/general_settings.glade:116
-#: data/ui/gate.glade:809 data/ui/limiter.glade:733 data/ui/loudness.glade:573
-#: data/ui/maximizer.glade:516 data/ui/multiband_compressor.glade:2199
-#: data/ui/multiband_gate.glade:2352 data/ui/pitch.glade:560
-#: data/ui/reverb.glade:857 data/ui/stereo_tools.glade:1029
-#: data/ui/webrtc.glade:814
+#: data/ui/autogain.glade:949 data/ui/bass_enhancer.glade:650
+#: data/ui/compressor.glade:1300 data/ui/convolver.glade:702
+#: data/ui/crossfeed.glade:394 data/ui/crystalizer.glade:514
+#: data/ui/deesser.glade:899 data/ui/delay.glade:433
+#: data/ui/equalizer.glade:744 data/ui/equalizer_band.glade:182
+#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:654
+#: data/ui/filter.glade:594 data/ui/general_settings.glade:116
+#: data/ui/gate.glade:862 data/ui/limiter.glade:735 data/ui/loudness.glade:615
+#: data/ui/maximizer.glade:519 data/ui/multiband_compressor.glade:2203
+#: data/ui/multiband_gate.glade:2360 data/ui/pitch.glade:559
+#: data/ui/reverb.glade:858 data/ui/stereo_tools.glade:1028
+#: data/ui/webrtc.glade:815
 msgid "Reset"
 msgstr "Vrátit na výchozí"
 
-#: data/ui/autogain.glade:969
+#: data/ui/autogain.glade:973
 msgid "Based on"
 msgstr "Na základě"
 
-#: data/ui/bass_enhancer.glade:117
+#: data/ui/bass_enhancer.glade:118
 msgid "Bass Enhancer"
 msgstr "Zlepšovač hloubek"
 
-#: data/ui/bass_enhancer.glade:169 data/ui/compressor.glade:506
-#: data/ui/deesser.glade:188 data/ui/exciter.glade:171
+#: data/ui/bass_enhancer.glade:170 data/ui/compressor.glade:506
+#: data/ui/deesser.glade:185 data/ui/exciter.glade:170
 msgid "Listen"
 msgstr "Poslouchat"
 
-#: data/ui/bass_enhancer.glade:210 data/ui/exciter.glade:213
+#: data/ui/bass_enhancer.glade:211 data/ui/exciter.glade:212
 msgid "3rd"
 msgstr "3."
 
-#: data/ui/bass_enhancer.glade:222 data/ui/exciter.glade:225
+#: data/ui/bass_enhancer.glade:223 data/ui/exciter.glade:224
 msgid "2nd"
 msgstr "2."
 
-#: data/ui/bass_enhancer.glade:234 data/ui/exciter.glade:237
+#: data/ui/bass_enhancer.glade:235 data/ui/exciter.glade:236
 msgid "Blend Harmonics"
 msgstr "Míchat harmonické kmity"
 
-#: data/ui/bass_enhancer.glade:266 data/ui/exciter.glade:271
-#: data/ui/reverb.glade:407
+#: data/ui/bass_enhancer.glade:267 data/ui/exciter.glade:270
+#: data/ui/reverb.glade:408
 msgid "Amount"
 msgstr "Množství"
 
-#: data/ui/bass_enhancer.glade:278 data/ui/bass_enhancer.glade:411
-#: data/ui/exciter.glade:284 data/ui/exciter.glade:417
+#: data/ui/bass_enhancer.glade:279 data/ui/bass_enhancer.glade:413
+#: data/ui/exciter.glade:283 data/ui/exciter.glade:417
 msgid "Harmonics"
 msgstr "Harmonické kmity"
 
-#: data/ui/bass_enhancer.glade:290 data/ui/exciter.glade:297
+#: data/ui/bass_enhancer.glade:291 data/ui/exciter.glade:296
 msgid "Scope"
 msgstr "Rozsah"
 
-#: data/ui/bass_enhancer.glade:379
+#: data/ui/bass_enhancer.glade:381
 msgid "Floor"
 msgstr "Spodní mez"
 
-#: data/ui/bass_enhancer.glade:679 data/ui/compressor.glade:1323
-#: data/ui/crossfeed.glade:419 data/ui/deesser.glade:922
-#: data/ui/delay.glade:458 data/ui/equalizer.glade:767
-#: data/ui/exciter.glade:685 data/ui/filter.glade:619 data/ui/gate.glade:833
-#: data/ui/limiter.glade:757 data/ui/loudness.glade:542
-#: data/ui/maximizer.glade:540 data/ui/multiband_compressor.glade:2223
-#: data/ui/multiband_gate.glade:2376 data/ui/pitch.glade:584
-#: data/ui/reverb.glade:881 data/ui/stereo_tools.glade:1053
-#: data/ui/webrtc.glade:838
+#: data/ui/bass_enhancer.glade:674 data/ui/compressor.glade:1324
+#: data/ui/crossfeed.glade:418 data/ui/deesser.glade:923
+#: data/ui/delay.glade:457 data/ui/equalizer.glade:768
+#: data/ui/exciter.glade:678 data/ui/filter.glade:618 data/ui/gate.glade:886
+#: data/ui/limiter.glade:759 data/ui/loudness.glade:584
+#: data/ui/maximizer.glade:543 data/ui/multiband_compressor.glade:2227
+#: data/ui/multiband_gate.glade:2384 data/ui/pitch.glade:583
+#: data/ui/reverb.glade:882 data/ui/stereo_tools.glade:1052
+#: data/ui/webrtc.glade:839
 msgid "Provided by"
 msgstr "Poskytuje"
 
@@ -368,138 +367,138 @@ msgstr "Výstupní efekty"
 msgid "Show Blocklisted Apps in Main Tab"
 msgstr "Zobrazit Aplikace z Blocklistu na Hlavní Kartě"
 
-#: data/ui/calibration_signals.glade:32 data/ui/equalizer_band.glade:152
-#: data/ui/filter.glade:280
+#: data/ui/calibration_signals.glade:30 data/ui/equalizer_band.glade:152
+#: data/ui/filter.glade:281
 msgid "Frequency"
 msgstr "Kmitočet"
 
-#: data/ui/calibration_signals.glade:64
+#: data/ui/calibration_signals.glade:62
 msgid "Volume"
 msgstr "Hlasitost"
 
-#: data/ui/calibration_signals.glade:108
+#: data/ui/calibration_signals.glade:106
 msgid "Sine"
 msgstr "Sinus"
 
-#: data/ui/calibration_signals.glade:109
+#: data/ui/calibration_signals.glade:107
 msgid "Square"
 msgstr "Čtverec"
 
-#: data/ui/calibration_signals.glade:110
+#: data/ui/calibration_signals.glade:108
 msgid "Saw"
 msgstr "Pila"
 
-#: data/ui/calibration_signals.glade:111
+#: data/ui/calibration_signals.glade:109
 msgid "Triangle"
 msgstr "Trojúhelník"
 
-#: data/ui/calibration_signals.glade:112
+#: data/ui/calibration_signals.glade:110
 msgid "Silence"
 msgstr "Ticho"
 
-#: data/ui/calibration_signals.glade:113
+#: data/ui/calibration_signals.glade:111
 msgid "White Noise"
 msgstr "Bílý šum"
 
-#: data/ui/calibration_signals.glade:114
+#: data/ui/calibration_signals.glade:112
 msgid "Pink Noise"
 msgstr "Růžový šum"
 
-#: data/ui/calibration_signals.glade:115
+#: data/ui/calibration_signals.glade:113
 msgid "Sine Table"
 msgstr "Sinusová tabulka"
 
-#: data/ui/calibration_signals.glade:116
+#: data/ui/calibration_signals.glade:114
 msgid "Ticks"
 msgstr "Tiknutí"
 
-#: data/ui/calibration_signals.glade:117
+#: data/ui/calibration_signals.glade:115
 msgid "Gaussian Noise"
 msgstr "Gaussovský šum"
 
-#: data/ui/calibration_signals.glade:118
+#: data/ui/calibration_signals.glade:116
 msgid "Red Noise"
 msgstr "Červený šum"
 
-#: data/ui/calibration_signals.glade:119
+#: data/ui/calibration_signals.glade:117
 msgid "Blue Noise"
 msgstr "Modrý šum"
 
-#: data/ui/calibration_signals.glade:120
+#: data/ui/calibration_signals.glade:118
 msgid "Violet Noise"
 msgstr "Fialový šum"
 
-#: data/ui/calibration_mic.glade:29
+#: data/ui/calibration_mic.glade:28
 msgid "Window"
 msgstr "Okno"
 
-#: data/ui/calibration_mic.glade:70
+#: data/ui/calibration_mic.glade:69
 msgid "Measure Noise"
 msgstr "Změřit šum"
 
-#: data/ui/calibration_mic.glade:99
+#: data/ui/calibration_mic.glade:98
 msgid "Subtract Noise"
 msgstr "Odečíst šum"
 
-#: data/ui/compressor.glade:292 data/ui/deesser.glade:483
-#: data/ui/gate.glade:370 data/ui/maximizer.glade:152
-#: data/ui/multiband_compressor.glade:609
+#: data/ui/compressor.glade:290 data/ui/deesser.glade:482
+#: data/ui/gate.glade:413 data/ui/maximizer.glade:153
+#: data/ui/multiband_compressor.glade:607
 #: data/ui/multiband_compressor.glade:983
-#: data/ui/multiband_compressor.glade:1361
-#: data/ui/multiband_compressor.glade:1739 data/ui/multiband_gate.glade:633
-#: data/ui/multiband_gate.glade:1040 data/ui/multiband_gate.glade:1450
-#: data/ui/multiband_gate.glade:1860
+#: data/ui/multiband_compressor.glade:1363
+#: data/ui/multiband_compressor.glade:1743 data/ui/multiband_gate.glade:631
+#: data/ui/multiband_gate.glade:1041 data/ui/multiband_gate.glade:1454
+#: data/ui/multiband_gate.glade:1867
 msgid "Threshold"
 msgstr "Práh"
 
-#: data/ui/compressor.glade:325 data/ui/deesser.glade:516
-#: data/ui/gate.glade:403 data/ui/multiband_compressor.glade:642
-#: data/ui/multiband_compressor.glade:1017
-#: data/ui/multiband_compressor.glade:1395
-#: data/ui/multiband_compressor.glade:1773 data/ui/multiband_gate.glade:666
-#: data/ui/multiband_gate.glade:1074 data/ui/multiband_gate.glade:1484
-#: data/ui/multiband_gate.glade:1894
+#: data/ui/compressor.glade:324 data/ui/deesser.glade:516
+#: data/ui/gate.glade:449 data/ui/multiband_compressor.glade:641
+#: data/ui/multiband_compressor.glade:1018
+#: data/ui/multiband_compressor.glade:1398
+#: data/ui/multiband_compressor.glade:1778 data/ui/multiband_gate.glade:665
+#: data/ui/multiband_gate.glade:1076 data/ui/multiband_gate.glade:1489
+#: data/ui/multiband_gate.glade:1902
 msgid "Ratio"
 msgstr "Poměr"
 
-#: data/ui/compressor.glade:357 data/ui/gate.glade:435
-#: data/ui/multiband_compressor.glade:674
-#: data/ui/multiband_compressor.glade:1050
-#: data/ui/multiband_compressor.glade:1428
-#: data/ui/multiband_compressor.glade:1806 data/ui/multiband_gate.glade:698
-#: data/ui/multiband_gate.glade:1107 data/ui/multiband_gate.glade:1517
-#: data/ui/multiband_gate.glade:1927
+#: data/ui/compressor.glade:356 data/ui/gate.glade:483
+#: data/ui/multiband_compressor.glade:673
+#: data/ui/multiband_compressor.glade:1051
+#: data/ui/multiband_compressor.glade:1431
+#: data/ui/multiband_compressor.glade:1811 data/ui/multiband_gate.glade:697
+#: data/ui/multiband_gate.glade:1109 data/ui/multiband_gate.glade:1522
+#: data/ui/multiband_gate.glade:1935
 msgid "Knee"
 msgstr "Přechod"
 
-#: data/ui/compressor.glade:391 data/ui/deesser.glade:547
-#: data/ui/gate.glade:469 data/ui/multiband_compressor.glade:708
-#: data/ui/multiband_compressor.glade:1085
-#: data/ui/multiband_compressor.glade:1463
-#: data/ui/multiband_compressor.glade:1841 data/ui/multiband_gate.glade:732
-#: data/ui/multiband_gate.glade:1142 data/ui/multiband_gate.glade:1552
-#: data/ui/multiband_gate.glade:1962
+#: data/ui/compressor.glade:390 data/ui/deesser.glade:547
+#: data/ui/gate.glade:519 data/ui/multiband_compressor.glade:707
+#: data/ui/multiband_compressor.glade:1086
+#: data/ui/multiband_compressor.glade:1466
+#: data/ui/multiband_compressor.glade:1846 data/ui/multiband_gate.glade:731
+#: data/ui/multiband_gate.glade:1144 data/ui/multiband_gate.glade:1557
+#: data/ui/multiband_gate.glade:1970
 msgid "Makeup"
 msgstr "Pozvednutí"
 
-#: data/ui/compressor.glade:425 data/ui/gate.glade:336
-#: data/ui/limiter.glade:310 data/ui/maximizer.glade:178
-#: data/ui/multiband_compressor.glade:575
+#: data/ui/compressor.glade:425 data/ui/gate.glade:377
+#: data/ui/limiter.glade:311 data/ui/maximizer.glade:179
+#: data/ui/multiband_compressor.glade:573
 #: data/ui/multiband_compressor.glade:948
-#: data/ui/multiband_compressor.glade:1326
-#: data/ui/multiband_compressor.glade:1704 data/ui/multiband_gate.glade:599
-#: data/ui/multiband_gate.glade:1005 data/ui/multiband_gate.glade:1415
-#: data/ui/multiband_gate.glade:1825
+#: data/ui/multiband_compressor.glade:1328
+#: data/ui/multiband_compressor.glade:1708 data/ui/multiband_gate.glade:597
+#: data/ui/multiband_gate.glade:1006 data/ui/multiband_gate.glade:1419
+#: data/ui/multiband_gate.glade:1832
 msgid "Release"
 msgstr "Uvolnění"
 
-#: data/ui/compressor.glade:438 data/ui/gate.glade:302
-#: data/ui/multiband_compressor.glade:541
+#: data/ui/compressor.glade:438 data/ui/gate.glade:341
+#: data/ui/multiband_compressor.glade:539
 #: data/ui/multiband_compressor.glade:913
-#: data/ui/multiband_compressor.glade:1291
-#: data/ui/multiband_compressor.glade:1669 data/ui/multiband_gate.glade:565
-#: data/ui/multiband_gate.glade:970 data/ui/multiband_gate.glade:1380
-#: data/ui/multiband_gate.glade:1790
+#: data/ui/multiband_compressor.glade:1293
+#: data/ui/multiband_compressor.glade:1673 data/ui/multiband_gate.glade:563
+#: data/ui/multiband_gate.glade:971 data/ui/multiband_gate.glade:1384
+#: data/ui/multiband_gate.glade:1797
 msgid "Attack"
 msgstr "Náběh"
 
@@ -515,210 +514,209 @@ msgstr "Nahoru"
 msgid "Compression Mode"
 msgstr "Kompresní režim"
 
-#: data/ui/compressor.glade:551
+#: data/ui/compressor.glade:552
 msgid "Pre-amplification"
 msgstr "Předzesílení"
 
-#: data/ui/compressor.glade:585
+#: data/ui/compressor.glade:586
 msgid "Reactivity"
 msgstr "Reaktivita"
 
-#: data/ui/compressor.glade:619 data/ui/limiter.glade:323
+#: data/ui/compressor.glade:620 data/ui/limiter.glade:324
 msgid "Lookahead"
 msgstr "Výhled"
 
-#: data/ui/compressor.glade:632
+#: data/ui/compressor.glade:633
 msgid "Feed-forward"
 msgstr "Kanál-vpřed"
 
-#: data/ui/compressor.glade:633
+#: data/ui/compressor.glade:634
 msgid "Feed-back"
 msgstr "Kanál-zpět"
 
-#: data/ui/compressor.glade:647 data/ui/equalizer_band.glade:48
+#: data/ui/compressor.glade:648 data/ui/equalizer_band.glade:48
 msgid "Type"
 msgstr "Typ"
 
-#: data/ui/compressor.glade:661 data/ui/deesser.glade:244
-#: data/ui/deesser.glade:354 data/ui/gate.glade:257
-#: data/ui/multiband_compressor.glade:514
+#: data/ui/compressor.glade:662 data/ui/deesser.glade:241
+#: data/ui/gate.glade:213 data/ui/multiband_compressor.glade:512
 #: data/ui/multiband_compressor.glade:886
-#: data/ui/multiband_compressor.glade:1264
-#: data/ui/multiband_compressor.glade:1642 data/ui/multiband_gate.glade:538
-#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1353
-#: data/ui/multiband_gate.glade:1763
+#: data/ui/multiband_compressor.glade:1266
+#: data/ui/multiband_compressor.glade:1646 data/ui/multiband_gate.glade:536
+#: data/ui/multiband_gate.glade:944 data/ui/multiband_gate.glade:1357
+#: data/ui/multiband_gate.glade:1770
 msgid "Peak"
 msgstr "Vrchol"
 
-#: data/ui/compressor.glade:662 data/ui/deesser.glade:243
-#: data/ui/gate.glade:256 data/ui/multiband_compressor.glade:513
+#: data/ui/compressor.glade:663 data/ui/deesser.glade:240
+#: data/ui/gate.glade:212 data/ui/multiband_compressor.glade:511
 #: data/ui/multiband_compressor.glade:885
-#: data/ui/multiband_compressor.glade:1263
-#: data/ui/multiband_compressor.glade:1641 data/ui/multiband_gate.glade:537
-#: data/ui/multiband_gate.glade:942 data/ui/multiband_gate.glade:1352
-#: data/ui/multiband_gate.glade:1762
+#: data/ui/multiband_compressor.glade:1265
+#: data/ui/multiband_compressor.glade:1645 data/ui/multiband_gate.glade:535
+#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1356
+#: data/ui/multiband_gate.glade:1769
 msgid "RMS"
 msgstr "RMS"
 
-#: data/ui/compressor.glade:663
+#: data/ui/compressor.glade:664
 msgid "Low-Pass"
 msgstr "Dolní pásmo"
 
-#: data/ui/compressor.glade:664
+#: data/ui/compressor.glade:665
 msgid "Uniform"
 msgstr "Rovnoměrný"
 
-#: data/ui/compressor.glade:678 data/ui/deesser.glade:230
-#: data/ui/equalizer.glade:224 data/ui/equalizer_band.glade:79
-#: data/ui/multiband_compressor.glade:324 data/ui/multiband_gate.glade:348
-#: data/ui/stereo_tools.glade:485 data/ui/webrtc.glade:376
+#: data/ui/compressor.glade:679 data/ui/deesser.glade:227
+#: data/ui/equalizer.glade:225 data/ui/equalizer_band.glade:79
+#: data/ui/multiband_compressor.glade:322 data/ui/multiband_gate.glade:346
+#: data/ui/stereo_tools.glade:486 data/ui/webrtc.glade:377
 msgid "Mode"
 msgstr "Režim"
 
-#: data/ui/compressor.glade:692
+#: data/ui/compressor.glade:693
 msgid "Middle"
 msgstr "Střední"
 
-#: data/ui/compressor.glade:693
+#: data/ui/compressor.glade:694
 msgid "Side"
 msgstr "Postranní"
 
-#: data/ui/compressor.glade:694 data/ui/delay.glade:157
-#: data/ui/equalizer.glade:474 data/ui/stereo_tools.glade:548
+#: data/ui/compressor.glade:695 data/ui/delay.glade:158
+#: data/ui/equalizer.glade:475 data/ui/stereo_tools.glade:549
 msgid "Left"
 msgstr "Levý"
 
-#: data/ui/compressor.glade:695 data/ui/delay.glade:189
-#: data/ui/equalizer.glade:515 data/ui/stereo_tools.glade:620
+#: data/ui/compressor.glade:696 data/ui/delay.glade:190
+#: data/ui/equalizer.glade:516 data/ui/stereo_tools.glade:621
 msgid "Right"
 msgstr "Pravý"
 
-#: data/ui/compressor.glade:709
+#: data/ui/compressor.glade:710
 msgid "Source"
 msgstr "Zdroj"
 
-#: data/ui/compressor.glade:725 data/ui/compressor.glade:1167
+#: data/ui/compressor.glade:726 data/ui/compressor.glade:1170
 msgid "Sidechain"
 msgstr "Postranní řetězec"
 
-#: data/ui/compressor.glade:821
+#: data/ui/compressor.glade:824
 msgid "Relative Release Threshold"
 msgstr "Relativní Práh Uvolnění"
 
-#: data/ui/compressor.glade:832
+#: data/ui/compressor.glade:835
 #, fuzzy
 msgid "Boost Threshold"
 msgstr "Práh"
 
-#: data/ui/compressor.glade:843
+#: data/ui/compressor.glade:846
 #, fuzzy
 msgid "High-pass Frequency"
 msgstr "Tlumení vysokého kmitočtu"
 
-#: data/ui/compressor.glade:854
+#: data/ui/compressor.glade:857
 #, fuzzy
 msgid "Low-pass Frequency"
 msgstr "Spočítat kmitočty"
 
-#: data/ui/compressor.glade:865
+#: data/ui/compressor.glade:868
 #, fuzzy
 msgid "High-pass Filter Mode"
 msgstr "Vysokopásmový filtr"
 
-#: data/ui/compressor.glade:876
+#: data/ui/compressor.glade:879
 msgid "Low-pass Filter Mode"
 msgstr "Nízkopropustný Mód Filtru"
 
-#: data/ui/compressor.glade:889 data/ui/compressor.glade:906
+#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
 #: data/ui/equalizer_band.glade:60
 msgid "Off"
 msgstr "Vypnuto"
 
-#: data/ui/compressor.glade:890 data/ui/compressor.glade:907
+#: data/ui/compressor.glade:893 data/ui/compressor.glade:910
 #, fuzzy
 msgid "12 dB/oct"
 msgstr "Nízká pásmová propust 12 dB/okt"
 
-#: data/ui/compressor.glade:891 data/ui/compressor.glade:908
+#: data/ui/compressor.glade:894 data/ui/compressor.glade:911
 #, fuzzy
 msgid "24 dB/oct"
 msgstr "Nízká pásmová propust 24 dB/okt"
 
-#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
+#: data/ui/compressor.glade:895 data/ui/compressor.glade:912
 #, fuzzy
 msgid "36 dB/oct"
 msgstr "Nízká pásmová propust 36 dB/okt"
 
-#: data/ui/compressor.glade:932
+#: data/ui/compressor.glade:935
 #, fuzzy
 msgid "Advanced"
 msgstr "Nastavení"
 
-#: data/ui/compressor.glade:1243
+#: data/ui/compressor.glade:1244
 msgid "Curve"
 msgstr "Křivka"
 
-#: data/ui/convolver.glade:91
+#: data/ui/convolver.glade:92
 msgid "Convolver"
 msgstr "Svinovač"
 
-#: data/ui/convolver.glade:125
+#: data/ui/convolver.glade:126
 msgid "Import Impulse"
 msgstr "Zavést impuls"
 
-#: data/ui/convolver.glade:129
+#: data/ui/convolver.glade:130
 msgid "Import Impulse Response File"
 msgstr "Zavést soubor s odpovědí impulsu"
 
-#: data/ui/convolver.glade:247
+#: data/ui/convolver.glade:248
 msgid "L"
 msgstr "L"
 
-#: data/ui/convolver.glade:261
+#: data/ui/convolver.glade:262
 msgid "R"
 msgstr "P"
 
-#: data/ui/convolver.glade:324
+#: data/ui/convolver.glade:325
 msgid "Duration"
 msgstr "Doba trvání"
 
-#: data/ui/convolver.glade:335
+#: data/ui/convolver.glade:336
 msgid "Samples"
 msgstr "Vzorky"
 
-#: data/ui/convolver.glade:367 src/convolver_ui.cpp:283
+#: data/ui/convolver.glade:368 src/convolver_ui.cpp:283
 msgid "Impulse Response"
 msgstr "Odpověď impulsu"
 
-#: data/ui/convolver.glade:389
+#: data/ui/convolver.glade:390
 msgid "Select the impulse Response File"
 msgstr "Vybrat soubor s odpovědí impulsu"
 
-#: data/ui/convolver.glade:409 src/spectrum_settings_ui.cpp:176
+#: data/ui/convolver.glade:410 src/spectrum_settings_ui.cpp:176
 msgid "Spectrum"
 msgstr "Spektrum"
 
-#: data/ui/convolver.glade:450
+#: data/ui/convolver.glade:451
 msgid "Stereo Width"
 msgstr "Šířka sterea"
 
-#: data/ui/crossfeed.glade:63
+#: data/ui/crossfeed.glade:62
 msgid "Jmeier"
 msgstr "Jmeier"
 
-#: data/ui/crossfeed.glade:76 data/ui/filter.glade:183 data/ui/reverb.glade:259
+#: data/ui/crossfeed.glade:75 data/ui/filter.glade:184 data/ui/reverb.glade:260
 msgid "Default"
 msgstr "Výchozí"
 
-#: data/ui/crossfeed.glade:89
+#: data/ui/crossfeed.glade:88
 msgid "Cmoy"
 msgstr "Sluchátkový zesilovač (CMoy)"
 
-#: data/ui/crossfeed.glade:120
+#: data/ui/crossfeed.glade:119
 msgid "Cutoff"
 msgstr "Useknutí"
 
-#: data/ui/crossfeed.glade:153
+#: data/ui/crossfeed.glade:152
 msgid "Feed"
 msgstr "Kanál"
 
@@ -726,115 +724,132 @@ msgstr "Kanál"
 msgid "Crossfeed"
 msgstr "Prolínání kanálů"
 
-#: data/ui/crystalizer.glade:115
+#: data/ui/crystalizer.glade:92
 msgid "Crystalizer"
 msgstr "Krystalizátor"
 
-#: data/ui/crystalizer.glade:187
+#: data/ui/crystalizer.glade:137
 msgid "Aggressive Mode"
 msgstr "Agresivní režim"
 
-#: data/ui/crystalizer.glade:447
+#: data/ui/crystalizer.glade:395
 msgid "Loudness Range"
 msgstr "Rozsah hlasitosti"
 
-#: data/ui/crystalizer.glade:466
+#: data/ui/crystalizer.glade:414
 msgid "Before"
 msgstr "Před"
 
-#: data/ui/crystalizer.glade:479
+#: data/ui/crystalizer.glade:427
 msgid "After"
 msgstr "Po"
 
 #: data/ui/crystalizer_band.glade:27 data/ui/equalizer_band.glade:313
-#: data/ui/stereo_tools.glade:574 data/ui/stereo_tools.glade:633
+#: data/ui/stereo_tools.glade:575 data/ui/stereo_tools.glade:634
 msgid "Mute"
 msgstr "Ztlumit"
 
-#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:483
+#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:481
 #: data/ui/multiband_compressor.glade:855
-#: data/ui/multiband_compressor.glade:1233
-#: data/ui/multiband_compressor.glade:1611 data/ui/multiband_gate.glade:507
-#: data/ui/multiband_gate.glade:912 data/ui/multiband_gate.glade:1322
-#: data/ui/multiband_gate.glade:1732
+#: data/ui/multiband_compressor.glade:1235
+#: data/ui/multiband_compressor.glade:1615 data/ui/multiband_gate.glade:505
+#: data/ui/multiband_gate.glade:913 data/ui/multiband_gate.glade:1326
+#: data/ui/multiband_gate.glade:1739
 msgid "Bypass"
 msgstr "Překlenutí"
 
-#: data/ui/deesser.glade:128
+#: data/ui/deesser.glade:127
 msgid "Deesser"
 msgstr "Odstraňovač sykotu"
 
-#: data/ui/deesser.glade:216 data/ui/gate.glade:195
+#: data/ui/deesser.glade:213 data/ui/gate.glade:198
 msgid "Detection"
 msgstr "Zjištění"
 
-#: data/ui/deesser.glade:258
+#: data/ui/deesser.glade:255
 msgid "Wide"
 msgstr "Rozšířit"
 
-#: data/ui/deesser.glade:259 data/ui/deesser.glade:288
+#: data/ui/deesser.glade:256
 msgid "Split"
 msgstr "Rozdělit"
 
-#: data/ui/deesser.glade:407
-msgid "Level"
+#: data/ui/deesser.glade:285
+#, fuzzy
+msgid "F1 Split"
+msgstr "Rozdělit"
+
+#: data/ui/deesser.glade:318
+#, fuzzy
+msgid "F1 Gain"
+msgstr "Zesílení"
+
+#: data/ui/deesser.glade:352
+#, fuzzy
+msgid "F2 Peak"
+msgstr "Vrchol"
+
+#: data/ui/deesser.glade:406
+#, fuzzy
+msgid "F2 Level"
 msgstr "Úroveň"
 
-#: data/ui/deesser.glade:420
-msgid "Peak Q"
+#: data/ui/deesser.glade:419
+#, fuzzy
+msgid "F2 Peak Q"
 msgstr "Vrchol Q"
 
-#: data/ui/deesser.glade:452
+#: data/ui/deesser.glade:451
 msgid "Laxity"
 msgstr "Nedbalost"
 
-#: data/ui/deesser.glade:778 data/ui/multiband_gate.glade:767
-#: data/ui/multiband_gate.glade:1197 data/ui/multiband_gate.glade:1607
-#: data/ui/multiband_gate.glade:2017
+#: data/ui/deesser.glade:779 data/ui/multiband_gate.glade:767
+#: data/ui/multiband_gate.glade:1201 data/ui/multiband_gate.glade:1614
+#: data/ui/multiband_gate.glade:2027
 msgid "Reduction"
 msgstr "Snížení"
 
-#: data/ui/deesser.glade:791
+#: data/ui/deesser.glade:792
 msgid "Detected"
 msgstr "Zjištěno"
 
-#: data/ui/delay.glade:91
+#: data/ui/delay.glade:92
 msgid "Delay"
 msgstr "Zpoždění"
 
-#: data/ui/equalizer.glade:44
+#: data/ui/equalizer.glade:45
 msgid "Equalizer"
 msgstr "Ekvalizér"
 
-#: data/ui/equalizer.glade:153
+#: data/ui/equalizer.glade:154
 msgid "Split Channels"
 msgstr "Rozdělit kanály"
 
-#: data/ui/equalizer.glade:179
+#: data/ui/equalizer.glade:180
 msgid "IIR"
 msgstr "IIR"
 
-#: data/ui/equalizer.glade:180
+#: data/ui/equalizer.glade:181
 msgid "FIR"
 msgstr "FIR"
 
-#: data/ui/equalizer.glade:181
+#: data/ui/equalizer.glade:182
 msgid "FFT"
 msgstr "FFT"
 
-#: data/ui/equalizer.glade:211
+#: data/ui/equalizer.glade:212
 msgid "Bands"
 msgstr "Pásma"
 
-#: data/ui/equalizer.glade:233
+#: data/ui/equalizer.glade:234
 msgid "Flat Response"
 msgstr "Uhladit"
 
-#: data/ui/equalizer.glade:248
+#: data/ui/equalizer.glade:249
 msgid "Calculate Frequencies"
 msgstr "Vypočítat Kmitočty"
 
-#: data/ui/equalizer.glade:262
+#: data/ui/equalizer.glade:263
 msgid "Import APO Presets"
 msgstr "Zavést APO Přednastavení"
 
@@ -862,7 +877,7 @@ msgstr "Dolní práh"
 msgid "Notch"
 msgstr "Vroubek"
 
-#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:314
+#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:315
 msgid "Resonance"
 msgstr "Rezonance"
 
@@ -906,12 +921,12 @@ msgstr "Jakost"
 msgid "Width"
 msgstr "Šířka"
 
-#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:496
+#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:494
 #: data/ui/multiband_compressor.glade:868
-#: data/ui/multiband_compressor.glade:1246
-#: data/ui/multiband_compressor.glade:1624 data/ui/multiband_gate.glade:520
-#: data/ui/multiband_gate.glade:925 data/ui/multiband_gate.glade:1335
-#: data/ui/multiband_gate.glade:1745
+#: data/ui/multiband_compressor.glade:1248
+#: data/ui/multiband_compressor.glade:1628 data/ui/multiband_gate.glade:518
+#: data/ui/multiband_gate.glade:926 data/ui/multiband_gate.glade:1339
+#: data/ui/multiband_gate.glade:1752
 msgid "Solo"
 msgstr "Sólo"
 
@@ -919,79 +934,79 @@ msgstr "Sólo"
 msgid "Apply"
 msgstr "Použít"
 
-#: data/ui/exciter.glade:117
+#: data/ui/exciter.glade:118
 msgid "Exciter"
 msgstr "Zvukový budič"
 
-#: data/ui/exciter.glade:384 data/ui/maximizer.glade:165
+#: data/ui/exciter.glade:384 data/ui/maximizer.glade:166
 msgid "Ceiling"
 msgstr "Strop"
 
-#: data/ui/filter.glade:98
+#: data/ui/filter.glade:99
 msgid "Filter"
 msgstr "Filtr"
 
-#: data/ui/filter.glade:147
+#: data/ui/filter.glade:148
 msgid "Muted"
 msgstr "Ztlumeno"
 
-#: data/ui/filter.glade:159 data/ui/reverb.glade:233
+#: data/ui/filter.glade:160 data/ui/reverb.glade:234
 msgid "Disco"
 msgstr "Disko"
 
-#: data/ui/filter.glade:171
+#: data/ui/filter.glade:172
 msgid "Distant Headphones"
 msgstr "Vzdálená sluchátka"
 
-#: data/ui/filter.glade:246
+#: data/ui/filter.glade:247
 msgid "12dB/oct Lowpass"
 msgstr "Nízká pásmová propust 12 dB/okt"
 
-#: data/ui/filter.glade:247
+#: data/ui/filter.glade:248
 msgid "24dB/oct Lowpass"
 msgstr "Nízká pásmová propust 24 dB/okt"
 
-#: data/ui/filter.glade:248
+#: data/ui/filter.glade:249
 msgid "36dB/oct Lowpass"
 msgstr "Nízká pásmová propust 36 dB/okt"
 
-#: data/ui/filter.glade:249
+#: data/ui/filter.glade:250
 msgid "12dB/oct Highpass"
 msgstr "Vysoká pásmová propust 12 dB/okt"
 
-#: data/ui/filter.glade:250
+#: data/ui/filter.glade:251
 msgid "24dB/oct Highpass"
 msgstr "Vysoká pásmová propust 24 dB/okt"
 
-#: data/ui/filter.glade:251
+#: data/ui/filter.glade:252
 msgid "36dB/oct Highpass"
 msgstr "Vysoká pásmová propust 36 dB/okt"
 
-#: data/ui/filter.glade:252
+#: data/ui/filter.glade:253
 msgid "6dB/oct Bandpass"
 msgstr "Pásmová propustnost 6 dB/okt"
 
-#: data/ui/filter.glade:253
+#: data/ui/filter.glade:254
 msgid "12dB/oct Bandpass"
 msgstr "Pásmová propustnost 12 dB/okt"
 
-#: data/ui/filter.glade:254
+#: data/ui/filter.glade:255
 msgid "18dB/oct Bandpass"
 msgstr "Pásmová propustnost 18 dB/okt"
 
-#: data/ui/filter.glade:255
+#: data/ui/filter.glade:256
 msgid "6dB/oct Bandreject"
 msgstr "Vyloučení pásma 6 dB/okt"
 
-#: data/ui/filter.glade:256
+#: data/ui/filter.glade:257
 msgid "12dB/oct Bandreject"
 msgstr "Vyloučení pásma 12 dB/okt"
 
-#: data/ui/filter.glade:257
+#: data/ui/filter.glade:258
 msgid "18dB/oct Bandreject"
 msgstr "Vyloučení pásma 18 dB/okt"
 
-#: data/ui/filter.glade:349
+#: data/ui/filter.glade:350
 msgid "Inertia"
 msgstr "Setrvačnost"
 
@@ -1035,50 +1050,51 @@ msgstr "Zpracovat všechny vstupy"
 msgid "Priority"
 msgstr "Přednost"
 
-#: data/ui/gate.glade:98
+#: data/ui/gate.glade:99
 msgid "Gate"
 msgstr "Brána"
 
-#: data/ui/gate.glade:209
+#: data/ui/gate.glade:240
+#, fuzzy
+msgid "Maximum Gain Reduction"
+msgstr "Zmenšení zesílení"
+
+#: data/ui/gate.glade:289
 msgid "Stereo Link"
 msgstr "Spojení sterea"
 
-#: data/ui/gate.glade:222 data/ui/maximizer.glade:293
-msgid "Gain Reduction"
-msgstr "Zmenšení zesílení"
-
-#: data/ui/gate.glade:273
+#: data/ui/gate.glade:304
 msgid "Average"
 msgstr "Průměr"
 
-#: data/ui/gate.glade:274
+#: data/ui/gate.glade:305
 msgid "Maximum"
 msgstr "Nejvýše"
 
-#: data/ui/gate.glade:525
+#: data/ui/gate.glade:578
 #, fuzzy
 msgid "Input Level"
 msgstr "Omezovač vstupu"
 
-#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:811
-#: data/ui/multiband_gate.glade:1220 data/ui/multiband_gate.glade:1630
-#: data/ui/multiband_gate.glade:2040
+#: data/ui/gate.glade:797 data/ui/multiband_gate.glade:812
+#: data/ui/multiband_gate.glade:1224 data/ui/multiband_gate.glade:1637
+#: data/ui/multiband_gate.glade:2050
 msgid "Gating"
 msgstr "Hradlo"
 
-#: data/ui/limiter.glade:97 data/ui/webrtc.glade:421
+#: data/ui/limiter.glade:98 data/ui/webrtc.glade:422
 msgid "Limiter"
 msgstr "Omezovač"
 
-#: data/ui/limiter.glade:176
+#: data/ui/limiter.glade:175
 msgid "Automatic Smoothing Control"
 msgstr "Automatické Vyhlazení"
 
-#: data/ui/limiter.glade:190
+#: data/ui/limiter.glade:189
 msgid "Automatic Leveling"
 msgstr "Automatické Úrovně"
 
-#: data/ui/limiter.glade:222
+#: data/ui/limiter.glade:221
 msgid "Input Gain"
 msgstr "Vstupní zesílení"
 
@@ -1086,136 +1102,140 @@ msgstr "Vstupní zesílení"
 msgid "Limit"
 msgstr "Omezení"
 
-#: data/ui/limiter.glade:358
+#: data/ui/limiter.glade:359
 msgid "Oversampling"
 msgstr "Převzorkování"
 
-#: data/ui/limiter.glade:411
+#: data/ui/limiter.glade:413
 #, fuzzy
 msgid "Output Gain"
 msgstr "Vstupní zesílení"
 
-#: data/ui/limiter.glade:429
+#: data/ui/limiter.glade:431
 msgid "ASC"
 msgstr "ASC"
 
-#: data/ui/limiter.glade:584
+#: data/ui/limiter.glade:586
 msgid "Attenuation"
 msgstr "Tlumení"
 
-#: data/ui/loudness.glade:91
+#: data/ui/loudness.glade:92
 msgid "Loudness Compensator"
 msgstr "Kompenzace Hlasitosti"
 
-#: data/ui/loudness.glade:147
-msgid "Standard"
-msgstr "Standardní"
-
-#: data/ui/loudness.glade:161
-msgid "Flat"
-msgstr "Rovný"
-
-#: data/ui/loudness.glade:162
-msgid "ISO226-2003"
-msgstr "ISO226-2003"
-
-#: data/ui/loudness.glade:163
-msgid "Fletcher-Munson"
-msgstr "Fletcher-Munson"
-
-#: data/ui/loudness.glade:164
-msgid "Robinson-Dadson"
-msgstr "Robinson-Dadson"
-
-#: data/ui/loudness.glade:174
-msgid "Reference Signal"
-msgstr "Referenční Signál"
-
-#: data/ui/loudness.glade:199
+#: data/ui/loudness.glade:155
 #, fuzzy
 msgid "FFT Size"
 msgstr "Rozměry rámečku"
 
-#: data/ui/maximizer.glade:96
+#: data/ui/loudness.glade:205
+msgid "Standard"
+msgstr "Standardní"
+
+#: data/ui/loudness.glade:220
+msgid "Flat"
+msgstr "Rovný"
+
+#: data/ui/loudness.glade:221
+msgid "ISO226-2003"
+msgstr "ISO226-2003"
+
+#: data/ui/loudness.glade:222
+msgid "Fletcher-Munson"
+msgstr "Fletcher-Munson"
+
+#: data/ui/loudness.glade:223
+msgid "Robinson-Dadson"
+msgstr "Robinson-Dadson"
+
+#: data/ui/loudness.glade:259
+msgid "Reference Signal"
+msgstr "Referenční Signál"
+
+#: data/ui/maximizer.glade:97
 msgid "Maximizer"
 msgstr "Zvětšovač"
 
-#: data/ui/multiband_compressor.glade:140
+#: data/ui/maximizer.glade:296
+msgid "Gain Reduction"
+msgstr "Zmenšení zesílení"
+
+#: data/ui/multiband_compressor.glade:141
 msgid "Multiband Compressor"
 msgstr "Vícepásmový kompresor"
 
-#: data/ui/multiband_compressor.glade:338 data/ui/multiband_gate.glade:362
+#: data/ui/multiband_compressor.glade:336 data/ui/multiband_gate.glade:360
 msgid "LR4"
 msgstr "LR4"
 
-#: data/ui/multiband_compressor.glade:339 data/ui/multiband_gate.glade:363
+#: data/ui/multiband_compressor.glade:337 data/ui/multiband_gate.glade:361
 msgid "LR8"
 msgstr "LR8"
 
-#: data/ui/multiband_compressor.glade:353 data/ui/multiband_gate.glade:377
+#: data/ui/multiband_compressor.glade:351 data/ui/multiband_gate.glade:375
 msgid "Split 1/2"
 msgstr "Rozdělit 1/2"
 
-#: data/ui/multiband_compressor.glade:366 data/ui/multiband_gate.glade:390
+#: data/ui/multiband_compressor.glade:364 data/ui/multiband_gate.glade:388
 msgid "Split 2/3"
 msgstr "Rozdělit 2/3"
 
-#: data/ui/multiband_compressor.glade:379 data/ui/multiband_gate.glade:403
+#: data/ui/multiband_compressor.glade:377 data/ui/multiband_gate.glade:401
 msgid "Split 3/4"
 msgstr "Rozdělit 3/4"
 
 #: data/ui/multiband_compressor.glade:754
-#: data/ui/multiband_compressor.glade:1131
-#: data/ui/multiband_compressor.glade:1509
-#: data/ui/multiband_compressor.glade:1887
+#: data/ui/multiband_compressor.glade:1133
+#: data/ui/multiband_compressor.glade:1513
+#: data/ui/multiband_compressor.glade:1893
 msgid "Compression"
 msgstr "Komprese"
 
-#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:894
+#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:895
 msgid "Sub Band"
 msgstr "Spodní pásmo"
 
-#: data/ui/multiband_compressor.glade:1214 data/ui/multiband_gate.glade:1303
+#: data/ui/multiband_compressor.glade:1216 data/ui/multiband_gate.glade:1307
 msgid "Low Band"
 msgstr "Nízké pásmo"
 
-#: data/ui/multiband_compressor.glade:1592 data/ui/multiband_gate.glade:1713
+#: data/ui/multiband_compressor.glade:1596 data/ui/multiband_gate.glade:1720
 msgid "Mid Band"
 msgstr "Střední pásmo"
 
-#: data/ui/multiband_compressor.glade:1970 data/ui/multiband_gate.glade:2123
+#: data/ui/multiband_compressor.glade:1976 data/ui/multiband_gate.glade:2133
 msgid "High Band"
 msgstr "Vysoké pásmo"
 
-#: data/ui/multiband_gate.glade:140
+#: data/ui/multiband_gate.glade:141
 msgid "Multiband Gate"
 msgstr "Vícepásmová brána"
 
-#: data/ui/pitch.glade:103
+#: data/ui/pitch.glade:104
 msgid "Pitch"
 msgstr "Výška tónu"
 
-#: data/ui/pitch.glade:178
+#: data/ui/pitch.glade:179
 msgid "Cents"
 msgstr "Centy"
 
-#: data/ui/pitch.glade:209
+#: data/ui/pitch.glade:210
 msgid "Semitones"
 msgstr "Půltóny"
 
-#: data/ui/pitch.glade:240
+#: data/ui/pitch.glade:241
 msgid "Octaves"
 msgstr "Oktávy"
 
-#: data/ui/pitch.glade:271
+#: data/ui/pitch.glade:272
 msgid "Crispness"
 msgstr "Křehkost"
 
-#: data/ui/pitch.glade:311
+#: data/ui/pitch.glade:312
 msgid "Faster"
 msgstr "Rychleji"
 
-#: data/ui/pitch.glade:325
+#: data/ui/pitch.glade:326
 msgid "Preserve Formant"
 msgstr "Zachovat složku rozhodující o barvě zvuku"
 
@@ -1313,83 +1333,83 @@ msgstr ""
 msgid "Pipeline Output"
 msgstr "Ekvalizér - výstup"
 
-#: data/ui/reverb.glade:131
+#: data/ui/reverb.glade:132
 msgid "Reverberation"
 msgstr "Dozvuk"
 
-#: data/ui/reverb.glade:181
+#: data/ui/reverb.glade:182
 msgid "Ambience"
 msgstr "Okolní prostředí"
 
-#: data/ui/reverb.glade:194
+#: data/ui/reverb.glade:195
 msgid "Empty Walls"
 msgstr "Prázdné zdi"
 
-#: data/ui/reverb.glade:207
+#: data/ui/reverb.glade:208
 msgid "Room"
 msgstr "Pokoj"
 
-#: data/ui/reverb.glade:220
+#: data/ui/reverb.glade:221
 msgid "Large Empty Hall"
 msgstr "Velký prázdný sál"
 
-#: data/ui/reverb.glade:246
+#: data/ui/reverb.glade:247
 msgid "Large Occupied Hall"
 msgstr "Velký obsazený sál"
 
-#: data/ui/reverb.glade:361
+#: data/ui/reverb.glade:362
 msgid "Pre Delay"
 msgstr "Předzpoždění"
 
-#: data/ui/reverb.glade:374
+#: data/ui/reverb.glade:375
 msgid "Decay Time"
 msgstr "Čas dozvuku"
 
-#: data/ui/reverb.glade:439
+#: data/ui/reverb.glade:441
 msgid "Dry"
 msgstr "Zkušební"
 
-#: data/ui/reverb.glade:471
+#: data/ui/reverb.glade:474
 msgid "Bass Cut"
 msgstr "Ořezání hloubek"
 
-#: data/ui/reverb.glade:522
+#: data/ui/reverb.glade:525
 msgid "Treble Cut"
 msgstr "Ořezání výšek"
 
-#: data/ui/reverb.glade:565
+#: data/ui/reverb.glade:568
 msgid "Diffusion"
 msgstr "Rozptylování"
 
-#: data/ui/reverb.glade:577
+#: data/ui/reverb.glade:580
 msgid "Room Size"
 msgstr "Velikost prostoru"
 
-#: data/ui/reverb.glade:590
+#: data/ui/reverb.glade:593
 msgid "Small"
 msgstr "Malý"
 
-#: data/ui/reverb.glade:591
+#: data/ui/reverb.glade:594
 msgid "Medium"
 msgstr "Střední"
 
-#: data/ui/reverb.glade:592
+#: data/ui/reverb.glade:595
 msgid "Large"
 msgstr "Velký"
 
-#: data/ui/reverb.glade:593
+#: data/ui/reverb.glade:596
 msgid "Tunnel"
 msgstr "Chodba"
 
-#: data/ui/reverb.glade:594
+#: data/ui/reverb.glade:597
 msgid "Large/smooth"
 msgstr "Velký/plynulý"
 
-#: data/ui/reverb.glade:595
+#: data/ui/reverb.glade:598
 msgid "Experimental"
 msgstr "Pokusný"
 
-#: data/ui/reverb.glade:608
+#: data/ui/reverb.glade:611
 msgid "High Frequency Damping"
 msgstr "Tlumení vysokého kmitočtu"
 
@@ -1463,23 +1483,23 @@ msgstr "Výška"
 msgid "Points"
 msgstr "Body"
 
-#: data/ui/stereo_tools.glade:109
+#: data/ui/stereo_tools.glade:110
 msgid "Stereo Tools"
 msgstr "Nástroje sterea"
 
-#: data/ui/stereo_tools.glade:231
+#: data/ui/stereo_tools.glade:230
 msgid "Softclip"
 msgstr "Softclip"
 
-#: data/ui/stereo_tools.glade:255 data/ui/stereo_tools.glade:671
+#: data/ui/stereo_tools.glade:254 data/ui/stereo_tools.glade:672
 msgid "Balance"
 msgstr "Vyvážení"
 
-#: data/ui/stereo_tools.glade:287
+#: data/ui/stereo_tools.glade:286
 msgid "S/C Level"
 msgstr "Úroveň S/C"
 
-#: data/ui/stereo_tools.glade:345
+#: data/ui/stereo_tools.glade:344
 msgid "Side Level"
 msgstr "Postranní úroveň"
 
@@ -1487,144 +1507,144 @@ msgstr "Postranní úroveň"
 msgid "Side Balance"
 msgstr "Postranní vyvážení"
 
-#: data/ui/stereo_tools.glade:428
+#: data/ui/stereo_tools.glade:429
 msgid "Middle Level"
 msgstr "Prostřední úroveň"
 
-#: data/ui/stereo_tools.glade:441
+#: data/ui/stereo_tools.glade:442
 msgid "Middle Panorama"
 msgstr "Prostřední panorama"
 
-#: data/ui/stereo_tools.glade:499
+#: data/ui/stereo_tools.glade:500
 msgid "LR > LR (Stereo Default)"
 msgstr "LP > LP (výchozí stereo)"
 
-#: data/ui/stereo_tools.glade:500
+#: data/ui/stereo_tools.glade:501
 msgid "LR > MS (Stereo to Mid-Side)"
 msgstr "LP > SS (stereo ke střední straně)"
 
-#: data/ui/stereo_tools.glade:501
+#: data/ui/stereo_tools.glade:502
 msgid "MS > LR (Mid-Side to Stereo)"
 msgstr "SS > LP (střední strana ke stereu)"
 
-#: data/ui/stereo_tools.glade:502
+#: data/ui/stereo_tools.glade:503
 msgid "LR > LL (Mono Left Channel)"
 msgstr "LP > LL (mono levý kanál)"
 
-#: data/ui/stereo_tools.glade:503
+#: data/ui/stereo_tools.glade:504
 msgid "LR > RR (Mono Right Channel)"
 msgstr "LP > PP (mono pravý kanál)"
 
-#: data/ui/stereo_tools.glade:504
+#: data/ui/stereo_tools.glade:505
 msgid "LR > L+R (Mono Sum L+R)"
 msgstr "LP > L+P (mono součet L+P)"
 
-#: data/ui/stereo_tools.glade:505
+#: data/ui/stereo_tools.glade:506
 msgid "LR > RL (Stereo Flip Channels)"
 msgstr "LR > RL (stereo obrácení kanálů)"
 
-#: data/ui/stereo_tools.glade:522
+#: data/ui/stereo_tools.glade:523
 msgid "Stereo Matrix"
 msgstr "Matrice sterea"
 
-#: data/ui/stereo_tools.glade:561 data/ui/stereo_tools.glade:602
+#: data/ui/stereo_tools.glade:562 data/ui/stereo_tools.glade:603
 msgid "Invert Phase"
 msgstr "Obrátit fázi"
 
-#: data/ui/stereo_tools.glade:703
+#: data/ui/stereo_tools.glade:704
 msgid "Delay L/R"
 msgstr "Zpoždění L/P"
 
-#: data/ui/stereo_tools.glade:737
+#: data/ui/stereo_tools.glade:738
 msgid "Stereo Base"
 msgstr "Základ sterea"
 
-#: data/ui/stereo_tools.glade:770
+#: data/ui/stereo_tools.glade:771
 msgid "Stereo Phase"
 msgstr "Fáze sterea"
 
-#: data/ui/webrtc.glade:97
+#: data/ui/webrtc.glade:98
 msgid "WebRTC"
 msgstr "WebRTC"
 
-#: data/ui/webrtc.glade:163 data/ui/webrtc.glade:283 data/ui/webrtc.glade:353
-#: data/ui/webrtc.glade:523
+#: data/ui/webrtc.glade:164 data/ui/webrtc.glade:284 data/ui/webrtc.glade:354
+#: data/ui/webrtc.glade:524
 msgid "Enable"
 msgstr "Povolit"
 
-#: data/ui/webrtc.glade:184
+#: data/ui/webrtc.glade:185
 msgid "Extended Filter"
 msgstr "Rozšířený filtr"
 
-#: data/ui/webrtc.glade:197
+#: data/ui/webrtc.glade:198
 msgid "Delay Agnostic"
 msgstr "Zpozdit absolutní"
 
-#: data/ui/webrtc.glade:209
+#: data/ui/webrtc.glade:210
 msgid "High Pass Filter"
 msgstr "Vysokopásmový filtr"
 
-#: data/ui/webrtc.glade:238 data/ui/webrtc.glade:306
+#: data/ui/webrtc.glade:239 data/ui/webrtc.glade:307
 msgid "Suppresion Level"
 msgstr "Úroveň potlačení"
 
-#: data/ui/webrtc.glade:251 data/ui/webrtc.glade:319 data/ui/webrtc.glade:575
+#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
 msgid "Low"
 msgstr "Nízký"
 
-#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
+#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
 msgid "Moderate"
 msgstr "Střední"
 
-#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
+#: data/ui/webrtc.glade:254 data/ui/webrtc.glade:322 data/ui/webrtc.glade:578
 msgid "High"
 msgstr "Vysoký"
 
-#: data/ui/webrtc.glade:270
+#: data/ui/webrtc.glade:271
 msgid "Echo Canceller"
 msgstr "Potlačovač echa"
 
-#: data/ui/webrtc.glade:322
+#: data/ui/webrtc.glade:323
 msgid "Very High"
 msgstr "Velmi vysoký"
 
-#: data/ui/webrtc.glade:339
+#: data/ui/webrtc.glade:340
 msgid "Noise Suppressor"
 msgstr "Potlačovač šumu"
 
-#: data/ui/webrtc.glade:389
+#: data/ui/webrtc.glade:390
 msgid "Adaptive Digital"
 msgstr "Přizpůsobivý digitální"
 
-#: data/ui/webrtc.glade:390
+#: data/ui/webrtc.glade:391
 msgid "Fixed Digital"
 msgstr "Pevný digitální"
 
-#: data/ui/webrtc.glade:407
+#: data/ui/webrtc.glade:408
 msgid "Gain Controller"
 msgstr "Ovladač zesílení"
 
-#: data/ui/webrtc.glade:445
+#: data/ui/webrtc.glade:446
 msgid "Target Level"
 msgstr "Úroveň cíle"
 
-#: data/ui/webrtc.glade:475
+#: data/ui/webrtc.glade:476
 msgid "Maximum Gain"
 msgstr "Největší zesílení"
 
-#: data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:549
 msgid "Detection Likelihood"
 msgstr "Pravděpodobnost zjištění"
 
-#: data/ui/webrtc.glade:561
+#: data/ui/webrtc.glade:562
 msgid "Frame Size"
 msgstr "Rozměry rámečku"
 
-#: data/ui/webrtc.glade:574
+#: data/ui/webrtc.glade:575
 msgid "Very Low"
 msgstr "Velmi nízká"
 
-#: data/ui/webrtc.glade:611
+#: data/ui/webrtc.glade:612
 msgid "Voice Detector"
 msgstr "Zjišťovatel hlasu"
 
@@ -1719,6 +1739,10 @@ msgstr "Obecné"
 #: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
+
+#, fuzzy
+#~ msgid "Gain Detection"
+#~ msgstr "Zmenšení zesílení"
 
 #~ msgid "Scale"
 #~ msgstr "Měřítko"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PulseEffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-22 15:29+0200\n"
+"POT-Creation-Date: 2020-08-24 16:51+0200\n"
 "PO-Revision-Date: 2020-01-12 17:49+0100\n"
 "Last-Translator: David Keller <blobcodes@protonmail.com>\n"
 "Language-Team: \n"
@@ -85,8 +85,8 @@ msgid "Input Limiter"
 msgstr "Eingabe-Limiter"
 
 #: data/com.github.wwmm.pulseeffects.appdata.xml.in:52
-#: data/ui/compressor.glade:111 data/ui/compressor.glade:494
-#: data/ui/webrtc.glade:509
+#: data/ui/compressor.glade:112 data/ui/compressor.glade:494
+#: data/ui/webrtc.glade:510
 msgid "Compressor"
 msgstr "Kompressor"
 
@@ -118,12 +118,12 @@ msgstr "Anwendungen"
 msgid "Format"
 msgstr "Format"
 
-#: data/ui/app_info.glade:75 data/ui/convolver.glade:283
+#: data/ui/app_info.glade:75 data/ui/convolver.glade:284
 msgid "Rate"
 msgstr "Rate"
 
 #: data/ui/app_info.glade:102 data/ui/pulse_info.glade:238
-#: data/ui/stereo_tools.glade:653
+#: data/ui/stereo_tools.glade:654
 msgid "Channels"
 msgstr "Kanäle"
 
@@ -161,7 +161,7 @@ msgstr "Testsignale"
 msgid "Global Bypass"
 msgstr "Globale Umleitung"
 
-#: data/ui/application.glade:170 data/ui/equalizer.glade:277
+#: data/ui/application.glade:170 data/ui/equalizer.glade:278
 #: data/ui/general_settings.glade:107
 msgid "Settings"
 msgstr "Einstellungen"
@@ -170,169 +170,168 @@ msgstr "Einstellungen"
 msgid "Help"
 msgstr "Hilfe"
 
-#: data/ui/application.glade:215 data/ui/crossfeed.glade:49
-#: data/ui/equalizer.glade:333 data/ui/filter.glade:230
-#: data/ui/reverb.glade:310 src/presets_menu_ui.cpp:113
+#: data/ui/application.glade:215 data/ui/crossfeed.glade:48
+#: data/ui/equalizer.glade:334 data/ui/filter.glade:231
+#: data/ui/reverb.glade:311 src/presets_menu_ui.cpp:113
 #: src/presets_menu_ui.cpp:258 src/presets_menu_ui.cpp:275
 msgid "Presets"
 msgstr "Presets"
 
-#: data/ui/autogain.glade:91
+#: data/ui/autogain.glade:92
 msgid "Auto Gain"
 msgstr "Automatische Verstärkungsregelung"
 
-#: data/ui/autogain.glade:171
+#: data/ui/autogain.glade:172
 msgid "Reset History"
 msgstr "Verlauf löschen"
 
-#: data/ui/autogain.glade:183
+#: data/ui/autogain.glade:184
 msgid "Detect Silence"
 msgstr "Stille erkennen"
 
-#: data/ui/autogain.glade:195
+#: data/ui/autogain.glade:196
 msgid "Use Geometric Mean"
 msgstr "Geometrisches Mittel nutzen"
 
-#: data/ui/autogain.glade:233
+#: data/ui/autogain.glade:234
 msgid "Target"
 msgstr "Ziel"
 
-#: data/ui/autogain.glade:283 data/ui/autogain.glade:627
+#: data/ui/autogain.glade:286 data/ui/autogain.glade:631
 msgid "Momentary"
 msgstr "Momentan"
 
-#: data/ui/autogain.glade:298 data/ui/autogain.glade:640
+#: data/ui/autogain.glade:301 data/ui/autogain.glade:644
 msgid "Short Term"
 msgstr "Kurzfristig"
 
-#: data/ui/autogain.glade:313 data/ui/autogain.glade:653
+#: data/ui/autogain.glade:316 data/ui/autogain.glade:657
 msgid "Integrated"
 msgstr "Integriert"
 
-#: data/ui/autogain.glade:388
+#: data/ui/autogain.glade:394
 msgid "Weights"
 msgstr "Gewichte"
 
-#: data/ui/autogain.glade:428 data/ui/autogain.glade:917
-#: data/ui/bass_enhancer.glade:504 data/ui/compressor.glade:974
-#: data/ui/convolver.glade:504 data/ui/crossfeed.glade:200
-#: data/ui/crystalizer.glade:255 data/ui/deesser.glade:593
-#: data/ui/delay.glade:236 data/ui/equalizer.glade:543
-#: data/ui/exciter.glade:510 data/ui/filter.glade:396 data/ui/gate.glade:558
-#: data/ui/limiter.glade:483 data/ui/loudness.glade:259
-#: data/ui/loudness.glade:338 data/ui/maximizer.glade:265
-#: data/ui/multiband_compressor.glade:2000 data/ui/multiband_gate.glade:2153
-#: data/ui/pitch.glade:362 data/ui/presets_menu.glade:255
-#: data/ui/reverb.glade:658 data/ui/stereo_tools.glade:323
-#: data/ui/stereo_tools.glade:829 data/ui/webrtc.glade:650
+#: data/ui/autogain.glade:434 data/ui/autogain.glade:921
+#: data/ui/bass_enhancer.glade:506 data/ui/compressor.glade:977
+#: data/ui/convolver.glade:505 data/ui/crossfeed.glade:199
+#: data/ui/crystalizer.glade:205 data/ui/deesser.glade:594
+#: data/ui/delay.glade:237 data/ui/equalizer.glade:544
+#: data/ui/exciter.glade:510 data/ui/filter.glade:397 data/ui/gate.glade:611
+#: data/ui/limiter.glade:485 data/ui/loudness.glade:299
+#: data/ui/loudness.glade:380 data/ui/maximizer.glade:268
+#: data/ui/multiband_compressor.glade:2006 data/ui/multiband_gate.glade:2163
+#: data/ui/pitch.glade:363 data/ui/presets_menu.glade:255
+#: data/ui/reverb.glade:661 data/ui/stereo_tools.glade:322
+#: data/ui/stereo_tools.glade:830 data/ui/webrtc.glade:651
 msgid "Input"
 msgstr "Eingang"
 
-#: data/ui/autogain.glade:443 data/ui/autogain.glade:862
-#: data/ui/bass_enhancer.glade:536 data/ui/compressor.glade:988
-#: data/ui/convolver.glade:519 data/ui/crossfeed.glade:214
-#: data/ui/crystalizer.glade:270 data/ui/deesser.glade:607
-#: data/ui/delay.glade:250 data/ui/equalizer.glade:557
-#: data/ui/exciter.glade:542 data/ui/filter.glade:411 data/ui/gate.glade:572
-#: data/ui/limiter.glade:626 data/ui/loudness.glade:292
-#: data/ui/loudness.glade:352 data/ui/maximizer.glade:279
+#: data/ui/autogain.glade:449 data/ui/autogain.glade:866
+#: data/ui/bass_enhancer.glade:537 data/ui/compressor.glade:991
+#: data/ui/convolver.glade:520 data/ui/crossfeed.glade:213
+#: data/ui/crystalizer.glade:220 data/ui/deesser.glade:608
+#: data/ui/delay.glade:251 data/ui/equalizer.glade:558
+#: data/ui/exciter.glade:541 data/ui/filter.glade:412 data/ui/gate.glade:625
+#: data/ui/limiter.glade:628 data/ui/loudness.glade:333
+#: data/ui/loudness.glade:394 data/ui/maximizer.glade:282
 #: data/ui/multiband_compressor.glade:794
-#: data/ui/multiband_compressor.glade:1171
-#: data/ui/multiband_compressor.glade:1549
-#: data/ui/multiband_compressor.glade:1927
-#: data/ui/multiband_compressor.glade:2015 data/ui/multiband_gate.glade:851
-#: data/ui/multiband_gate.glade:1260 data/ui/multiband_gate.glade:1670
-#: data/ui/multiband_gate.glade:2080 data/ui/multiband_gate.glade:2168
-#: data/ui/pitch.glade:376 data/ui/presets_menu.glade:146
-#: data/ui/reverb.glade:673 data/ui/stereo_tools.glade:800
-#: data/ui/stereo_tools.glade:843 data/ui/webrtc.glade:664
+#: data/ui/multiband_compressor.glade:1173
+#: data/ui/multiband_compressor.glade:1553
+#: data/ui/multiband_compressor.glade:1933
+#: data/ui/multiband_compressor.glade:2021 data/ui/multiband_gate.glade:852
+#: data/ui/multiband_gate.glade:1264 data/ui/multiband_gate.glade:1677
+#: data/ui/multiband_gate.glade:2090 data/ui/multiband_gate.glade:2178
+#: data/ui/pitch.glade:377 data/ui/presets_menu.glade:146
+#: data/ui/reverb.glade:676 data/ui/stereo_tools.glade:801
+#: data/ui/stereo_tools.glade:844 data/ui/webrtc.glade:665
 msgid "Output"
 msgstr "Ausgang"
 
-#: data/ui/autogain.glade:744
+#: data/ui/autogain.glade:748
 msgid "Relative"
 msgstr "Relativ"
 
-#: data/ui/autogain.glade:757 data/ui/compressor.glade:1154
-#: data/ui/deesser.glade:321
+#: data/ui/autogain.glade:761 data/ui/compressor.glade:1157
 msgid "Gain"
 msgstr "Verstärkung"
 
-#: data/ui/autogain.glade:823
+#: data/ui/autogain.glade:827
 msgid "Loudness"
 msgstr "Lautstärke"
 
-#: data/ui/autogain.glade:876
+#: data/ui/autogain.glade:880
 msgid "Range"
 msgstr "Umfang"
 
-#: data/ui/autogain.glade:945 data/ui/bass_enhancer.glade:655
-#: data/ui/compressor.glade:1299 data/ui/convolver.glade:703
-#: data/ui/crossfeed.glade:395 data/ui/crystalizer.glade:566
-#: data/ui/deesser.glade:898 data/ui/delay.glade:434
-#: data/ui/equalizer.glade:743 data/ui/equalizer_band.glade:182
-#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:661
-#: data/ui/filter.glade:595 data/ui/general_settings.glade:116
-#: data/ui/gate.glade:809 data/ui/limiter.glade:733 data/ui/loudness.glade:573
-#: data/ui/maximizer.glade:516 data/ui/multiband_compressor.glade:2199
-#: data/ui/multiband_gate.glade:2352 data/ui/pitch.glade:560
-#: data/ui/reverb.glade:857 data/ui/stereo_tools.glade:1029
-#: data/ui/webrtc.glade:814
+#: data/ui/autogain.glade:949 data/ui/bass_enhancer.glade:650
+#: data/ui/compressor.glade:1300 data/ui/convolver.glade:702
+#: data/ui/crossfeed.glade:394 data/ui/crystalizer.glade:514
+#: data/ui/deesser.glade:899 data/ui/delay.glade:433
+#: data/ui/equalizer.glade:744 data/ui/equalizer_band.glade:182
+#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:654
+#: data/ui/filter.glade:594 data/ui/general_settings.glade:116
+#: data/ui/gate.glade:862 data/ui/limiter.glade:735 data/ui/loudness.glade:615
+#: data/ui/maximizer.glade:519 data/ui/multiband_compressor.glade:2203
+#: data/ui/multiband_gate.glade:2360 data/ui/pitch.glade:559
+#: data/ui/reverb.glade:858 data/ui/stereo_tools.glade:1028
+#: data/ui/webrtc.glade:815
 msgid "Reset"
 msgstr "Zurücksetzen"
 
-#: data/ui/autogain.glade:969
+#: data/ui/autogain.glade:973
 msgid "Based on"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:117
+#: data/ui/bass_enhancer.glade:118
 msgid "Bass Enhancer"
 msgstr "Bassverstärker"
 
-#: data/ui/bass_enhancer.glade:169 data/ui/compressor.glade:506
-#: data/ui/deesser.glade:188 data/ui/exciter.glade:171
+#: data/ui/bass_enhancer.glade:170 data/ui/compressor.glade:506
+#: data/ui/deesser.glade:185 data/ui/exciter.glade:170
 msgid "Listen"
 msgstr "Zuhören"
 
-#: data/ui/bass_enhancer.glade:210 data/ui/exciter.glade:213
+#: data/ui/bass_enhancer.glade:211 data/ui/exciter.glade:212
 msgid "3rd"
 msgstr "Dritte"
 
-#: data/ui/bass_enhancer.glade:222 data/ui/exciter.glade:225
+#: data/ui/bass_enhancer.glade:223 data/ui/exciter.glade:224
 msgid "2nd"
 msgstr "Zweite"
 
-#: data/ui/bass_enhancer.glade:234 data/ui/exciter.glade:237
+#: data/ui/bass_enhancer.glade:235 data/ui/exciter.glade:236
 msgid "Blend Harmonics"
 msgstr "Oberwellen mischen"
 
-#: data/ui/bass_enhancer.glade:266 data/ui/exciter.glade:271
-#: data/ui/reverb.glade:407
+#: data/ui/bass_enhancer.glade:267 data/ui/exciter.glade:270
+#: data/ui/reverb.glade:408
 msgid "Amount"
 msgstr "Betrag"
 
-#: data/ui/bass_enhancer.glade:278 data/ui/bass_enhancer.glade:411
-#: data/ui/exciter.glade:284 data/ui/exciter.glade:417
+#: data/ui/bass_enhancer.glade:279 data/ui/bass_enhancer.glade:413
+#: data/ui/exciter.glade:283 data/ui/exciter.glade:417
 msgid "Harmonics"
 msgstr "Obertöne"
 
-#: data/ui/bass_enhancer.glade:290 data/ui/exciter.glade:297
+#: data/ui/bass_enhancer.glade:291 data/ui/exciter.glade:296
 msgid "Scope"
 msgstr "Bereich"
 
-#: data/ui/bass_enhancer.glade:379
+#: data/ui/bass_enhancer.glade:381
 msgid "Floor"
 msgstr "Boden"
 
-#: data/ui/bass_enhancer.glade:679 data/ui/compressor.glade:1323
-#: data/ui/crossfeed.glade:419 data/ui/deesser.glade:922
-#: data/ui/delay.glade:458 data/ui/equalizer.glade:767
-#: data/ui/exciter.glade:685 data/ui/filter.glade:619 data/ui/gate.glade:833
-#: data/ui/limiter.glade:757 data/ui/loudness.glade:542
-#: data/ui/maximizer.glade:540 data/ui/multiband_compressor.glade:2223
-#: data/ui/multiband_gate.glade:2376 data/ui/pitch.glade:584
-#: data/ui/reverb.glade:881 data/ui/stereo_tools.glade:1053
-#: data/ui/webrtc.glade:838
+#: data/ui/bass_enhancer.glade:674 data/ui/compressor.glade:1324
+#: data/ui/crossfeed.glade:418 data/ui/deesser.glade:923
+#: data/ui/delay.glade:457 data/ui/equalizer.glade:768
+#: data/ui/exciter.glade:678 data/ui/filter.glade:618 data/ui/gate.glade:886
+#: data/ui/limiter.glade:759 data/ui/loudness.glade:584
+#: data/ui/maximizer.glade:543 data/ui/multiband_compressor.glade:2227
+#: data/ui/multiband_gate.glade:2384 data/ui/pitch.glade:583
+#: data/ui/reverb.glade:882 data/ui/stereo_tools.glade:1052
+#: data/ui/webrtc.glade:839
 msgid "Provided by"
 msgstr ""
 
@@ -367,138 +366,138 @@ msgstr "Ausgabeeffekte"
 msgid "Show Blocklisted Apps in Main Tab"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:32 data/ui/equalizer_band.glade:152
-#: data/ui/filter.glade:280
+#: data/ui/calibration_signals.glade:30 data/ui/equalizer_band.glade:152
+#: data/ui/filter.glade:281
 msgid "Frequency"
 msgstr "Frequenz"
 
-#: data/ui/calibration_signals.glade:64
+#: data/ui/calibration_signals.glade:62
 msgid "Volume"
 msgstr "Lautstärke"
 
-#: data/ui/calibration_signals.glade:108
+#: data/ui/calibration_signals.glade:106
 msgid "Sine"
 msgstr "Sinus"
 
-#: data/ui/calibration_signals.glade:109
+#: data/ui/calibration_signals.glade:107
 msgid "Square"
 msgstr "Rechteck"
 
-#: data/ui/calibration_signals.glade:110
+#: data/ui/calibration_signals.glade:108
 msgid "Saw"
 msgstr "Sägezahn"
 
-#: data/ui/calibration_signals.glade:111
+#: data/ui/calibration_signals.glade:109
 msgid "Triangle"
 msgstr "Dreieck"
 
-#: data/ui/calibration_signals.glade:112
+#: data/ui/calibration_signals.glade:110
 msgid "Silence"
 msgstr "Ruhe"
 
-#: data/ui/calibration_signals.glade:113
+#: data/ui/calibration_signals.glade:111
 msgid "White Noise"
 msgstr "Weißes Rauschen"
 
-#: data/ui/calibration_signals.glade:114
+#: data/ui/calibration_signals.glade:112
 msgid "Pink Noise"
 msgstr "Rosa Rauschen"
 
-#: data/ui/calibration_signals.glade:115
+#: data/ui/calibration_signals.glade:113
 msgid "Sine Table"
 msgstr "Sinustabelle"
 
-#: data/ui/calibration_signals.glade:116
+#: data/ui/calibration_signals.glade:114
 msgid "Ticks"
 msgstr "Ticken"
 
-#: data/ui/calibration_signals.glade:117
+#: data/ui/calibration_signals.glade:115
 msgid "Gaussian Noise"
 msgstr "Gaußsches Rauschen"
 
-#: data/ui/calibration_signals.glade:118
+#: data/ui/calibration_signals.glade:116
 msgid "Red Noise"
 msgstr "Rotes Rauschen"
 
-#: data/ui/calibration_signals.glade:119
+#: data/ui/calibration_signals.glade:117
 msgid "Blue Noise"
 msgstr "Blaues Rauschen"
 
-#: data/ui/calibration_signals.glade:120
+#: data/ui/calibration_signals.glade:118
 msgid "Violet Noise"
 msgstr "Violettes Rauschen"
 
-#: data/ui/calibration_mic.glade:29
+#: data/ui/calibration_mic.glade:28
 msgid "Window"
 msgstr "Fenster"
 
-#: data/ui/calibration_mic.glade:70
+#: data/ui/calibration_mic.glade:69
 msgid "Measure Noise"
 msgstr "Rauschen messen"
 
-#: data/ui/calibration_mic.glade:99
+#: data/ui/calibration_mic.glade:98
 msgid "Subtract Noise"
 msgstr "Rauschen reduzieren"
 
-#: data/ui/compressor.glade:292 data/ui/deesser.glade:483
-#: data/ui/gate.glade:370 data/ui/maximizer.glade:152
-#: data/ui/multiband_compressor.glade:609
+#: data/ui/compressor.glade:290 data/ui/deesser.glade:482
+#: data/ui/gate.glade:413 data/ui/maximizer.glade:153
+#: data/ui/multiband_compressor.glade:607
 #: data/ui/multiband_compressor.glade:983
-#: data/ui/multiband_compressor.glade:1361
-#: data/ui/multiband_compressor.glade:1739 data/ui/multiband_gate.glade:633
-#: data/ui/multiband_gate.glade:1040 data/ui/multiband_gate.glade:1450
-#: data/ui/multiband_gate.glade:1860
+#: data/ui/multiband_compressor.glade:1363
+#: data/ui/multiband_compressor.glade:1743 data/ui/multiband_gate.glade:631
+#: data/ui/multiband_gate.glade:1041 data/ui/multiband_gate.glade:1454
+#: data/ui/multiband_gate.glade:1867
 msgid "Threshold"
 msgstr "Schwelle"
 
-#: data/ui/compressor.glade:325 data/ui/deesser.glade:516
-#: data/ui/gate.glade:403 data/ui/multiband_compressor.glade:642
-#: data/ui/multiband_compressor.glade:1017
-#: data/ui/multiband_compressor.glade:1395
-#: data/ui/multiband_compressor.glade:1773 data/ui/multiband_gate.glade:666
-#: data/ui/multiband_gate.glade:1074 data/ui/multiband_gate.glade:1484
-#: data/ui/multiband_gate.glade:1894
+#: data/ui/compressor.glade:324 data/ui/deesser.glade:516
+#: data/ui/gate.glade:449 data/ui/multiband_compressor.glade:641
+#: data/ui/multiband_compressor.glade:1018
+#: data/ui/multiband_compressor.glade:1398
+#: data/ui/multiband_compressor.glade:1778 data/ui/multiband_gate.glade:665
+#: data/ui/multiband_gate.glade:1076 data/ui/multiband_gate.glade:1489
+#: data/ui/multiband_gate.glade:1902
 msgid "Ratio"
 msgstr "Verhältnis"
 
-#: data/ui/compressor.glade:357 data/ui/gate.glade:435
-#: data/ui/multiband_compressor.glade:674
-#: data/ui/multiband_compressor.glade:1050
-#: data/ui/multiband_compressor.glade:1428
-#: data/ui/multiband_compressor.glade:1806 data/ui/multiband_gate.glade:698
-#: data/ui/multiband_gate.glade:1107 data/ui/multiband_gate.glade:1517
-#: data/ui/multiband_gate.glade:1927
+#: data/ui/compressor.glade:356 data/ui/gate.glade:483
+#: data/ui/multiband_compressor.glade:673
+#: data/ui/multiband_compressor.glade:1051
+#: data/ui/multiband_compressor.glade:1431
+#: data/ui/multiband_compressor.glade:1811 data/ui/multiband_gate.glade:697
+#: data/ui/multiband_gate.glade:1109 data/ui/multiband_gate.glade:1522
+#: data/ui/multiband_gate.glade:1935
 msgid "Knee"
 msgstr "Übergang"
 
-#: data/ui/compressor.glade:391 data/ui/deesser.glade:547
-#: data/ui/gate.glade:469 data/ui/multiband_compressor.glade:708
-#: data/ui/multiband_compressor.glade:1085
-#: data/ui/multiband_compressor.glade:1463
-#: data/ui/multiband_compressor.glade:1841 data/ui/multiband_gate.glade:732
-#: data/ui/multiband_gate.glade:1142 data/ui/multiband_gate.glade:1552
-#: data/ui/multiband_gate.glade:1962
+#: data/ui/compressor.glade:390 data/ui/deesser.glade:547
+#: data/ui/gate.glade:519 data/ui/multiband_compressor.glade:707
+#: data/ui/multiband_compressor.glade:1086
+#: data/ui/multiband_compressor.glade:1466
+#: data/ui/multiband_compressor.glade:1846 data/ui/multiband_gate.glade:731
+#: data/ui/multiband_gate.glade:1144 data/ui/multiband_gate.glade:1557
+#: data/ui/multiband_gate.glade:1970
 msgid "Makeup"
 msgstr "Hebung"
 
-#: data/ui/compressor.glade:425 data/ui/gate.glade:336
-#: data/ui/limiter.glade:310 data/ui/maximizer.glade:178
-#: data/ui/multiband_compressor.glade:575
+#: data/ui/compressor.glade:425 data/ui/gate.glade:377
+#: data/ui/limiter.glade:311 data/ui/maximizer.glade:179
+#: data/ui/multiband_compressor.glade:573
 #: data/ui/multiband_compressor.glade:948
-#: data/ui/multiband_compressor.glade:1326
-#: data/ui/multiband_compressor.glade:1704 data/ui/multiband_gate.glade:599
-#: data/ui/multiband_gate.glade:1005 data/ui/multiband_gate.glade:1415
-#: data/ui/multiband_gate.glade:1825
+#: data/ui/multiband_compressor.glade:1328
+#: data/ui/multiband_compressor.glade:1708 data/ui/multiband_gate.glade:597
+#: data/ui/multiband_gate.glade:1006 data/ui/multiband_gate.glade:1419
+#: data/ui/multiband_gate.glade:1832
 msgid "Release"
 msgstr "Ausklingzeit"
 
-#: data/ui/compressor.glade:438 data/ui/gate.glade:302
-#: data/ui/multiband_compressor.glade:541
+#: data/ui/compressor.glade:438 data/ui/gate.glade:341
+#: data/ui/multiband_compressor.glade:539
 #: data/ui/multiband_compressor.glade:913
-#: data/ui/multiband_compressor.glade:1291
-#: data/ui/multiband_compressor.glade:1669 data/ui/multiband_gate.glade:565
-#: data/ui/multiband_gate.glade:970 data/ui/multiband_gate.glade:1380
-#: data/ui/multiband_gate.glade:1790
+#: data/ui/multiband_compressor.glade:1293
+#: data/ui/multiband_compressor.glade:1673 data/ui/multiband_gate.glade:563
+#: data/ui/multiband_gate.glade:971 data/ui/multiband_gate.glade:1384
+#: data/ui/multiband_gate.glade:1797
 msgid "Attack"
 msgstr "Anstiegszeit"
 
@@ -514,210 +513,209 @@ msgstr "Aufwärts"
 msgid "Compression Mode"
 msgstr "Kompressionsmodus"
 
-#: data/ui/compressor.glade:551
+#: data/ui/compressor.glade:552
 msgid "Pre-amplification"
 msgstr "Vorverstärkung"
 
-#: data/ui/compressor.glade:585
+#: data/ui/compressor.glade:586
 msgid "Reactivity"
 msgstr "Reaktivität"
 
-#: data/ui/compressor.glade:619 data/ui/limiter.glade:323
+#: data/ui/compressor.glade:620 data/ui/limiter.glade:324
 msgid "Lookahead"
 msgstr "Ausblick"
 
-#: data/ui/compressor.glade:632
+#: data/ui/compressor.glade:633
 msgid "Feed-forward"
 msgstr "Feedforward"
 
-#: data/ui/compressor.glade:633
+#: data/ui/compressor.glade:634
 msgid "Feed-back"
 msgstr "Feedback"
 
-#: data/ui/compressor.glade:647 data/ui/equalizer_band.glade:48
+#: data/ui/compressor.glade:648 data/ui/equalizer_band.glade:48
 msgid "Type"
 msgstr "Typ"
 
-#: data/ui/compressor.glade:661 data/ui/deesser.glade:244
-#: data/ui/deesser.glade:354 data/ui/gate.glade:257
-#: data/ui/multiband_compressor.glade:514
+#: data/ui/compressor.glade:662 data/ui/deesser.glade:241
+#: data/ui/gate.glade:213 data/ui/multiband_compressor.glade:512
 #: data/ui/multiband_compressor.glade:886
-#: data/ui/multiband_compressor.glade:1264
-#: data/ui/multiband_compressor.glade:1642 data/ui/multiband_gate.glade:538
-#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1353
-#: data/ui/multiband_gate.glade:1763
+#: data/ui/multiband_compressor.glade:1266
+#: data/ui/multiband_compressor.glade:1646 data/ui/multiband_gate.glade:536
+#: data/ui/multiband_gate.glade:944 data/ui/multiband_gate.glade:1357
+#: data/ui/multiband_gate.glade:1770
 msgid "Peak"
 msgstr "Hochpunkt"
 
-#: data/ui/compressor.glade:662 data/ui/deesser.glade:243
-#: data/ui/gate.glade:256 data/ui/multiband_compressor.glade:513
+#: data/ui/compressor.glade:663 data/ui/deesser.glade:240
+#: data/ui/gate.glade:212 data/ui/multiband_compressor.glade:511
 #: data/ui/multiband_compressor.glade:885
-#: data/ui/multiband_compressor.glade:1263
-#: data/ui/multiband_compressor.glade:1641 data/ui/multiband_gate.glade:537
-#: data/ui/multiband_gate.glade:942 data/ui/multiband_gate.glade:1352
-#: data/ui/multiband_gate.glade:1762
+#: data/ui/multiband_compressor.glade:1265
+#: data/ui/multiband_compressor.glade:1645 data/ui/multiband_gate.glade:535
+#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1356
+#: data/ui/multiband_gate.glade:1769
 msgid "RMS"
 msgstr "RMS"
 
-#: data/ui/compressor.glade:663
+#: data/ui/compressor.glade:664
 msgid "Low-Pass"
 msgstr "Tiefpass"
 
-#: data/ui/compressor.glade:664
+#: data/ui/compressor.glade:665
 msgid "Uniform"
 msgstr "Einheitlich"
 
-#: data/ui/compressor.glade:678 data/ui/deesser.glade:230
-#: data/ui/equalizer.glade:224 data/ui/equalizer_band.glade:79
-#: data/ui/multiband_compressor.glade:324 data/ui/multiband_gate.glade:348
-#: data/ui/stereo_tools.glade:485 data/ui/webrtc.glade:376
+#: data/ui/compressor.glade:679 data/ui/deesser.glade:227
+#: data/ui/equalizer.glade:225 data/ui/equalizer_band.glade:79
+#: data/ui/multiband_compressor.glade:322 data/ui/multiband_gate.glade:346
+#: data/ui/stereo_tools.glade:486 data/ui/webrtc.glade:377
 msgid "Mode"
 msgstr "Modus"
 
-#: data/ui/compressor.glade:692
+#: data/ui/compressor.glade:693
 msgid "Middle"
 msgstr "Mitte"
 
-#: data/ui/compressor.glade:693
+#: data/ui/compressor.glade:694
 msgid "Side"
 msgstr "Seite"
 
-#: data/ui/compressor.glade:694 data/ui/delay.glade:157
-#: data/ui/equalizer.glade:474 data/ui/stereo_tools.glade:548
+#: data/ui/compressor.glade:695 data/ui/delay.glade:158
+#: data/ui/equalizer.glade:475 data/ui/stereo_tools.glade:549
 msgid "Left"
 msgstr "Links"
 
-#: data/ui/compressor.glade:695 data/ui/delay.glade:189
-#: data/ui/equalizer.glade:515 data/ui/stereo_tools.glade:620
+#: data/ui/compressor.glade:696 data/ui/delay.glade:190
+#: data/ui/equalizer.glade:516 data/ui/stereo_tools.glade:621
 msgid "Right"
 msgstr "Rechts"
 
-#: data/ui/compressor.glade:709
+#: data/ui/compressor.glade:710
 msgid "Source"
 msgstr "Quelle"
 
-#: data/ui/compressor.glade:725 data/ui/compressor.glade:1167
+#: data/ui/compressor.glade:726 data/ui/compressor.glade:1170
 msgid "Sidechain"
 msgstr "Sidechain"
 
-#: data/ui/compressor.glade:821
+#: data/ui/compressor.glade:824
 msgid "Relative Release Threshold"
 msgstr ""
 
-#: data/ui/compressor.glade:832
+#: data/ui/compressor.glade:835
 #, fuzzy
 msgid "Boost Threshold"
 msgstr "Schwelle"
 
-#: data/ui/compressor.glade:843
+#: data/ui/compressor.glade:846
 #, fuzzy
 msgid "High-pass Frequency"
 msgstr "Frequenz zurücksetzen"
 
-#: data/ui/compressor.glade:854
+#: data/ui/compressor.glade:857
 #, fuzzy
 msgid "Low-pass Frequency"
 msgstr "Frequenz zurücksetzen"
 
-#: data/ui/compressor.glade:865
+#: data/ui/compressor.glade:868
 #, fuzzy
 msgid "High-pass Filter Mode"
 msgstr "Hochpassfilter"
 
-#: data/ui/compressor.glade:876
+#: data/ui/compressor.glade:879
 msgid "Low-pass Filter Mode"
 msgstr ""
 
-#: data/ui/compressor.glade:889 data/ui/compressor.glade:906
+#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
 #: data/ui/equalizer_band.glade:60
 msgid "Off"
 msgstr "Aus"
 
-#: data/ui/compressor.glade:890 data/ui/compressor.glade:907
+#: data/ui/compressor.glade:893 data/ui/compressor.glade:910
 #, fuzzy
 msgid "12 dB/oct"
 msgstr "12dB/okt Tiefpass"
 
-#: data/ui/compressor.glade:891 data/ui/compressor.glade:908
+#: data/ui/compressor.glade:894 data/ui/compressor.glade:911
 #, fuzzy
 msgid "24 dB/oct"
 msgstr "24dB/okt Tiefpass"
 
-#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
+#: data/ui/compressor.glade:895 data/ui/compressor.glade:912
 #, fuzzy
 msgid "36 dB/oct"
 msgstr "36dB/okt Tiefpass"
 
-#: data/ui/compressor.glade:932
+#: data/ui/compressor.glade:935
 #, fuzzy
 msgid "Advanced"
 msgstr "Einstellungen"
 
-#: data/ui/compressor.glade:1243
+#: data/ui/compressor.glade:1244
 msgid "Curve"
 msgstr "Kurve"
 
-#: data/ui/convolver.glade:91
+#: data/ui/convolver.glade:92
 msgid "Convolver"
 msgstr "Convolver"
 
-#: data/ui/convolver.glade:125
+#: data/ui/convolver.glade:126
 msgid "Import Impulse"
 msgstr "Impuls importieren"
 
-#: data/ui/convolver.glade:129
+#: data/ui/convolver.glade:130
 msgid "Import Impulse Response File"
 msgstr "Impulsantwortdatei importieren"
 
-#: data/ui/convolver.glade:247
+#: data/ui/convolver.glade:248
 msgid "L"
 msgstr "L"
 
-#: data/ui/convolver.glade:261
+#: data/ui/convolver.glade:262
 msgid "R"
 msgstr "R"
 
-#: data/ui/convolver.glade:324
+#: data/ui/convolver.glade:325
 msgid "Duration"
 msgstr "Dauer"
 
-#: data/ui/convolver.glade:335
+#: data/ui/convolver.glade:336
 msgid "Samples"
 msgstr "Probenahme"
 
-#: data/ui/convolver.glade:367 src/convolver_ui.cpp:283
+#: data/ui/convolver.glade:368 src/convolver_ui.cpp:283
 msgid "Impulse Response"
 msgstr "Impulsantwort"
 
-#: data/ui/convolver.glade:389
+#: data/ui/convolver.glade:390
 msgid "Select the impulse Response File"
 msgstr "Auswahl der Impulsantwortdatei"
 
-#: data/ui/convolver.glade:409 src/spectrum_settings_ui.cpp:176
+#: data/ui/convolver.glade:410 src/spectrum_settings_ui.cpp:176
 msgid "Spectrum"
 msgstr "Spektrum"
 
-#: data/ui/convolver.glade:450
+#: data/ui/convolver.glade:451
 msgid "Stereo Width"
 msgstr "Stereo-Breite"
 
-#: data/ui/crossfeed.glade:63
+#: data/ui/crossfeed.glade:62
 msgid "Jmeier"
 msgstr "Jmeier"
 
-#: data/ui/crossfeed.glade:76 data/ui/filter.glade:183 data/ui/reverb.glade:259
+#: data/ui/crossfeed.glade:75 data/ui/filter.glade:184 data/ui/reverb.glade:260
 msgid "Default"
 msgstr "Standard"
 
-#: data/ui/crossfeed.glade:89
+#: data/ui/crossfeed.glade:88
 msgid "Cmoy"
 msgstr "Cmoy"
 
-#: data/ui/crossfeed.glade:120
+#: data/ui/crossfeed.glade:119
 msgid "Cutoff"
 msgstr "Abgrenzung"
 
-#: data/ui/crossfeed.glade:153
+#: data/ui/crossfeed.glade:152
 msgid "Feed"
 msgstr "Speisung"
 
@@ -725,115 +723,132 @@ msgstr "Speisung"
 msgid "Crossfeed"
 msgstr "Crossfeed"
 
-#: data/ui/crystalizer.glade:115
+#: data/ui/crystalizer.glade:92
 msgid "Crystalizer"
 msgstr "Crystalizer"
 
-#: data/ui/crystalizer.glade:187
+#: data/ui/crystalizer.glade:137
 msgid "Aggressive Mode"
 msgstr "Aggressiver Modus"
 
-#: data/ui/crystalizer.glade:447
+#: data/ui/crystalizer.glade:395
 msgid "Loudness Range"
 msgstr "Lautstärkebereich"
 
-#: data/ui/crystalizer.glade:466
+#: data/ui/crystalizer.glade:414
 msgid "Before"
 msgstr "Vorher"
 
-#: data/ui/crystalizer.glade:479
+#: data/ui/crystalizer.glade:427
 msgid "After"
 msgstr "Nachher"
 
 #: data/ui/crystalizer_band.glade:27 data/ui/equalizer_band.glade:313
-#: data/ui/stereo_tools.glade:574 data/ui/stereo_tools.glade:633
+#: data/ui/stereo_tools.glade:575 data/ui/stereo_tools.glade:634
 msgid "Mute"
 msgstr "Stummschalten"
 
-#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:483
+#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:481
 #: data/ui/multiband_compressor.glade:855
-#: data/ui/multiband_compressor.glade:1233
-#: data/ui/multiband_compressor.glade:1611 data/ui/multiband_gate.glade:507
-#: data/ui/multiband_gate.glade:912 data/ui/multiband_gate.glade:1322
-#: data/ui/multiband_gate.glade:1732
+#: data/ui/multiband_compressor.glade:1235
+#: data/ui/multiband_compressor.glade:1615 data/ui/multiband_gate.glade:505
+#: data/ui/multiband_gate.glade:913 data/ui/multiband_gate.glade:1326
+#: data/ui/multiband_gate.glade:1739
 msgid "Bypass"
 msgstr "Umleitung"
 
-#: data/ui/deesser.glade:128
+#: data/ui/deesser.glade:127
 msgid "Deesser"
 msgstr "Deesser"
 
-#: data/ui/deesser.glade:216 data/ui/gate.glade:195
+#: data/ui/deesser.glade:213 data/ui/gate.glade:198
 msgid "Detection"
 msgstr "Erkennung"
 
-#: data/ui/deesser.glade:258
+#: data/ui/deesser.glade:255
 msgid "Wide"
 msgstr "Breit"
 
-#: data/ui/deesser.glade:259 data/ui/deesser.glade:288
+#: data/ui/deesser.glade:256
 msgid "Split"
 msgstr "Teilen"
 
-#: data/ui/deesser.glade:407
-msgid "Level"
+#: data/ui/deesser.glade:285
+#, fuzzy
+msgid "F1 Split"
+msgstr "Teilen"
+
+#: data/ui/deesser.glade:318
+#, fuzzy
+msgid "F1 Gain"
+msgstr "Verstärkung"
+
+#: data/ui/deesser.glade:352
+#, fuzzy
+msgid "F2 Peak"
+msgstr "Hochpunkt"
+
+#: data/ui/deesser.glade:406
+#, fuzzy
+msgid "F2 Level"
 msgstr "Ebene"
 
-#: data/ui/deesser.glade:420
-msgid "Peak Q"
+#: data/ui/deesser.glade:419
+#, fuzzy
+msgid "F2 Peak Q"
 msgstr "Höchstwert Q"
 
-#: data/ui/deesser.glade:452
+#: data/ui/deesser.glade:451
 msgid "Laxity"
 msgstr "Nachgiebigkeit"
 
-#: data/ui/deesser.glade:778 data/ui/multiband_gate.glade:767
-#: data/ui/multiband_gate.glade:1197 data/ui/multiband_gate.glade:1607
-#: data/ui/multiband_gate.glade:2017
+#: data/ui/deesser.glade:779 data/ui/multiband_gate.glade:767
+#: data/ui/multiband_gate.glade:1201 data/ui/multiband_gate.glade:1614
+#: data/ui/multiband_gate.glade:2027
 msgid "Reduction"
 msgstr "Senkung"
 
-#: data/ui/deesser.glade:791
+#: data/ui/deesser.glade:792
 msgid "Detected"
 msgstr "Erkannt"
 
-#: data/ui/delay.glade:91
+#: data/ui/delay.glade:92
 msgid "Delay"
 msgstr "Verzögerung"
 
-#: data/ui/equalizer.glade:44
+#: data/ui/equalizer.glade:45
 msgid "Equalizer"
 msgstr "Equalizer"
 
-#: data/ui/equalizer.glade:153
+#: data/ui/equalizer.glade:154
 msgid "Split Channels"
 msgstr "Kanäle trennen"
 
-#: data/ui/equalizer.glade:179
+#: data/ui/equalizer.glade:180
 msgid "IIR"
 msgstr "IIR"
 
-#: data/ui/equalizer.glade:180
+#: data/ui/equalizer.glade:181
 msgid "FIR"
 msgstr "FIR"
 
-#: data/ui/equalizer.glade:181
+#: data/ui/equalizer.glade:182
 msgid "FFT"
 msgstr "FFT"
 
-#: data/ui/equalizer.glade:211
+#: data/ui/equalizer.glade:212
 msgid "Bands"
 msgstr "Bereiche"
 
-#: data/ui/equalizer.glade:233
+#: data/ui/equalizer.glade:234
 msgid "Flat Response"
 msgstr "Glätten"
 
-#: data/ui/equalizer.glade:248
+#: data/ui/equalizer.glade:249
 msgid "Calculate Frequencies"
 msgstr "Frequenzen berechnen"
 
-#: data/ui/equalizer.glade:262
+#: data/ui/equalizer.glade:263
 #, fuzzy
 msgid "Import APO Presets"
 msgstr "Presets importieren"
@@ -862,7 +877,7 @@ msgstr "Tiefen-Kuhschwanzfilter"
 msgid "Notch"
 msgstr "Badewannenfilter"
 
-#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:314
+#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:315
 msgid "Resonance"
 msgstr "Resonanz"
 
@@ -906,12 +921,12 @@ msgstr "Qualität"
 msgid "Width"
 msgstr "Breite"
 
-#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:496
+#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:494
 #: data/ui/multiband_compressor.glade:868
-#: data/ui/multiband_compressor.glade:1246
-#: data/ui/multiband_compressor.glade:1624 data/ui/multiband_gate.glade:520
-#: data/ui/multiband_gate.glade:925 data/ui/multiband_gate.glade:1335
-#: data/ui/multiband_gate.glade:1745
+#: data/ui/multiband_compressor.glade:1248
+#: data/ui/multiband_compressor.glade:1628 data/ui/multiband_gate.glade:518
+#: data/ui/multiband_gate.glade:926 data/ui/multiband_gate.glade:1339
+#: data/ui/multiband_gate.glade:1752
 msgid "Solo"
 msgstr "Solo"
 
@@ -919,79 +934,79 @@ msgstr "Solo"
 msgid "Apply"
 msgstr "Anwenden"
 
-#: data/ui/exciter.glade:117
+#: data/ui/exciter.glade:118
 msgid "Exciter"
 msgstr "Exciter"
 
-#: data/ui/exciter.glade:384 data/ui/maximizer.glade:165
+#: data/ui/exciter.glade:384 data/ui/maximizer.glade:166
 msgid "Ceiling"
 msgstr "Grenze"
 
-#: data/ui/filter.glade:98
+#: data/ui/filter.glade:99
 msgid "Filter"
 msgstr "Filter"
 
-#: data/ui/filter.glade:147
+#: data/ui/filter.glade:148
 msgid "Muted"
 msgstr "Stumm"
 
-#: data/ui/filter.glade:159 data/ui/reverb.glade:233
+#: data/ui/filter.glade:160 data/ui/reverb.glade:234
 msgid "Disco"
 msgstr "Disco"
 
-#: data/ui/filter.glade:171
+#: data/ui/filter.glade:172
 msgid "Distant Headphones"
 msgstr "Entfernte Kopfhörer"
 
-#: data/ui/filter.glade:246
+#: data/ui/filter.glade:247
 msgid "12dB/oct Lowpass"
 msgstr "12dB/okt Tiefpass"
 
-#: data/ui/filter.glade:247
+#: data/ui/filter.glade:248
 msgid "24dB/oct Lowpass"
 msgstr "24dB/okt Tiefpass"
 
-#: data/ui/filter.glade:248
+#: data/ui/filter.glade:249
 msgid "36dB/oct Lowpass"
 msgstr "36dB/okt Tiefpass"
 
-#: data/ui/filter.glade:249
+#: data/ui/filter.glade:250
 msgid "12dB/oct Highpass"
 msgstr "12dB/okt Hochpass"
 
-#: data/ui/filter.glade:250
+#: data/ui/filter.glade:251
 msgid "24dB/oct Highpass"
 msgstr "24dB/okt Hochpass"
 
-#: data/ui/filter.glade:251
+#: data/ui/filter.glade:252
 msgid "36dB/oct Highpass"
 msgstr "36dB/okt Hochpass"
 
-#: data/ui/filter.glade:252
+#: data/ui/filter.glade:253
 msgid "6dB/oct Bandpass"
 msgstr "6dB/okt Bandpass"
 
-#: data/ui/filter.glade:253
+#: data/ui/filter.glade:254
 msgid "12dB/oct Bandpass"
 msgstr "12dB/okt Bandpass"
 
-#: data/ui/filter.glade:254
+#: data/ui/filter.glade:255
 msgid "18dB/oct Bandpass"
 msgstr "18dB/okt Bandpass"
 
-#: data/ui/filter.glade:255
+#: data/ui/filter.glade:256
 msgid "6dB/oct Bandreject"
 msgstr "6dB/okt Bandsperre"
 
-#: data/ui/filter.glade:256
+#: data/ui/filter.glade:257
 msgid "12dB/oct Bandreject"
 msgstr "12dB/okt Bandsperre"
 
-#: data/ui/filter.glade:257
+#: data/ui/filter.glade:258
 msgid "18dB/oct Bandreject"
 msgstr "18dB/okt Bandsperre"
 
-#: data/ui/filter.glade:349
+#: data/ui/filter.glade:350
 msgid "Inertia"
 msgstr "Trägheit"
 
@@ -1035,50 +1050,51 @@ msgstr "Alle Eingänge verarbeiten"
 msgid "Priority"
 msgstr "Priorität"
 
-#: data/ui/gate.glade:98
+#: data/ui/gate.glade:99
 msgid "Gate"
 msgstr "Gate"
 
-#: data/ui/gate.glade:209
+#: data/ui/gate.glade:240
+#, fuzzy
+msgid "Maximum Gain Reduction"
+msgstr "Amplitudenreduktion"
+
+#: data/ui/gate.glade:289
 msgid "Stereo Link"
 msgstr "Stereoverbindung"
 
-#: data/ui/gate.glade:222 data/ui/maximizer.glade:293
-msgid "Gain Reduction"
-msgstr "Amplitudenreduktion"
-
-#: data/ui/gate.glade:273
+#: data/ui/gate.glade:304
 msgid "Average"
 msgstr "Durchschnitt"
 
-#: data/ui/gate.glade:274
+#: data/ui/gate.glade:305
 msgid "Maximum"
 msgstr "Maximum"
 
-#: data/ui/gate.glade:525
+#: data/ui/gate.glade:578
 #, fuzzy
 msgid "Input Level"
 msgstr "Limiter"
 
-#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:811
-#: data/ui/multiband_gate.glade:1220 data/ui/multiband_gate.glade:1630
-#: data/ui/multiband_gate.glade:2040
+#: data/ui/gate.glade:797 data/ui/multiband_gate.glade:812
+#: data/ui/multiband_gate.glade:1224 data/ui/multiband_gate.glade:1637
+#: data/ui/multiband_gate.glade:2050
 msgid "Gating"
 msgstr "Gating"
 
-#: data/ui/limiter.glade:97 data/ui/webrtc.glade:421
+#: data/ui/limiter.glade:98 data/ui/webrtc.glade:422
 msgid "Limiter"
 msgstr "Limiter"
 
-#: data/ui/limiter.glade:176
+#: data/ui/limiter.glade:175
 msgid "Automatic Smoothing Control"
 msgstr ""
 
-#: data/ui/limiter.glade:190
+#: data/ui/limiter.glade:189
 msgid "Automatic Leveling"
 msgstr ""
 
-#: data/ui/limiter.glade:222
+#: data/ui/limiter.glade:221
 msgid "Input Gain"
 msgstr "Eingabeverstärkung"
 
@@ -1086,136 +1102,140 @@ msgstr "Eingabeverstärkung"
 msgid "Limit"
 msgstr "Grenze"
 
-#: data/ui/limiter.glade:358
+#: data/ui/limiter.glade:359
 msgid "Oversampling"
 msgstr "Überabtastung"
 
-#: data/ui/limiter.glade:411
+#: data/ui/limiter.glade:413
 #, fuzzy
 msgid "Output Gain"
 msgstr "Eingabeverstärkung"
 
-#: data/ui/limiter.glade:429
+#: data/ui/limiter.glade:431
 msgid "ASC"
 msgstr "ASC"
 
-#: data/ui/limiter.glade:584
+#: data/ui/limiter.glade:586
 msgid "Attenuation"
 msgstr "Dämpfung"
 
-#: data/ui/loudness.glade:91
+#: data/ui/loudness.glade:92
 msgid "Loudness Compensator"
 msgstr ""
 
-#: data/ui/loudness.glade:147
-msgid "Standard"
-msgstr ""
-
-#: data/ui/loudness.glade:161
-msgid "Flat"
-msgstr ""
-
-#: data/ui/loudness.glade:162
-msgid "ISO226-2003"
-msgstr ""
-
-#: data/ui/loudness.glade:163
-msgid "Fletcher-Munson"
-msgstr ""
-
-#: data/ui/loudness.glade:164
-msgid "Robinson-Dadson"
-msgstr ""
-
-#: data/ui/loudness.glade:174
-msgid "Reference Signal"
-msgstr ""
-
-#: data/ui/loudness.glade:199
+#: data/ui/loudness.glade:155
 #, fuzzy
 msgid "FFT Size"
 msgstr "Rahmengröße"
 
-#: data/ui/maximizer.glade:96
+#: data/ui/loudness.glade:205
+msgid "Standard"
+msgstr ""
+
+#: data/ui/loudness.glade:220
+msgid "Flat"
+msgstr ""
+
+#: data/ui/loudness.glade:221
+msgid "ISO226-2003"
+msgstr ""
+
+#: data/ui/loudness.glade:222
+msgid "Fletcher-Munson"
+msgstr ""
+
+#: data/ui/loudness.glade:223
+msgid "Robinson-Dadson"
+msgstr ""
+
+#: data/ui/loudness.glade:259
+msgid "Reference Signal"
+msgstr ""
+
+#: data/ui/maximizer.glade:97
 msgid "Maximizer"
 msgstr "Maximierer"
 
-#: data/ui/multiband_compressor.glade:140
+#: data/ui/maximizer.glade:296
+msgid "Gain Reduction"
+msgstr "Amplitudenreduktion"
+
+#: data/ui/multiband_compressor.glade:141
 msgid "Multiband Compressor"
 msgstr "Multiband-Kompressor"
 
-#: data/ui/multiband_compressor.glade:338 data/ui/multiband_gate.glade:362
+#: data/ui/multiband_compressor.glade:336 data/ui/multiband_gate.glade:360
 msgid "LR4"
 msgstr "LR4"
 
-#: data/ui/multiband_compressor.glade:339 data/ui/multiband_gate.glade:363
+#: data/ui/multiband_compressor.glade:337 data/ui/multiband_gate.glade:361
 msgid "LR8"
 msgstr "LR8"
 
-#: data/ui/multiband_compressor.glade:353 data/ui/multiband_gate.glade:377
+#: data/ui/multiband_compressor.glade:351 data/ui/multiband_gate.glade:375
 msgid "Split 1/2"
 msgstr "1/2 Teilen"
 
-#: data/ui/multiband_compressor.glade:366 data/ui/multiband_gate.glade:390
+#: data/ui/multiband_compressor.glade:364 data/ui/multiband_gate.glade:388
 msgid "Split 2/3"
 msgstr "2/3 Teilen"
 
-#: data/ui/multiband_compressor.glade:379 data/ui/multiband_gate.glade:403
+#: data/ui/multiband_compressor.glade:377 data/ui/multiband_gate.glade:401
 msgid "Split 3/4"
 msgstr "3/4 Teilen"
 
 #: data/ui/multiband_compressor.glade:754
-#: data/ui/multiband_compressor.glade:1131
-#: data/ui/multiband_compressor.glade:1509
-#: data/ui/multiband_compressor.glade:1887
+#: data/ui/multiband_compressor.glade:1133
+#: data/ui/multiband_compressor.glade:1513
+#: data/ui/multiband_compressor.glade:1893
 msgid "Compression"
 msgstr "Kompression"
 
-#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:894
+#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:895
 msgid "Sub Band"
 msgstr "Subband"
 
-#: data/ui/multiband_compressor.glade:1214 data/ui/multiband_gate.glade:1303
+#: data/ui/multiband_compressor.glade:1216 data/ui/multiband_gate.glade:1307
 msgid "Low Band"
 msgstr "Tiefband"
 
-#: data/ui/multiband_compressor.glade:1592 data/ui/multiband_gate.glade:1713
+#: data/ui/multiband_compressor.glade:1596 data/ui/multiband_gate.glade:1720
 msgid "Mid Band"
 msgstr "Mittelband"
 
-#: data/ui/multiband_compressor.glade:1970 data/ui/multiband_gate.glade:2123
+#: data/ui/multiband_compressor.glade:1976 data/ui/multiband_gate.glade:2133
 msgid "High Band"
 msgstr "Hochband"
 
-#: data/ui/multiband_gate.glade:140
+#: data/ui/multiband_gate.glade:141
 msgid "Multiband Gate"
 msgstr "Multiband Gate"
 
-#: data/ui/pitch.glade:103
+#: data/ui/pitch.glade:104
 msgid "Pitch"
 msgstr "Tonhöhe"
 
-#: data/ui/pitch.glade:178
+#: data/ui/pitch.glade:179
 msgid "Cents"
 msgstr "Cent"
 
-#: data/ui/pitch.glade:209
+#: data/ui/pitch.glade:210
 msgid "Semitones"
 msgstr "Halbtöne"
 
-#: data/ui/pitch.glade:240
+#: data/ui/pitch.glade:241
 msgid "Octaves"
 msgstr "Oktaven"
 
-#: data/ui/pitch.glade:271
+#: data/ui/pitch.glade:272
 msgid "Crispness"
 msgstr "Klarheit"
 
-#: data/ui/pitch.glade:311
+#: data/ui/pitch.glade:312
 msgid "Faster"
 msgstr "Schneller"
 
-#: data/ui/pitch.glade:325
+#: data/ui/pitch.glade:326
 msgid "Preserve Formant"
 msgstr "Formant erhalten"
 
@@ -1312,83 +1332,83 @@ msgstr "Pipeline-Eingang"
 msgid "Pipeline Output"
 msgstr "Pipeline-Ausgang"
 
-#: data/ui/reverb.glade:131
+#: data/ui/reverb.glade:132
 msgid "Reverberation"
 msgstr "Nachhall"
 
-#: data/ui/reverb.glade:181
+#: data/ui/reverb.glade:182
 msgid "Ambience"
 msgstr "Atmosphäre"
 
-#: data/ui/reverb.glade:194
+#: data/ui/reverb.glade:195
 msgid "Empty Walls"
 msgstr "Leere Wände"
 
-#: data/ui/reverb.glade:207
+#: data/ui/reverb.glade:208
 msgid "Room"
 msgstr "Raum"
 
-#: data/ui/reverb.glade:220
+#: data/ui/reverb.glade:221
 msgid "Large Empty Hall"
 msgstr "Große leere Halle"
 
-#: data/ui/reverb.glade:246
+#: data/ui/reverb.glade:247
 msgid "Large Occupied Hall"
 msgstr "Große besetzte Halle"
 
-#: data/ui/reverb.glade:361
+#: data/ui/reverb.glade:362
 msgid "Pre Delay"
 msgstr "Vorverzögerung"
 
-#: data/ui/reverb.glade:374
+#: data/ui/reverb.glade:375
 msgid "Decay Time"
 msgstr "Abklingzeit"
 
-#: data/ui/reverb.glade:439
+#: data/ui/reverb.glade:441
 msgid "Dry"
 msgstr "Trocken"
 
-#: data/ui/reverb.glade:471
+#: data/ui/reverb.glade:474
 msgid "Bass Cut"
 msgstr "Bassschnitt"
 
-#: data/ui/reverb.glade:522
+#: data/ui/reverb.glade:525
 msgid "Treble Cut"
 msgstr "Höhenschnitt"
 
-#: data/ui/reverb.glade:565
+#: data/ui/reverb.glade:568
 msgid "Diffusion"
 msgstr "Verbreitung"
 
-#: data/ui/reverb.glade:577
+#: data/ui/reverb.glade:580
 msgid "Room Size"
 msgstr "Raumgröße"
 
-#: data/ui/reverb.glade:590
+#: data/ui/reverb.glade:593
 msgid "Small"
 msgstr "Klein"
 
-#: data/ui/reverb.glade:591
+#: data/ui/reverb.glade:594
 msgid "Medium"
 msgstr "Mittel"
 
-#: data/ui/reverb.glade:592
+#: data/ui/reverb.glade:595
 msgid "Large"
 msgstr "Groß"
 
-#: data/ui/reverb.glade:593
+#: data/ui/reverb.glade:596
 msgid "Tunnel"
 msgstr "Tunnel"
 
-#: data/ui/reverb.glade:594
+#: data/ui/reverb.glade:597
 msgid "Large/smooth"
 msgstr "Groß/sanft"
 
-#: data/ui/reverb.glade:595
+#: data/ui/reverb.glade:598
 msgid "Experimental"
 msgstr "Experimentell"
 
-#: data/ui/reverb.glade:608
+#: data/ui/reverb.glade:611
 msgid "High Frequency Damping"
 msgstr "Hochfrequenz-Dämpfung"
 
@@ -1462,23 +1482,23 @@ msgstr "Höhe"
 msgid "Points"
 msgstr "Punkte"
 
-#: data/ui/stereo_tools.glade:109
+#: data/ui/stereo_tools.glade:110
 msgid "Stereo Tools"
 msgstr "Stereowerkzeuge"
 
-#: data/ui/stereo_tools.glade:231
+#: data/ui/stereo_tools.glade:230
 msgid "Softclip"
 msgstr "Softclip"
 
-#: data/ui/stereo_tools.glade:255 data/ui/stereo_tools.glade:671
+#: data/ui/stereo_tools.glade:254 data/ui/stereo_tools.glade:672
 msgid "Balance"
 msgstr "Balance"
 
-#: data/ui/stereo_tools.glade:287
+#: data/ui/stereo_tools.glade:286
 msgid "S/C Level"
 msgstr "S/C-Level"
 
-#: data/ui/stereo_tools.glade:345
+#: data/ui/stereo_tools.glade:344
 msgid "Side Level"
 msgstr "Seitenebene"
 
@@ -1486,144 +1506,144 @@ msgstr "Seitenebene"
 msgid "Side Balance"
 msgstr "Seitenausgleich"
 
-#: data/ui/stereo_tools.glade:428
+#: data/ui/stereo_tools.glade:429
 msgid "Middle Level"
 msgstr "Mittlere Ebene"
 
-#: data/ui/stereo_tools.glade:441
+#: data/ui/stereo_tools.glade:442
 msgid "Middle Panorama"
 msgstr "Mittleres Panorama"
 
-#: data/ui/stereo_tools.glade:499
+#: data/ui/stereo_tools.glade:500
 msgid "LR > LR (Stereo Default)"
 msgstr "LR > LR (Stereo Standard)"
 
-#: data/ui/stereo_tools.glade:500
+#: data/ui/stereo_tools.glade:501
 msgid "LR > MS (Stereo to Mid-Side)"
 msgstr "LR > MS (Stereo zu Mittelseite)"
 
-#: data/ui/stereo_tools.glade:501
+#: data/ui/stereo_tools.glade:502
 msgid "MS > LR (Mid-Side to Stereo)"
 msgstr "MS > LR (Mittelseite zu Stereo)"
 
-#: data/ui/stereo_tools.glade:502
+#: data/ui/stereo_tools.glade:503
 msgid "LR > LL (Mono Left Channel)"
 msgstr "LR > LL (Linker Monokanal)"
 
-#: data/ui/stereo_tools.glade:503
+#: data/ui/stereo_tools.glade:504
 msgid "LR > RR (Mono Right Channel)"
 msgstr "LR > RR (Rechter Monokanal)"
 
-#: data/ui/stereo_tools.glade:504
+#: data/ui/stereo_tools.glade:505
 msgid "LR > L+R (Mono Sum L+R)"
 msgstr "LR > L+R (Monosumme L+R)"
 
-#: data/ui/stereo_tools.glade:505
+#: data/ui/stereo_tools.glade:506
 msgid "LR > RL (Stereo Flip Channels)"
 msgstr "LR > RL (Stereo Kanäle tauschen)"
 
-#: data/ui/stereo_tools.glade:522
+#: data/ui/stereo_tools.glade:523
 msgid "Stereo Matrix"
 msgstr "Stereo-Matrix"
 
-#: data/ui/stereo_tools.glade:561 data/ui/stereo_tools.glade:602
+#: data/ui/stereo_tools.glade:562 data/ui/stereo_tools.glade:603
 msgid "Invert Phase"
 msgstr "Phase umkehren"
 
-#: data/ui/stereo_tools.glade:703
+#: data/ui/stereo_tools.glade:704
 msgid "Delay L/R"
 msgstr "Verzögerung L/R"
 
-#: data/ui/stereo_tools.glade:737
+#: data/ui/stereo_tools.glade:738
 msgid "Stereo Base"
 msgstr "Stereo Basis"
 
-#: data/ui/stereo_tools.glade:770
+#: data/ui/stereo_tools.glade:771
 msgid "Stereo Phase"
 msgstr "Stereo Phase"
 
-#: data/ui/webrtc.glade:97
+#: data/ui/webrtc.glade:98
 msgid "WebRTC"
 msgstr ""
 
-#: data/ui/webrtc.glade:163 data/ui/webrtc.glade:283 data/ui/webrtc.glade:353
-#: data/ui/webrtc.glade:523
+#: data/ui/webrtc.glade:164 data/ui/webrtc.glade:284 data/ui/webrtc.glade:354
+#: data/ui/webrtc.glade:524
 msgid "Enable"
 msgstr "Aktivieren"
 
-#: data/ui/webrtc.glade:184
+#: data/ui/webrtc.glade:185
 msgid "Extended Filter"
 msgstr "Erweiterter Filter"
 
-#: data/ui/webrtc.glade:197
+#: data/ui/webrtc.glade:198
 msgid "Delay Agnostic"
 msgstr "Verzögerungsagnostisch"
 
-#: data/ui/webrtc.glade:209
+#: data/ui/webrtc.glade:210
 msgid "High Pass Filter"
 msgstr "Hochpassfilter"
 
-#: data/ui/webrtc.glade:238 data/ui/webrtc.glade:306
+#: data/ui/webrtc.glade:239 data/ui/webrtc.glade:307
 msgid "Suppresion Level"
 msgstr "Unterdrückungsgrad"
 
-#: data/ui/webrtc.glade:251 data/ui/webrtc.glade:319 data/ui/webrtc.glade:575
+#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
 msgid "Low"
 msgstr "Tief"
 
-#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
+#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
 msgid "Moderate"
 msgstr "Mäßig"
 
-#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
+#: data/ui/webrtc.glade:254 data/ui/webrtc.glade:322 data/ui/webrtc.glade:578
 msgid "High"
 msgstr "Hoch"
 
-#: data/ui/webrtc.glade:270
+#: data/ui/webrtc.glade:271
 msgid "Echo Canceller"
 msgstr "Echounterdrückung"
 
-#: data/ui/webrtc.glade:322
+#: data/ui/webrtc.glade:323
 msgid "Very High"
 msgstr "Sehr hoch"
 
-#: data/ui/webrtc.glade:339
+#: data/ui/webrtc.glade:340
 msgid "Noise Suppressor"
 msgstr "Rauschunterdrücker"
 
-#: data/ui/webrtc.glade:389
+#: data/ui/webrtc.glade:390
 msgid "Adaptive Digital"
 msgstr "Adaptiv Digital"
 
-#: data/ui/webrtc.glade:390
+#: data/ui/webrtc.glade:391
 msgid "Fixed Digital"
 msgstr "Fixiert Digital"
 
-#: data/ui/webrtc.glade:407
+#: data/ui/webrtc.glade:408
 msgid "Gain Controller"
 msgstr "Verstärkungsregler"
 
-#: data/ui/webrtc.glade:445
+#: data/ui/webrtc.glade:446
 msgid "Target Level"
 msgstr "Zielwert"
 
-#: data/ui/webrtc.glade:475
+#: data/ui/webrtc.glade:476
 msgid "Maximum Gain"
 msgstr "Maximale Verstärkung"
 
-#: data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:549
 msgid "Detection Likelihood"
 msgstr "Erkennungswahrscheinlichkeit"
 
-#: data/ui/webrtc.glade:561
+#: data/ui/webrtc.glade:562
 msgid "Frame Size"
 msgstr "Rahmengröße"
 
-#: data/ui/webrtc.glade:574
+#: data/ui/webrtc.glade:575
 msgid "Very Low"
 msgstr "Sehr Tief"
 
-#: data/ui/webrtc.glade:611
+#: data/ui/webrtc.glade:612
 msgid "Voice Detector"
 msgstr "Spracherkennung"
 
@@ -1720,6 +1740,10 @@ msgstr "Allgemein"
 #: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr "PulseAudio"
+
+#, fuzzy
+#~ msgid "Gain Detection"
+#~ msgstr "Amplitudenreduktion"
 
 #~ msgid "Scale"
 #~ msgstr "Skala"

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-22 15:29+0200\n"
+"POT-Creation-Date: 2020-08-24 16:51+0200\n"
 "PO-Revision-Date: 2017-08-29 11:00+0200\n"
 "Last-Translator: Nathan Graule <solarliner@gmail.com>\n"
 "Language-Team: \n"
@@ -86,8 +86,8 @@ msgid "Input Limiter"
 msgstr "Limiteur d'entrée"
 
 #: data/com.github.wwmm.pulseeffects.appdata.xml.in:52
-#: data/ui/compressor.glade:111 data/ui/compressor.glade:494
-#: data/ui/webrtc.glade:509
+#: data/ui/compressor.glade:112 data/ui/compressor.glade:494
+#: data/ui/webrtc.glade:510
 msgid "Compressor"
 msgstr "Compresseur"
 
@@ -123,12 +123,12 @@ msgstr "Calibration"
 msgid "Format"
 msgstr ""
 
-#: data/ui/app_info.glade:75 data/ui/convolver.glade:283
+#: data/ui/app_info.glade:75 data/ui/convolver.glade:284
 msgid "Rate"
 msgstr ""
 
 #: data/ui/app_info.glade:102 data/ui/pulse_info.glade:238
-#: data/ui/stereo_tools.glade:653
+#: data/ui/stereo_tools.glade:654
 msgid "Channels"
 msgstr ""
 
@@ -167,7 +167,7 @@ msgstr "Signal de test"
 msgid "Global Bypass"
 msgstr ""
 
-#: data/ui/application.glade:170 data/ui/equalizer.glade:277
+#: data/ui/application.glade:170 data/ui/equalizer.glade:278
 #: data/ui/general_settings.glade:107
 msgid "Settings"
 msgstr "Paramètres"
@@ -176,174 +176,173 @@ msgstr "Paramètres"
 msgid "Help"
 msgstr ""
 
-#: data/ui/application.glade:215 data/ui/crossfeed.glade:49
-#: data/ui/equalizer.glade:333 data/ui/filter.glade:230
-#: data/ui/reverb.glade:310 src/presets_menu_ui.cpp:113
+#: data/ui/application.glade:215 data/ui/crossfeed.glade:48
+#: data/ui/equalizer.glade:334 data/ui/filter.glade:231
+#: data/ui/reverb.glade:311 src/presets_menu_ui.cpp:113
 #: src/presets_menu_ui.cpp:258 src/presets_menu_ui.cpp:275
 msgid "Presets"
 msgstr "Préréglage"
 
-#: data/ui/autogain.glade:91
+#: data/ui/autogain.glade:92
 #, fuzzy
 msgid "Auto Gain"
 msgstr "Gain d'entrée [dB]"
 
-#: data/ui/autogain.glade:171
+#: data/ui/autogain.glade:172
 msgid "Reset History"
 msgstr ""
 
-#: data/ui/autogain.glade:183
+#: data/ui/autogain.glade:184
 #, fuzzy
 msgid "Detect Silence"
 msgstr "Atténuation"
 
-#: data/ui/autogain.glade:195
+#: data/ui/autogain.glade:196
 msgid "Use Geometric Mean"
 msgstr ""
 
-#: data/ui/autogain.glade:233
+#: data/ui/autogain.glade:234
 #, fuzzy
 msgid "Target"
 msgstr "Cible [dB]"
 
-#: data/ui/autogain.glade:283 data/ui/autogain.glade:627
+#: data/ui/autogain.glade:286 data/ui/autogain.glade:631
 msgid "Momentary"
 msgstr ""
 
-#: data/ui/autogain.glade:298 data/ui/autogain.glade:640
+#: data/ui/autogain.glade:301 data/ui/autogain.glade:644
 msgid "Short Term"
 msgstr ""
 
-#: data/ui/autogain.glade:313 data/ui/autogain.glade:653
+#: data/ui/autogain.glade:316 data/ui/autogain.glade:657
 msgid "Integrated"
 msgstr ""
 
-#: data/ui/autogain.glade:388
+#: data/ui/autogain.glade:394
 msgid "Weights"
 msgstr ""
 
-#: data/ui/autogain.glade:428 data/ui/autogain.glade:917
-#: data/ui/bass_enhancer.glade:504 data/ui/compressor.glade:974
-#: data/ui/convolver.glade:504 data/ui/crossfeed.glade:200
-#: data/ui/crystalizer.glade:255 data/ui/deesser.glade:593
-#: data/ui/delay.glade:236 data/ui/equalizer.glade:543
-#: data/ui/exciter.glade:510 data/ui/filter.glade:396 data/ui/gate.glade:558
-#: data/ui/limiter.glade:483 data/ui/loudness.glade:259
-#: data/ui/loudness.glade:338 data/ui/maximizer.glade:265
-#: data/ui/multiband_compressor.glade:2000 data/ui/multiband_gate.glade:2153
-#: data/ui/pitch.glade:362 data/ui/presets_menu.glade:255
-#: data/ui/reverb.glade:658 data/ui/stereo_tools.glade:323
-#: data/ui/stereo_tools.glade:829 data/ui/webrtc.glade:650
+#: data/ui/autogain.glade:434 data/ui/autogain.glade:921
+#: data/ui/bass_enhancer.glade:506 data/ui/compressor.glade:977
+#: data/ui/convolver.glade:505 data/ui/crossfeed.glade:199
+#: data/ui/crystalizer.glade:205 data/ui/deesser.glade:594
+#: data/ui/delay.glade:237 data/ui/equalizer.glade:544
+#: data/ui/exciter.glade:510 data/ui/filter.glade:397 data/ui/gate.glade:611
+#: data/ui/limiter.glade:485 data/ui/loudness.glade:299
+#: data/ui/loudness.glade:380 data/ui/maximizer.glade:268
+#: data/ui/multiband_compressor.glade:2006 data/ui/multiband_gate.glade:2163
+#: data/ui/pitch.glade:363 data/ui/presets_menu.glade:255
+#: data/ui/reverb.glade:661 data/ui/stereo_tools.glade:322
+#: data/ui/stereo_tools.glade:830 data/ui/webrtc.glade:651
 msgid "Input"
 msgstr "Entrée"
 
-#: data/ui/autogain.glade:443 data/ui/autogain.glade:862
-#: data/ui/bass_enhancer.glade:536 data/ui/compressor.glade:988
-#: data/ui/convolver.glade:519 data/ui/crossfeed.glade:214
-#: data/ui/crystalizer.glade:270 data/ui/deesser.glade:607
-#: data/ui/delay.glade:250 data/ui/equalizer.glade:557
-#: data/ui/exciter.glade:542 data/ui/filter.glade:411 data/ui/gate.glade:572
-#: data/ui/limiter.glade:626 data/ui/loudness.glade:292
-#: data/ui/loudness.glade:352 data/ui/maximizer.glade:279
+#: data/ui/autogain.glade:449 data/ui/autogain.glade:866
+#: data/ui/bass_enhancer.glade:537 data/ui/compressor.glade:991
+#: data/ui/convolver.glade:520 data/ui/crossfeed.glade:213
+#: data/ui/crystalizer.glade:220 data/ui/deesser.glade:608
+#: data/ui/delay.glade:251 data/ui/equalizer.glade:558
+#: data/ui/exciter.glade:541 data/ui/filter.glade:412 data/ui/gate.glade:625
+#: data/ui/limiter.glade:628 data/ui/loudness.glade:333
+#: data/ui/loudness.glade:394 data/ui/maximizer.glade:282
 #: data/ui/multiband_compressor.glade:794
-#: data/ui/multiband_compressor.glade:1171
-#: data/ui/multiband_compressor.glade:1549
-#: data/ui/multiband_compressor.glade:1927
-#: data/ui/multiband_compressor.glade:2015 data/ui/multiband_gate.glade:851
-#: data/ui/multiband_gate.glade:1260 data/ui/multiband_gate.glade:1670
-#: data/ui/multiband_gate.glade:2080 data/ui/multiband_gate.glade:2168
-#: data/ui/pitch.glade:376 data/ui/presets_menu.glade:146
-#: data/ui/reverb.glade:673 data/ui/stereo_tools.glade:800
-#: data/ui/stereo_tools.glade:843 data/ui/webrtc.glade:664
+#: data/ui/multiband_compressor.glade:1173
+#: data/ui/multiband_compressor.glade:1553
+#: data/ui/multiband_compressor.glade:1933
+#: data/ui/multiband_compressor.glade:2021 data/ui/multiband_gate.glade:852
+#: data/ui/multiband_gate.glade:1264 data/ui/multiband_gate.glade:1677
+#: data/ui/multiband_gate.glade:2090 data/ui/multiband_gate.glade:2178
+#: data/ui/pitch.glade:377 data/ui/presets_menu.glade:146
+#: data/ui/reverb.glade:676 data/ui/stereo_tools.glade:801
+#: data/ui/stereo_tools.glade:844 data/ui/webrtc.glade:665
 msgid "Output"
 msgstr "Sortie"
 
-#: data/ui/autogain.glade:744
+#: data/ui/autogain.glade:748
 msgid "Relative"
 msgstr ""
 
-#: data/ui/autogain.glade:757 data/ui/compressor.glade:1154
-#: data/ui/deesser.glade:321
+#: data/ui/autogain.glade:761 data/ui/compressor.glade:1157
 #, fuzzy
 msgid "Gain"
 msgstr "Gain d'entrée [dB]"
 
-#: data/ui/autogain.glade:823
+#: data/ui/autogain.glade:827
 msgid "Loudness"
 msgstr ""
 
-#: data/ui/autogain.glade:876
+#: data/ui/autogain.glade:880
 msgid "Range"
 msgstr ""
 
-#: data/ui/autogain.glade:945 data/ui/bass_enhancer.glade:655
-#: data/ui/compressor.glade:1299 data/ui/convolver.glade:703
-#: data/ui/crossfeed.glade:395 data/ui/crystalizer.glade:566
-#: data/ui/deesser.glade:898 data/ui/delay.glade:434
-#: data/ui/equalizer.glade:743 data/ui/equalizer_band.glade:182
-#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:661
-#: data/ui/filter.glade:595 data/ui/general_settings.glade:116
-#: data/ui/gate.glade:809 data/ui/limiter.glade:733 data/ui/loudness.glade:573
-#: data/ui/maximizer.glade:516 data/ui/multiband_compressor.glade:2199
-#: data/ui/multiband_gate.glade:2352 data/ui/pitch.glade:560
-#: data/ui/reverb.glade:857 data/ui/stereo_tools.glade:1029
-#: data/ui/webrtc.glade:814
+#: data/ui/autogain.glade:949 data/ui/bass_enhancer.glade:650
+#: data/ui/compressor.glade:1300 data/ui/convolver.glade:702
+#: data/ui/crossfeed.glade:394 data/ui/crystalizer.glade:514
+#: data/ui/deesser.glade:899 data/ui/delay.glade:433
+#: data/ui/equalizer.glade:744 data/ui/equalizer_band.glade:182
+#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:654
+#: data/ui/filter.glade:594 data/ui/general_settings.glade:116
+#: data/ui/gate.glade:862 data/ui/limiter.glade:735 data/ui/loudness.glade:615
+#: data/ui/maximizer.glade:519 data/ui/multiband_compressor.glade:2203
+#: data/ui/multiband_gate.glade:2360 data/ui/pitch.glade:559
+#: data/ui/reverb.glade:858 data/ui/stereo_tools.glade:1028
+#: data/ui/webrtc.glade:815
 msgid "Reset"
 msgstr "Remettre à zéro"
 
-#: data/ui/autogain.glade:969
+#: data/ui/autogain.glade:973
 msgid "Based on"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:117
+#: data/ui/bass_enhancer.glade:118
 #, fuzzy
 msgid "Bass Enhancer"
 msgstr "Amélioration audio"
 
-#: data/ui/bass_enhancer.glade:169 data/ui/compressor.glade:506
-#: data/ui/deesser.glade:188 data/ui/exciter.glade:171
+#: data/ui/bass_enhancer.glade:170 data/ui/compressor.glade:506
+#: data/ui/deesser.glade:185 data/ui/exciter.glade:170
 msgid "Listen"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:210 data/ui/exciter.glade:213
+#: data/ui/bass_enhancer.glade:211 data/ui/exciter.glade:212
 msgid "3rd"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:222 data/ui/exciter.glade:225
+#: data/ui/bass_enhancer.glade:223 data/ui/exciter.glade:224
 msgid "2nd"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:234 data/ui/exciter.glade:237
+#: data/ui/bass_enhancer.glade:235 data/ui/exciter.glade:236
 msgid "Blend Harmonics"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:266 data/ui/exciter.glade:271
-#: data/ui/reverb.glade:407
+#: data/ui/bass_enhancer.glade:267 data/ui/exciter.glade:270
+#: data/ui/reverb.glade:408
 msgid "Amount"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:278 data/ui/bass_enhancer.glade:411
-#: data/ui/exciter.glade:284 data/ui/exciter.glade:417
+#: data/ui/bass_enhancer.glade:279 data/ui/bass_enhancer.glade:413
+#: data/ui/exciter.glade:283 data/ui/exciter.glade:417
 msgid "Harmonics"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:290 data/ui/exciter.glade:297
+#: data/ui/bass_enhancer.glade:291 data/ui/exciter.glade:296
 msgid "Scope"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:379
+#: data/ui/bass_enhancer.glade:381
 msgid "Floor"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:679 data/ui/compressor.glade:1323
-#: data/ui/crossfeed.glade:419 data/ui/deesser.glade:922
-#: data/ui/delay.glade:458 data/ui/equalizer.glade:767
-#: data/ui/exciter.glade:685 data/ui/filter.glade:619 data/ui/gate.glade:833
-#: data/ui/limiter.glade:757 data/ui/loudness.glade:542
-#: data/ui/maximizer.glade:540 data/ui/multiband_compressor.glade:2223
-#: data/ui/multiband_gate.glade:2376 data/ui/pitch.glade:584
-#: data/ui/reverb.glade:881 data/ui/stereo_tools.glade:1053
-#: data/ui/webrtc.glade:838
+#: data/ui/bass_enhancer.glade:674 data/ui/compressor.glade:1324
+#: data/ui/crossfeed.glade:418 data/ui/deesser.glade:923
+#: data/ui/delay.glade:457 data/ui/equalizer.glade:768
+#: data/ui/exciter.glade:678 data/ui/filter.glade:618 data/ui/gate.glade:886
+#: data/ui/limiter.glade:759 data/ui/loudness.glade:584
+#: data/ui/maximizer.glade:543 data/ui/multiband_compressor.glade:2227
+#: data/ui/multiband_gate.glade:2384 data/ui/pitch.glade:583
+#: data/ui/reverb.glade:882 data/ui/stereo_tools.glade:1052
+#: data/ui/webrtc.glade:839
 msgid "Provided by"
 msgstr ""
 
@@ -381,146 +380,146 @@ msgstr "Limiteur d'entrée"
 msgid "Show Blocklisted Apps in Main Tab"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:32 data/ui/equalizer_band.glade:152
-#: data/ui/filter.glade:280
+#: data/ui/calibration_signals.glade:30 data/ui/equalizer_band.glade:152
+#: data/ui/filter.glade:281
 #, fuzzy
 msgid "Frequency"
 msgstr "Fréquence [Hz]"
 
-#: data/ui/calibration_signals.glade:64
+#: data/ui/calibration_signals.glade:62
 msgid "Volume"
 msgstr "Volume"
 
-#: data/ui/calibration_signals.glade:108
+#: data/ui/calibration_signals.glade:106
 msgid "Sine"
 msgstr "Sinusoïde"
 
-#: data/ui/calibration_signals.glade:109
+#: data/ui/calibration_signals.glade:107
 msgid "Square"
 msgstr "Carrée"
 
-#: data/ui/calibration_signals.glade:110
+#: data/ui/calibration_signals.glade:108
 msgid "Saw"
 msgstr "Dent de scie"
 
-#: data/ui/calibration_signals.glade:111
+#: data/ui/calibration_signals.glade:109
 msgid "Triangle"
 msgstr "Triangle"
 
-#: data/ui/calibration_signals.glade:112
+#: data/ui/calibration_signals.glade:110
 #, fuzzy
 msgid "Silence"
 msgstr "Silence"
 
-#: data/ui/calibration_signals.glade:113
+#: data/ui/calibration_signals.glade:111
 msgid "White Noise"
 msgstr "Bruit blanc"
 
-#: data/ui/calibration_signals.glade:114
+#: data/ui/calibration_signals.glade:112
 msgid "Pink Noise"
 msgstr "Bruit rose"
 
-#: data/ui/calibration_signals.glade:115
+#: data/ui/calibration_signals.glade:113
 msgid "Sine Table"
 msgstr "Table sinusoïdale"
 
-#: data/ui/calibration_signals.glade:116
+#: data/ui/calibration_signals.glade:114
 msgid "Ticks"
 msgstr "Ticks"
 
-#: data/ui/calibration_signals.glade:117
+#: data/ui/calibration_signals.glade:115
 msgid "Gaussian Noise"
 msgstr "Bruit Gaussien"
 
-#: data/ui/calibration_signals.glade:118
+#: data/ui/calibration_signals.glade:116
 msgid "Red Noise"
 msgstr "Bruit rouge"
 
-#: data/ui/calibration_signals.glade:119
+#: data/ui/calibration_signals.glade:117
 msgid "Blue Noise"
 msgstr "Bruit bleu"
 
-#: data/ui/calibration_signals.glade:120
+#: data/ui/calibration_signals.glade:118
 msgid "Violet Noise"
 msgstr "Bruit violet"
 
-#: data/ui/calibration_mic.glade:29
+#: data/ui/calibration_mic.glade:28
 #, fuzzy
 msgid "Window"
 msgstr "Fenêtre [s]"
 
-#: data/ui/calibration_mic.glade:70
+#: data/ui/calibration_mic.glade:69
 msgid "Measure Noise"
 msgstr "Mesurer le bruit"
 
-#: data/ui/calibration_mic.glade:99
+#: data/ui/calibration_mic.glade:98
 msgid "Subtract Noise"
 msgstr "Enlever le bruit"
 
-#: data/ui/compressor.glade:292 data/ui/deesser.glade:483
-#: data/ui/gate.glade:370 data/ui/maximizer.glade:152
-#: data/ui/multiband_compressor.glade:609
+#: data/ui/compressor.glade:290 data/ui/deesser.glade:482
+#: data/ui/gate.glade:413 data/ui/maximizer.glade:153
+#: data/ui/multiband_compressor.glade:607
 #: data/ui/multiband_compressor.glade:983
-#: data/ui/multiband_compressor.glade:1361
-#: data/ui/multiband_compressor.glade:1739 data/ui/multiband_gate.glade:633
-#: data/ui/multiband_gate.glade:1040 data/ui/multiband_gate.glade:1450
-#: data/ui/multiband_gate.glade:1860
+#: data/ui/multiband_compressor.glade:1363
+#: data/ui/multiband_compressor.glade:1743 data/ui/multiband_gate.glade:631
+#: data/ui/multiband_gate.glade:1041 data/ui/multiband_gate.glade:1454
+#: data/ui/multiband_gate.glade:1867
 #, fuzzy
 msgid "Threshold"
 msgstr "Seuil [dB]"
 
-#: data/ui/compressor.glade:325 data/ui/deesser.glade:516
-#: data/ui/gate.glade:403 data/ui/multiband_compressor.glade:642
-#: data/ui/multiband_compressor.glade:1017
-#: data/ui/multiband_compressor.glade:1395
-#: data/ui/multiband_compressor.glade:1773 data/ui/multiband_gate.glade:666
-#: data/ui/multiband_gate.glade:1074 data/ui/multiband_gate.glade:1484
-#: data/ui/multiband_gate.glade:1894
+#: data/ui/compressor.glade:324 data/ui/deesser.glade:516
+#: data/ui/gate.glade:449 data/ui/multiband_compressor.glade:641
+#: data/ui/multiband_compressor.glade:1018
+#: data/ui/multiband_compressor.glade:1398
+#: data/ui/multiband_compressor.glade:1778 data/ui/multiband_gate.glade:665
+#: data/ui/multiband_gate.glade:1076 data/ui/multiband_gate.glade:1489
+#: data/ui/multiband_gate.glade:1902
 #, fuzzy
 msgid "Ratio"
 msgstr "Ratio [n:1]"
 
-#: data/ui/compressor.glade:357 data/ui/gate.glade:435
-#: data/ui/multiband_compressor.glade:674
-#: data/ui/multiband_compressor.glade:1050
-#: data/ui/multiband_compressor.glade:1428
-#: data/ui/multiband_compressor.glade:1806 data/ui/multiband_gate.glade:698
-#: data/ui/multiband_gate.glade:1107 data/ui/multiband_gate.glade:1517
-#: data/ui/multiband_gate.glade:1927
+#: data/ui/compressor.glade:356 data/ui/gate.glade:483
+#: data/ui/multiband_compressor.glade:673
+#: data/ui/multiband_compressor.glade:1051
+#: data/ui/multiband_compressor.glade:1431
+#: data/ui/multiband_compressor.glade:1811 data/ui/multiband_gate.glade:697
+#: data/ui/multiband_gate.glade:1109 data/ui/multiband_gate.glade:1522
+#: data/ui/multiband_gate.glade:1935
 #, fuzzy
 msgid "Knee"
 msgstr "Coudée [dB]"
 
-#: data/ui/compressor.glade:391 data/ui/deesser.glade:547
-#: data/ui/gate.glade:469 data/ui/multiband_compressor.glade:708
-#: data/ui/multiband_compressor.glade:1085
-#: data/ui/multiband_compressor.glade:1463
-#: data/ui/multiband_compressor.glade:1841 data/ui/multiband_gate.glade:732
-#: data/ui/multiband_gate.glade:1142 data/ui/multiband_gate.glade:1552
-#: data/ui/multiband_gate.glade:1962
+#: data/ui/compressor.glade:390 data/ui/deesser.glade:547
+#: data/ui/gate.glade:519 data/ui/multiband_compressor.glade:707
+#: data/ui/multiband_compressor.glade:1086
+#: data/ui/multiband_compressor.glade:1466
+#: data/ui/multiband_compressor.glade:1846 data/ui/multiband_gate.glade:731
+#: data/ui/multiband_gate.glade:1144 data/ui/multiband_gate.glade:1557
+#: data/ui/multiband_gate.glade:1970
 #, fuzzy
 msgid "Makeup"
 msgstr "Gain de remise [dB]"
 
-#: data/ui/compressor.glade:425 data/ui/gate.glade:336
-#: data/ui/limiter.glade:310 data/ui/maximizer.glade:178
-#: data/ui/multiband_compressor.glade:575
+#: data/ui/compressor.glade:425 data/ui/gate.glade:377
+#: data/ui/limiter.glade:311 data/ui/maximizer.glade:179
+#: data/ui/multiband_compressor.glade:573
 #: data/ui/multiband_compressor.glade:948
-#: data/ui/multiband_compressor.glade:1326
-#: data/ui/multiband_compressor.glade:1704 data/ui/multiband_gate.glade:599
-#: data/ui/multiband_gate.glade:1005 data/ui/multiband_gate.glade:1415
-#: data/ui/multiband_gate.glade:1825
+#: data/ui/multiband_compressor.glade:1328
+#: data/ui/multiband_compressor.glade:1708 data/ui/multiband_gate.glade:597
+#: data/ui/multiband_gate.glade:1006 data/ui/multiband_gate.glade:1419
+#: data/ui/multiband_gate.glade:1832
 #, fuzzy
 msgid "Release"
 msgstr "Relâche [s]"
 
-#: data/ui/compressor.glade:438 data/ui/gate.glade:302
-#: data/ui/multiband_compressor.glade:541
+#: data/ui/compressor.glade:438 data/ui/gate.glade:341
+#: data/ui/multiband_compressor.glade:539
 #: data/ui/multiband_compressor.glade:913
-#: data/ui/multiband_compressor.glade:1291
-#: data/ui/multiband_compressor.glade:1669 data/ui/multiband_gate.glade:565
-#: data/ui/multiband_gate.glade:970 data/ui/multiband_gate.glade:1380
-#: data/ui/multiband_gate.glade:1790
+#: data/ui/multiband_compressor.glade:1293
+#: data/ui/multiband_compressor.glade:1673 data/ui/multiband_gate.glade:563
+#: data/ui/multiband_gate.glade:971 data/ui/multiband_gate.glade:1384
+#: data/ui/multiband_gate.glade:1797
 #, fuzzy
 msgid "Attack"
 msgstr "Attaque [ms]"
@@ -538,219 +537,218 @@ msgstr ""
 msgid "Compression Mode"
 msgstr "Aucune compression"
 
-#: data/ui/compressor.glade:551
+#: data/ui/compressor.glade:552
 #, fuzzy
 msgid "Pre-amplification"
 msgstr "Calibration"
 
-#: data/ui/compressor.glade:585
+#: data/ui/compressor.glade:586
 msgid "Reactivity"
 msgstr ""
 
-#: data/ui/compressor.glade:619 data/ui/limiter.glade:323
+#: data/ui/compressor.glade:620 data/ui/limiter.glade:324
 msgid "Lookahead"
 msgstr ""
 
-#: data/ui/compressor.glade:632
+#: data/ui/compressor.glade:633
 msgid "Feed-forward"
 msgstr ""
 
-#: data/ui/compressor.glade:633
+#: data/ui/compressor.glade:634
 #, fuzzy
 msgid "Feed-back"
 msgstr "Coudée [dB]"
 
-#: data/ui/compressor.glade:647 data/ui/equalizer_band.glade:48
+#: data/ui/compressor.glade:648 data/ui/equalizer_band.glade:48
 msgid "Type"
 msgstr ""
 
-#: data/ui/compressor.glade:661 data/ui/deesser.glade:244
-#: data/ui/deesser.glade:354 data/ui/gate.glade:257
-#: data/ui/multiband_compressor.glade:514
+#: data/ui/compressor.glade:662 data/ui/deesser.glade:241
+#: data/ui/gate.glade:213 data/ui/multiband_compressor.glade:512
 #: data/ui/multiband_compressor.glade:886
-#: data/ui/multiband_compressor.glade:1264
-#: data/ui/multiband_compressor.glade:1642 data/ui/multiband_gate.glade:538
-#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1353
-#: data/ui/multiband_gate.glade:1763
+#: data/ui/multiband_compressor.glade:1266
+#: data/ui/multiband_compressor.glade:1646 data/ui/multiband_gate.glade:536
+#: data/ui/multiband_gate.glade:944 data/ui/multiband_gate.glade:1357
+#: data/ui/multiband_gate.glade:1770
 msgid "Peak"
 msgstr ""
 
-#: data/ui/compressor.glade:662 data/ui/deesser.glade:243
-#: data/ui/gate.glade:256 data/ui/multiband_compressor.glade:513
+#: data/ui/compressor.glade:663 data/ui/deesser.glade:240
+#: data/ui/gate.glade:212 data/ui/multiband_compressor.glade:511
 #: data/ui/multiband_compressor.glade:885
-#: data/ui/multiband_compressor.glade:1263
-#: data/ui/multiband_compressor.glade:1641 data/ui/multiband_gate.glade:537
-#: data/ui/multiband_gate.glade:942 data/ui/multiband_gate.glade:1352
-#: data/ui/multiband_gate.glade:1762
+#: data/ui/multiband_compressor.glade:1265
+#: data/ui/multiband_compressor.glade:1645 data/ui/multiband_gate.glade:535
+#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1356
+#: data/ui/multiband_gate.glade:1769
 msgid "RMS"
 msgstr ""
 
-#: data/ui/compressor.glade:663
+#: data/ui/compressor.glade:664
 #, fuzzy
 msgid "Low-Pass"
 msgstr "Passe-bas"
 
-#: data/ui/compressor.glade:664
+#: data/ui/compressor.glade:665
 msgid "Uniform"
 msgstr ""
 
-#: data/ui/compressor.glade:678 data/ui/deesser.glade:230
-#: data/ui/equalizer.glade:224 data/ui/equalizer_band.glade:79
-#: data/ui/multiband_compressor.glade:324 data/ui/multiband_gate.glade:348
-#: data/ui/stereo_tools.glade:485 data/ui/webrtc.glade:376
+#: data/ui/compressor.glade:679 data/ui/deesser.glade:227
+#: data/ui/equalizer.glade:225 data/ui/equalizer_band.glade:79
+#: data/ui/multiband_compressor.glade:322 data/ui/multiband_gate.glade:346
+#: data/ui/stereo_tools.glade:486 data/ui/webrtc.glade:377
 msgid "Mode"
 msgstr ""
 
-#: data/ui/compressor.glade:692
+#: data/ui/compressor.glade:693
 #, fuzzy
 msgid "Middle"
 msgstr "Niveau"
 
-#: data/ui/compressor.glade:693
+#: data/ui/compressor.glade:694
 #, fuzzy
 msgid "Side"
 msgstr "Gain d'entrée [dB]"
 
-#: data/ui/compressor.glade:694 data/ui/delay.glade:157
-#: data/ui/equalizer.glade:474 data/ui/stereo_tools.glade:548
+#: data/ui/compressor.glade:695 data/ui/delay.glade:158
+#: data/ui/equalizer.glade:475 data/ui/stereo_tools.glade:549
 msgid "Left"
 msgstr ""
 
-#: data/ui/compressor.glade:695 data/ui/delay.glade:189
-#: data/ui/equalizer.glade:515 data/ui/stereo_tools.glade:620
+#: data/ui/compressor.glade:696 data/ui/delay.glade:190
+#: data/ui/equalizer.glade:516 data/ui/stereo_tools.glade:621
 msgid "Right"
 msgstr ""
 
-#: data/ui/compressor.glade:709
+#: data/ui/compressor.glade:710
 msgid "Source"
 msgstr ""
 
-#: data/ui/compressor.glade:725 data/ui/compressor.glade:1167
+#: data/ui/compressor.glade:726 data/ui/compressor.glade:1170
 #, fuzzy
 msgid "Sidechain"
 msgstr "Gain d'entrée [dB]"
 
-#: data/ui/compressor.glade:821
+#: data/ui/compressor.glade:824
 msgid "Relative Release Threshold"
 msgstr ""
 
-#: data/ui/compressor.glade:832
+#: data/ui/compressor.glade:835
 #, fuzzy
 msgid "Boost Threshold"
 msgstr "Seuil [dB]"
 
-#: data/ui/compressor.glade:843
+#: data/ui/compressor.glade:846
 #, fuzzy
 msgid "High-pass Frequency"
 msgstr "Recentrer fréquences"
 
-#: data/ui/compressor.glade:854
+#: data/ui/compressor.glade:857
 #, fuzzy
 msgid "Low-pass Frequency"
 msgstr "Recentrer fréquences"
 
-#: data/ui/compressor.glade:865
+#: data/ui/compressor.glade:868
 #, fuzzy
 msgid "High-pass Filter Mode"
 msgstr "Passe-haut"
 
-#: data/ui/compressor.glade:876
+#: data/ui/compressor.glade:879
 msgid "Low-pass Filter Mode"
 msgstr ""
 
-#: data/ui/compressor.glade:889 data/ui/compressor.glade:906
+#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
 #: data/ui/equalizer_band.glade:60
 msgid "Off"
 msgstr ""
 
-#: data/ui/compressor.glade:890 data/ui/compressor.glade:907
+#: data/ui/compressor.glade:893 data/ui/compressor.glade:910
 msgid "12 dB/oct"
 msgstr ""
 
-#: data/ui/compressor.glade:891 data/ui/compressor.glade:908
+#: data/ui/compressor.glade:894 data/ui/compressor.glade:911
 msgid "24 dB/oct"
 msgstr ""
 
-#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
+#: data/ui/compressor.glade:895 data/ui/compressor.glade:912
 msgid "36 dB/oct"
 msgstr ""
 
-#: data/ui/compressor.glade:932
+#: data/ui/compressor.glade:935
 #, fuzzy
 msgid "Advanced"
 msgstr "Paramètres"
 
-#: data/ui/compressor.glade:1243
+#: data/ui/compressor.glade:1244
 msgid "Curve"
 msgstr ""
 
-#: data/ui/convolver.glade:91
+#: data/ui/convolver.glade:92
 msgid "Convolver"
 msgstr ""
 
-#: data/ui/convolver.glade:125
+#: data/ui/convolver.glade:126
 #, fuzzy
 msgid "Import Impulse"
 msgstr "Réponse plane"
 
-#: data/ui/convolver.glade:129
+#: data/ui/convolver.glade:130
 msgid "Import Impulse Response File"
 msgstr ""
 
-#: data/ui/convolver.glade:247
+#: data/ui/convolver.glade:248
 msgid "L"
 msgstr "L"
 
-#: data/ui/convolver.glade:261
+#: data/ui/convolver.glade:262
 msgid "R"
 msgstr "R"
 
-#: data/ui/convolver.glade:324
+#: data/ui/convolver.glade:325
 #, fuzzy
 msgid "Duration"
 msgstr "Calibration"
 
-#: data/ui/convolver.glade:335
+#: data/ui/convolver.glade:336
 msgid "Samples"
 msgstr ""
 
-#: data/ui/convolver.glade:367 src/convolver_ui.cpp:283
+#: data/ui/convolver.glade:368 src/convolver_ui.cpp:283
 #, fuzzy
 msgid "Impulse Response"
 msgstr "Réponse plane"
 
-#: data/ui/convolver.glade:389
+#: data/ui/convolver.glade:390
 #, fuzzy
 msgid "Select the impulse Response File"
 msgstr "Réponse plane"
 
-#: data/ui/convolver.glade:409 src/spectrum_settings_ui.cpp:176
+#: data/ui/convolver.glade:410 src/spectrum_settings_ui.cpp:176
 msgid "Spectrum"
 msgstr "Spectromètre"
 
-#: data/ui/convolver.glade:450
+#: data/ui/convolver.glade:451
 #, fuzzy
 msgid "Stereo Width"
 msgstr "Amélioration audio"
 
-#: data/ui/crossfeed.glade:63
+#: data/ui/crossfeed.glade:62
 msgid "Jmeier"
 msgstr ""
 
-#: data/ui/crossfeed.glade:76 data/ui/filter.glade:183 data/ui/reverb.glade:259
+#: data/ui/crossfeed.glade:75 data/ui/filter.glade:184 data/ui/reverb.glade:260
 msgid "Default"
 msgstr ""
 
-#: data/ui/crossfeed.glade:89
+#: data/ui/crossfeed.glade:88
 msgid "Cmoy"
 msgstr ""
 
-#: data/ui/crossfeed.glade:120
+#: data/ui/crossfeed.glade:119
 #, fuzzy
 msgid "Cutoff"
 msgstr "Coupure [Hz]"
 
-#: data/ui/crossfeed.glade:153
+#: data/ui/crossfeed.glade:152
 #, fuzzy
 msgid "Feed"
 msgstr "Coudée [dB]"
@@ -759,121 +757,135 @@ msgstr "Coudée [dB]"
 msgid "Crossfeed"
 msgstr ""
 
-#: data/ui/crystalizer.glade:115
+#: data/ui/crystalizer.glade:92
 #, fuzzy
 msgid "Crystalizer"
 msgstr "Égaliseur"
 
-#: data/ui/crystalizer.glade:187
+#: data/ui/crystalizer.glade:137
 #, fuzzy
 msgid "Aggressive Mode"
 msgstr "Aucune compression"
 
-#: data/ui/crystalizer.glade:447
+#: data/ui/crystalizer.glade:395
 msgid "Loudness Range"
 msgstr ""
 
-#: data/ui/crystalizer.glade:466
+#: data/ui/crystalizer.glade:414
 msgid "Before"
 msgstr ""
 
-#: data/ui/crystalizer.glade:479
+#: data/ui/crystalizer.glade:427
 msgid "After"
 msgstr ""
 
 #: data/ui/crystalizer_band.glade:27 data/ui/equalizer_band.glade:313
-#: data/ui/stereo_tools.glade:574 data/ui/stereo_tools.glade:633
+#: data/ui/stereo_tools.glade:575 data/ui/stereo_tools.glade:634
 msgid "Mute"
 msgstr ""
 
-#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:483
+#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:481
 #: data/ui/multiband_compressor.glade:855
-#: data/ui/multiband_compressor.glade:1233
-#: data/ui/multiband_compressor.glade:1611 data/ui/multiband_gate.glade:507
-#: data/ui/multiband_gate.glade:912 data/ui/multiband_gate.glade:1322
-#: data/ui/multiband_gate.glade:1732
+#: data/ui/multiband_compressor.glade:1235
+#: data/ui/multiband_compressor.glade:1615 data/ui/multiband_gate.glade:505
+#: data/ui/multiband_gate.glade:913 data/ui/multiband_gate.glade:1326
+#: data/ui/multiband_gate.glade:1739
 msgid "Bypass"
 msgstr ""
 
-#: data/ui/deesser.glade:128
+#: data/ui/deesser.glade:127
 msgid "Deesser"
 msgstr ""
 
-#: data/ui/deesser.glade:216 data/ui/gate.glade:195
+#: data/ui/deesser.glade:213 data/ui/gate.glade:198
 #, fuzzy
 msgid "Detection"
 msgstr "Atténuation"
 
-#: data/ui/deesser.glade:258
+#: data/ui/deesser.glade:255
 msgid "Wide"
 msgstr ""
 
-#: data/ui/deesser.glade:259 data/ui/deesser.glade:288
+#: data/ui/deesser.glade:256
 msgid "Split"
 msgstr ""
 
-#: data/ui/deesser.glade:407
-msgid "Level"
-msgstr "Niveau"
-
-#: data/ui/deesser.glade:420
-msgid "Peak Q"
+#: data/ui/deesser.glade:285
+msgid "F1 Split"
 msgstr ""
 
-#: data/ui/deesser.glade:452
+#: data/ui/deesser.glade:318
+#, fuzzy
+msgid "F1 Gain"
+msgstr "Gain d'entrée [dB]"
+
+#: data/ui/deesser.glade:352
+msgid "F2 Peak"
+msgstr ""
+
+#: data/ui/deesser.glade:406
+#, fuzzy
+msgid "F2 Level"
+msgstr "Niveau"
+
+#: data/ui/deesser.glade:419
+msgid "F2 Peak Q"
+msgstr ""
+
+#: data/ui/deesser.glade:451
 msgid "Laxity"
 msgstr ""
 
-#: data/ui/deesser.glade:778 data/ui/multiband_gate.glade:767
-#: data/ui/multiband_gate.glade:1197 data/ui/multiband_gate.glade:1607
-#: data/ui/multiband_gate.glade:2017
+#: data/ui/deesser.glade:779 data/ui/multiband_gate.glade:767
+#: data/ui/multiband_gate.glade:1201 data/ui/multiband_gate.glade:1614
+#: data/ui/multiband_gate.glade:2027
 #, fuzzy
 msgid "Reduction"
 msgstr "Réduction de gain"
 
-#: data/ui/deesser.glade:791
+#: data/ui/deesser.glade:792
 #, fuzzy
 msgid "Detected"
 msgstr "Atténuation"
 
-#: data/ui/delay.glade:91
+#: data/ui/delay.glade:92
 #, fuzzy
 msgid "Delay"
 msgstr "Relâche [ms]"
 
-#: data/ui/equalizer.glade:44
+#: data/ui/equalizer.glade:45
 msgid "Equalizer"
 msgstr "Égaliseur"
 
-#: data/ui/equalizer.glade:153
+#: data/ui/equalizer.glade:154
 msgid "Split Channels"
 msgstr ""
 
-#: data/ui/equalizer.glade:179
+#: data/ui/equalizer.glade:180
 msgid "IIR"
 msgstr ""
 
-#: data/ui/equalizer.glade:180
+#: data/ui/equalizer.glade:181
 msgid "FIR"
 msgstr ""
 
-#: data/ui/equalizer.glade:181
+#: data/ui/equalizer.glade:182
 msgid "FFT"
 msgstr ""
 
-#: data/ui/equalizer.glade:211
+#: data/ui/equalizer.glade:212
 msgid "Bands"
 msgstr ""
 
-#: data/ui/equalizer.glade:233
+#: data/ui/equalizer.glade:234
 msgid "Flat Response"
 msgstr "Réponse plane"
 
-#: data/ui/equalizer.glade:248
+#: data/ui/equalizer.glade:249
 msgid "Calculate Frequencies"
 msgstr ""
 
-#: data/ui/equalizer.glade:262
+#: data/ui/equalizer.glade:263
 #, fuzzy
 msgid "Import APO Presets"
 msgstr "Ouvrir préréglage"
@@ -903,7 +915,7 @@ msgstr ""
 msgid "Notch"
 msgstr ""
 
-#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:314
+#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:315
 msgid "Resonance"
 msgstr ""
 
@@ -948,12 +960,12 @@ msgstr "Remettre facteurs Q"
 msgid "Width"
 msgstr "Largeur"
 
-#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:496
+#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:494
 #: data/ui/multiband_compressor.glade:868
-#: data/ui/multiband_compressor.glade:1246
-#: data/ui/multiband_compressor.glade:1624 data/ui/multiband_gate.glade:520
-#: data/ui/multiband_gate.glade:925 data/ui/multiband_gate.glade:1335
-#: data/ui/multiband_gate.glade:1745
+#: data/ui/multiband_compressor.glade:1248
+#: data/ui/multiband_compressor.glade:1628 data/ui/multiband_gate.glade:518
+#: data/ui/multiband_gate.glade:926 data/ui/multiband_gate.glade:1339
+#: data/ui/multiband_gate.glade:1752
 msgid "Solo"
 msgstr ""
 
@@ -961,80 +973,80 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: data/ui/exciter.glade:117
+#: data/ui/exciter.glade:118
 msgid "Exciter"
 msgstr ""
 
-#: data/ui/exciter.glade:384 data/ui/maximizer.glade:165
+#: data/ui/exciter.glade:384 data/ui/maximizer.glade:166
 #, fuzzy
 msgid "Ceiling"
 msgstr "Limite [dB]"
 
-#: data/ui/filter.glade:98
+#: data/ui/filter.glade:99
 msgid "Filter"
 msgstr ""
 
-#: data/ui/filter.glade:147
+#: data/ui/filter.glade:148
 msgid "Muted"
 msgstr ""
 
-#: data/ui/filter.glade:159 data/ui/reverb.glade:233
+#: data/ui/filter.glade:160 data/ui/reverb.glade:234
 msgid "Disco"
 msgstr ""
 
-#: data/ui/filter.glade:171
+#: data/ui/filter.glade:172
 msgid "Distant Headphones"
 msgstr ""
 
-#: data/ui/filter.glade:246
+#: data/ui/filter.glade:247
 msgid "12dB/oct Lowpass"
 msgstr ""
 
-#: data/ui/filter.glade:247
+#: data/ui/filter.glade:248
 msgid "24dB/oct Lowpass"
 msgstr ""
 
-#: data/ui/filter.glade:248
+#: data/ui/filter.glade:249
 msgid "36dB/oct Lowpass"
 msgstr ""
 
-#: data/ui/filter.glade:249
+#: data/ui/filter.glade:250
 msgid "12dB/oct Highpass"
 msgstr ""
 
-#: data/ui/filter.glade:250
+#: data/ui/filter.glade:251
 msgid "24dB/oct Highpass"
 msgstr ""
 
-#: data/ui/filter.glade:251
+#: data/ui/filter.glade:252
 msgid "36dB/oct Highpass"
 msgstr ""
 
-#: data/ui/filter.glade:252
+#: data/ui/filter.glade:253
 msgid "6dB/oct Bandpass"
 msgstr ""
 
-#: data/ui/filter.glade:253
+#: data/ui/filter.glade:254
 msgid "12dB/oct Bandpass"
 msgstr ""
 
-#: data/ui/filter.glade:254
+#: data/ui/filter.glade:255
 msgid "18dB/oct Bandpass"
 msgstr ""
 
-#: data/ui/filter.glade:255
+#: data/ui/filter.glade:256
 msgid "6dB/oct Bandreject"
 msgstr ""
 
-#: data/ui/filter.glade:256
+#: data/ui/filter.glade:257
 msgid "12dB/oct Bandreject"
 msgstr ""
 
-#: data/ui/filter.glade:257
+#: data/ui/filter.glade:258
 msgid "18dB/oct Bandreject"
 msgstr ""
 
-#: data/ui/filter.glade:349
+#: data/ui/filter.glade:350
 msgid "Inertia"
 msgstr ""
 
@@ -1078,52 +1090,53 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: data/ui/gate.glade:98
+#: data/ui/gate.glade:99
 msgid "Gate"
 msgstr ""
 
-#: data/ui/gate.glade:209
+#: data/ui/gate.glade:240
+#, fuzzy
+msgid "Maximum Gain Reduction"
+msgstr "Réduction de gain"
+
+#: data/ui/gate.glade:289
 #, fuzzy
 msgid "Stereo Link"
 msgstr "Amélioration audio"
 
-#: data/ui/gate.glade:222 data/ui/maximizer.glade:293
-msgid "Gain Reduction"
-msgstr "Réduction de gain"
-
-#: data/ui/gate.glade:273
+#: data/ui/gate.glade:304
 msgid "Average"
 msgstr ""
 
-#: data/ui/gate.glade:274
+#: data/ui/gate.glade:305
 msgid "Maximum"
 msgstr ""
 
-#: data/ui/gate.glade:525
+#: data/ui/gate.glade:578
 #, fuzzy
 msgid "Input Level"
 msgstr "Limiteur d'entrée"
 
-#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:811
-#: data/ui/multiband_gate.glade:1220 data/ui/multiband_gate.glade:1630
-#: data/ui/multiband_gate.glade:2040
+#: data/ui/gate.glade:797 data/ui/multiband_gate.glade:812
+#: data/ui/multiband_gate.glade:1224 data/ui/multiband_gate.glade:1637
+#: data/ui/multiband_gate.glade:2050
 msgid "Gating"
 msgstr ""
 
-#: data/ui/limiter.glade:97 data/ui/webrtc.glade:421
+#: data/ui/limiter.glade:98 data/ui/webrtc.glade:422
 #, fuzzy
 msgid "Limiter"
 msgstr "Limite [dB]"
 
-#: data/ui/limiter.glade:176
+#: data/ui/limiter.glade:175
 msgid "Automatic Smoothing Control"
 msgstr ""
 
-#: data/ui/limiter.glade:190
+#: data/ui/limiter.glade:189
 msgid "Automatic Leveling"
 msgstr ""
 
-#: data/ui/limiter.glade:222
+#: data/ui/limiter.glade:221
 #, fuzzy
 msgid "Input Gain"
 msgstr "Gain d'entrée [dB]"
@@ -1133,144 +1146,148 @@ msgstr "Gain d'entrée [dB]"
 msgid "Limit"
 msgstr "Limite [dB]"
 
-#: data/ui/limiter.glade:358
+#: data/ui/limiter.glade:359
 msgid "Oversampling"
 msgstr ""
 
-#: data/ui/limiter.glade:411
+#: data/ui/limiter.glade:413
 #, fuzzy
 msgid "Output Gain"
 msgstr "Gain d'entrée [dB]"
 
-#: data/ui/limiter.glade:429
+#: data/ui/limiter.glade:431
 msgid "ASC"
 msgstr ""
 
-#: data/ui/limiter.glade:584
+#: data/ui/limiter.glade:586
 msgid "Attenuation"
 msgstr "Atténuation"
 
-#: data/ui/loudness.glade:91
+#: data/ui/loudness.glade:92
 msgid "Loudness Compensator"
 msgstr ""
 
-#: data/ui/loudness.glade:147
-msgid "Standard"
-msgstr ""
-
-#: data/ui/loudness.glade:161
-msgid "Flat"
-msgstr ""
-
-#: data/ui/loudness.glade:162
-msgid "ISO226-2003"
-msgstr ""
-
-#: data/ui/loudness.glade:163
-msgid "Fletcher-Munson"
-msgstr ""
-
-#: data/ui/loudness.glade:164
-msgid "Robinson-Dadson"
-msgstr ""
-
-#: data/ui/loudness.glade:174
-msgid "Reference Signal"
-msgstr ""
-
 # Taking lingual shortcuts to squeeze it in the text box
-#: data/ui/loudness.glade:199
+#: data/ui/loudness.glade:155
 #, fuzzy
 msgid "FFT Size"
 msgstr "Taille pièce"
 
-#: data/ui/maximizer.glade:96
+#: data/ui/loudness.glade:205
+msgid "Standard"
+msgstr ""
+
+#: data/ui/loudness.glade:220
+msgid "Flat"
+msgstr ""
+
+#: data/ui/loudness.glade:221
+msgid "ISO226-2003"
+msgstr ""
+
+#: data/ui/loudness.glade:222
+msgid "Fletcher-Munson"
+msgstr ""
+
+#: data/ui/loudness.glade:223
+msgid "Robinson-Dadson"
+msgstr ""
+
+#: data/ui/loudness.glade:259
+msgid "Reference Signal"
+msgstr ""
+
+#: data/ui/maximizer.glade:97
 msgid "Maximizer"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:140
+#: data/ui/maximizer.glade:296
+msgid "Gain Reduction"
+msgstr "Réduction de gain"
+
+#: data/ui/multiband_compressor.glade:141
 #, fuzzy
 msgid "Multiband Compressor"
 msgstr "Compresseur"
 
-#: data/ui/multiband_compressor.glade:338 data/ui/multiband_gate.glade:362
+#: data/ui/multiband_compressor.glade:336 data/ui/multiband_gate.glade:360
 msgid "LR4"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:339 data/ui/multiband_gate.glade:363
+#: data/ui/multiband_compressor.glade:337 data/ui/multiband_gate.glade:361
 msgid "LR8"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:353 data/ui/multiband_gate.glade:377
+#: data/ui/multiband_compressor.glade:351 data/ui/multiband_gate.glade:375
 msgid "Split 1/2"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:366 data/ui/multiband_gate.glade:390
+#: data/ui/multiband_compressor.glade:364 data/ui/multiband_gate.glade:388
 msgid "Split 2/3"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:379 data/ui/multiband_gate.glade:403
+#: data/ui/multiband_compressor.glade:377 data/ui/multiband_gate.glade:401
 msgid "Split 3/4"
 msgstr ""
 
 #: data/ui/multiband_compressor.glade:754
-#: data/ui/multiband_compressor.glade:1131
-#: data/ui/multiband_compressor.glade:1509
-#: data/ui/multiband_compressor.glade:1887
+#: data/ui/multiband_compressor.glade:1133
+#: data/ui/multiband_compressor.glade:1513
+#: data/ui/multiband_compressor.glade:1893
 #, fuzzy
 msgid "Compression"
 msgstr "Aucune compression"
 
-#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:894
+#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:895
 #, fuzzy
 msgid "Sub Band"
 msgstr "Entrée [dB]"
 
-#: data/ui/multiband_compressor.glade:1214 data/ui/multiband_gate.glade:1303
+#: data/ui/multiband_compressor.glade:1216 data/ui/multiband_gate.glade:1307
 #, fuzzy
 msgid "Low Band"
 msgstr "Passe-bas"
 
-#: data/ui/multiband_compressor.glade:1592 data/ui/multiband_gate.glade:1713
+#: data/ui/multiband_compressor.glade:1596 data/ui/multiband_gate.glade:1720
 #, fuzzy
 msgid "Mid Band"
 msgstr "Gain d'entrée [dB]"
 
-#: data/ui/multiband_compressor.glade:1970 data/ui/multiband_gate.glade:2123
+#: data/ui/multiband_compressor.glade:1976 data/ui/multiband_gate.glade:2133
 #, fuzzy
 msgid "High Band"
 msgstr "Passe-haut"
 
-#: data/ui/multiband_gate.glade:140
+#: data/ui/multiband_gate.glade:141
 #, fuzzy
 msgid "Multiband Gate"
 msgstr "Compresseur"
 
-#: data/ui/pitch.glade:103
+#: data/ui/pitch.glade:104
 msgid "Pitch"
 msgstr ""
 
-#: data/ui/pitch.glade:178
+#: data/ui/pitch.glade:179
 msgid "Cents"
 msgstr ""
 
-#: data/ui/pitch.glade:209
+#: data/ui/pitch.glade:210
 msgid "Semitones"
 msgstr ""
 
-#: data/ui/pitch.glade:240
+#: data/ui/pitch.glade:241
 msgid "Octaves"
 msgstr ""
 
-#: data/ui/pitch.glade:271
+#: data/ui/pitch.glade:272
 msgid "Crispness"
 msgstr ""
 
-#: data/ui/pitch.glade:311
+#: data/ui/pitch.glade:312
 msgid "Faster"
 msgstr ""
 
-#: data/ui/pitch.glade:325
+#: data/ui/pitch.glade:326
 msgid "Preserve Formant"
 msgstr ""
 
@@ -1370,90 +1387,90 @@ msgstr ""
 msgid "Pipeline Output"
 msgstr "Égaliseur - Sortie"
 
-#: data/ui/reverb.glade:131
+#: data/ui/reverb.glade:132
 msgid "Reverberation"
 msgstr "Réverberation"
 
-#: data/ui/reverb.glade:181
+#: data/ui/reverb.glade:182
 #, fuzzy
 msgid "Ambience"
 msgstr "Silence"
 
-#: data/ui/reverb.glade:194
+#: data/ui/reverb.glade:195
 msgid "Empty Walls"
 msgstr ""
 
 # Taking lingual shortcuts to squeeze it in the text box
-#: data/ui/reverb.glade:207
+#: data/ui/reverb.glade:208
 #, fuzzy
 msgid "Room"
 msgstr "Taille pièce"
 
-#: data/ui/reverb.glade:220
+#: data/ui/reverb.glade:221
 msgid "Large Empty Hall"
 msgstr ""
 
-#: data/ui/reverb.glade:246
+#: data/ui/reverb.glade:247
 msgid "Large Occupied Hall"
 msgstr ""
 
-#: data/ui/reverb.glade:361
+#: data/ui/reverb.glade:362
 #, fuzzy
 msgid "Pre Delay"
 msgstr "Relâche [ms]"
 
-#: data/ui/reverb.glade:374
+#: data/ui/reverb.glade:375
 msgid "Decay Time"
 msgstr ""
 
-#: data/ui/reverb.glade:439
+#: data/ui/reverb.glade:441
 msgid "Dry"
 msgstr ""
 
-#: data/ui/reverb.glade:471
+#: data/ui/reverb.glade:474
 msgid "Bass Cut"
 msgstr ""
 
-#: data/ui/reverb.glade:522
+#: data/ui/reverb.glade:525
 msgid "Treble Cut"
 msgstr ""
 
-#: data/ui/reverb.glade:565
+#: data/ui/reverb.glade:568
 msgid "Diffusion"
 msgstr ""
 
 # Taking lingual shortcuts to squeeze it in the text box
-#: data/ui/reverb.glade:577
+#: data/ui/reverb.glade:580
 msgid "Room Size"
 msgstr "Taille pièce"
 
-#: data/ui/reverb.glade:590
+#: data/ui/reverb.glade:593
 #, fuzzy
 msgid "Small"
 msgstr "Petite pièce"
 
-#: data/ui/reverb.glade:591
+#: data/ui/reverb.glade:594
 msgid "Medium"
 msgstr ""
 
-#: data/ui/reverb.glade:592
+#: data/ui/reverb.glade:595
 #, fuzzy
 msgid "Large"
 msgstr "Cible [dB]"
 
-#: data/ui/reverb.glade:593
+#: data/ui/reverb.glade:596
 msgid "Tunnel"
 msgstr ""
 
-#: data/ui/reverb.glade:594
+#: data/ui/reverb.glade:597
 msgid "Large/smooth"
 msgstr ""
 
-#: data/ui/reverb.glade:595
+#: data/ui/reverb.glade:598
 msgid "Experimental"
 msgstr ""
 
-#: data/ui/reverb.glade:608
+#: data/ui/reverb.glade:611
 msgid "High Frequency Damping"
 msgstr ""
 
@@ -1532,26 +1549,26 @@ msgstr ""
 msgid "Points"
 msgstr "Points"
 
-#: data/ui/stereo_tools.glade:109
+#: data/ui/stereo_tools.glade:110
 #, fuzzy
 msgid "Stereo Tools"
 msgstr "Amélioration audio"
 
-#: data/ui/stereo_tools.glade:231
+#: data/ui/stereo_tools.glade:230
 msgid "Softclip"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:255 data/ui/stereo_tools.glade:671
+#: data/ui/stereo_tools.glade:254 data/ui/stereo_tools.glade:672
 #, fuzzy
 msgid "Balance"
 msgstr "Amélioration audio"
 
-#: data/ui/stereo_tools.glade:287
+#: data/ui/stereo_tools.glade:286
 #, fuzzy
 msgid "S/C Level"
 msgstr "Niveau"
 
-#: data/ui/stereo_tools.glade:345
+#: data/ui/stereo_tools.glade:344
 #, fuzzy
 msgid "Side Level"
 msgstr "Niveau"
@@ -1561,161 +1578,161 @@ msgstr "Niveau"
 msgid "Side Balance"
 msgstr "Amélioration audio"
 
-#: data/ui/stereo_tools.glade:428
+#: data/ui/stereo_tools.glade:429
 #, fuzzy
 msgid "Middle Level"
 msgstr "Niveau"
 
-#: data/ui/stereo_tools.glade:441
+#: data/ui/stereo_tools.glade:442
 #, fuzzy
 msgid "Middle Panorama"
 msgstr "Panorama"
 
-#: data/ui/stereo_tools.glade:499
+#: data/ui/stereo_tools.glade:500
 msgid "LR > LR (Stereo Default)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:500
+#: data/ui/stereo_tools.glade:501
 msgid "LR > MS (Stereo to Mid-Side)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:501
+#: data/ui/stereo_tools.glade:502
 msgid "MS > LR (Mid-Side to Stereo)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:502
+#: data/ui/stereo_tools.glade:503
 msgid "LR > LL (Mono Left Channel)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:503
+#: data/ui/stereo_tools.glade:504
 msgid "LR > RR (Mono Right Channel)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:504
+#: data/ui/stereo_tools.glade:505
 msgid "LR > L+R (Mono Sum L+R)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:505
+#: data/ui/stereo_tools.glade:506
 msgid "LR > RL (Stereo Flip Channels)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:522
+#: data/ui/stereo_tools.glade:523
 #, fuzzy
 msgid "Stereo Matrix"
 msgstr "Amélioration audio"
 
-#: data/ui/stereo_tools.glade:561 data/ui/stereo_tools.glade:602
+#: data/ui/stereo_tools.glade:562 data/ui/stereo_tools.glade:603
 msgid "Invert Phase"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:703
+#: data/ui/stereo_tools.glade:704
 #, fuzzy
 msgid "Delay L/R"
 msgstr "Relâche [ms]"
 
-#: data/ui/stereo_tools.glade:737
+#: data/ui/stereo_tools.glade:738
 #, fuzzy
 msgid "Stereo Base"
 msgstr "Amélioration audio"
 
-#: data/ui/stereo_tools.glade:770
+#: data/ui/stereo_tools.glade:771
 #, fuzzy
 msgid "Stereo Phase"
 msgstr "Amélioration audio"
 
-#: data/ui/webrtc.glade:97
+#: data/ui/webrtc.glade:98
 msgid "WebRTC"
 msgstr ""
 
-#: data/ui/webrtc.glade:163 data/ui/webrtc.glade:283 data/ui/webrtc.glade:353
-#: data/ui/webrtc.glade:523
+#: data/ui/webrtc.glade:164 data/ui/webrtc.glade:284 data/ui/webrtc.glade:354
+#: data/ui/webrtc.glade:524
 #, fuzzy
 msgid "Enable"
 msgstr "Table sinusoïdale"
 
-#: data/ui/webrtc.glade:184
+#: data/ui/webrtc.glade:185
 msgid "Extended Filter"
 msgstr ""
 
-#: data/ui/webrtc.glade:197
+#: data/ui/webrtc.glade:198
 msgid "Delay Agnostic"
 msgstr ""
 
-#: data/ui/webrtc.glade:209
+#: data/ui/webrtc.glade:210
 #, fuzzy
 msgid "High Pass Filter"
 msgstr "Passe-haut"
 
-#: data/ui/webrtc.glade:238 data/ui/webrtc.glade:306
+#: data/ui/webrtc.glade:239 data/ui/webrtc.glade:307
 #, fuzzy
 msgid "Suppresion Level"
 msgstr "Réduction de gain"
 
-#: data/ui/webrtc.glade:251 data/ui/webrtc.glade:319 data/ui/webrtc.glade:575
+#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
 msgid "Low"
 msgstr ""
 
-#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
+#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
 msgid "Moderate"
 msgstr ""
 
-#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
+#: data/ui/webrtc.glade:254 data/ui/webrtc.glade:322 data/ui/webrtc.glade:578
 #, fuzzy
 msgid "High"
 msgstr "Passe-haut"
 
-#: data/ui/webrtc.glade:270
+#: data/ui/webrtc.glade:271
 #, fuzzy
 msgid "Echo Canceller"
 msgstr "Amélioration audio"
 
-#: data/ui/webrtc.glade:322
+#: data/ui/webrtc.glade:323
 #, fuzzy
 msgid "Very High"
 msgstr "Passe-haut"
 
-#: data/ui/webrtc.glade:339
+#: data/ui/webrtc.glade:340
 #, fuzzy
 msgid "Noise Suppressor"
 msgstr "Compresseur"
 
-#: data/ui/webrtc.glade:389
+#: data/ui/webrtc.glade:390
 msgid "Adaptive Digital"
 msgstr ""
 
-#: data/ui/webrtc.glade:390
+#: data/ui/webrtc.glade:391
 msgid "Fixed Digital"
 msgstr ""
 
-#: data/ui/webrtc.glade:407
+#: data/ui/webrtc.glade:408
 msgid "Gain Controller"
 msgstr ""
 
-#: data/ui/webrtc.glade:445
+#: data/ui/webrtc.glade:446
 #, fuzzy
 msgid "Target Level"
 msgstr "Cible [dB]"
 
-#: data/ui/webrtc.glade:475
+#: data/ui/webrtc.glade:476
 msgid "Maximum Gain"
 msgstr ""
 
-#: data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:549
 #, fuzzy
 msgid "Detection Likelihood"
 msgstr "Atténuation"
 
 # Taking lingual shortcuts to squeeze it in the text box
-#: data/ui/webrtc.glade:561
+#: data/ui/webrtc.glade:562
 #, fuzzy
 msgid "Frame Size"
 msgstr "Taille pièce"
 
-#: data/ui/webrtc.glade:574
+#: data/ui/webrtc.glade:575
 msgid "Very Low"
 msgstr ""
 
-#: data/ui/webrtc.glade:611
+#: data/ui/webrtc.glade:612
 #, fuzzy
 msgid "Voice Detector"
 msgstr "Atténuation"
@@ -1817,3 +1834,7 @@ msgstr "Général"
 #: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Gain Detection"
+#~ msgstr "Réduction de gain"

--- a/po/hr.po
+++ b/po/hr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PulseEffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-22 15:29+0200\n"
+"POT-Creation-Date: 2020-08-24 16:51+0200\n"
 "PO-Revision-Date: 2018-11-22 20:12+0200\n"
 "Last-Translator: flipwise <tyx027@gmail.com>\n"
 "Language-Team: Croatian\n"
@@ -87,8 +87,8 @@ msgid "Input Limiter"
 msgstr "Graničnik ulaza"
 
 #: data/com.github.wwmm.pulseeffects.appdata.xml.in:52
-#: data/ui/compressor.glade:111 data/ui/compressor.glade:494
-#: data/ui/webrtc.glade:509
+#: data/ui/compressor.glade:112 data/ui/compressor.glade:494
+#: data/ui/webrtc.glade:510
 msgid "Compressor"
 msgstr "Kompresor"
 
@@ -122,12 +122,12 @@ msgstr "Aplikacije"
 msgid "Format"
 msgstr "Format"
 
-#: data/ui/app_info.glade:75 data/ui/convolver.glade:283
+#: data/ui/app_info.glade:75 data/ui/convolver.glade:284
 msgid "Rate"
 msgstr "Frekvencija"
 
 #: data/ui/app_info.glade:102 data/ui/pulse_info.glade:238
-#: data/ui/stereo_tools.glade:653
+#: data/ui/stereo_tools.glade:654
 msgid "Channels"
 msgstr "Kanali"
 
@@ -166,7 +166,7 @@ msgstr "Testni signali"
 msgid "Global Bypass"
 msgstr "Premosnica"
 
-#: data/ui/application.glade:170 data/ui/equalizer.glade:277
+#: data/ui/application.glade:170 data/ui/equalizer.glade:278
 #: data/ui/general_settings.glade:107
 msgid "Settings"
 msgstr "Postavke"
@@ -175,173 +175,172 @@ msgstr "Postavke"
 msgid "Help"
 msgstr "Pomoć"
 
-#: data/ui/application.glade:215 data/ui/crossfeed.glade:49
-#: data/ui/equalizer.glade:333 data/ui/filter.glade:230
-#: data/ui/reverb.glade:310 src/presets_menu_ui.cpp:113
+#: data/ui/application.glade:215 data/ui/crossfeed.glade:48
+#: data/ui/equalizer.glade:334 data/ui/filter.glade:231
+#: data/ui/reverb.glade:311 src/presets_menu_ui.cpp:113
 #: src/presets_menu_ui.cpp:258 src/presets_menu_ui.cpp:275
 msgid "Presets"
 msgstr "Predlošci"
 
-#: data/ui/autogain.glade:91
+#: data/ui/autogain.glade:92
 #, fuzzy
 msgid "Auto Gain"
 msgstr "Automatsko pojačavanje"
 
-#: data/ui/autogain.glade:171
+#: data/ui/autogain.glade:172
 #, fuzzy
 msgid "Reset History"
 msgstr "Vrati izvornu kvalitetu"
 
-#: data/ui/autogain.glade:183
+#: data/ui/autogain.glade:184
 #, fuzzy
 msgid "Detect Silence"
 msgstr "Detekcija"
 
-#: data/ui/autogain.glade:195
+#: data/ui/autogain.glade:196
 msgid "Use Geometric Mean"
 msgstr ""
 
-#: data/ui/autogain.glade:233
+#: data/ui/autogain.glade:234
 msgid "Target"
 msgstr "Meta"
 
-#: data/ui/autogain.glade:283 data/ui/autogain.glade:627
+#: data/ui/autogain.glade:286 data/ui/autogain.glade:631
 msgid "Momentary"
 msgstr "Trenutačno"
 
-#: data/ui/autogain.glade:298 data/ui/autogain.glade:640
+#: data/ui/autogain.glade:301 data/ui/autogain.glade:644
 msgid "Short Term"
 msgstr "Kratkoročno"
 
-#: data/ui/autogain.glade:313 data/ui/autogain.glade:653
+#: data/ui/autogain.glade:316 data/ui/autogain.glade:657
 msgid "Integrated"
 msgstr "Integrirano"
 
-#: data/ui/autogain.glade:388
+#: data/ui/autogain.glade:394
 #, fuzzy
 msgid "Weights"
 msgstr "Otežanja"
 
-#: data/ui/autogain.glade:428 data/ui/autogain.glade:917
-#: data/ui/bass_enhancer.glade:504 data/ui/compressor.glade:974
-#: data/ui/convolver.glade:504 data/ui/crossfeed.glade:200
-#: data/ui/crystalizer.glade:255 data/ui/deesser.glade:593
-#: data/ui/delay.glade:236 data/ui/equalizer.glade:543
-#: data/ui/exciter.glade:510 data/ui/filter.glade:396 data/ui/gate.glade:558
-#: data/ui/limiter.glade:483 data/ui/loudness.glade:259
-#: data/ui/loudness.glade:338 data/ui/maximizer.glade:265
-#: data/ui/multiband_compressor.glade:2000 data/ui/multiband_gate.glade:2153
-#: data/ui/pitch.glade:362 data/ui/presets_menu.glade:255
-#: data/ui/reverb.glade:658 data/ui/stereo_tools.glade:323
-#: data/ui/stereo_tools.glade:829 data/ui/webrtc.glade:650
+#: data/ui/autogain.glade:434 data/ui/autogain.glade:921
+#: data/ui/bass_enhancer.glade:506 data/ui/compressor.glade:977
+#: data/ui/convolver.glade:505 data/ui/crossfeed.glade:199
+#: data/ui/crystalizer.glade:205 data/ui/deesser.glade:594
+#: data/ui/delay.glade:237 data/ui/equalizer.glade:544
+#: data/ui/exciter.glade:510 data/ui/filter.glade:397 data/ui/gate.glade:611
+#: data/ui/limiter.glade:485 data/ui/loudness.glade:299
+#: data/ui/loudness.glade:380 data/ui/maximizer.glade:268
+#: data/ui/multiband_compressor.glade:2006 data/ui/multiband_gate.glade:2163
+#: data/ui/pitch.glade:363 data/ui/presets_menu.glade:255
+#: data/ui/reverb.glade:661 data/ui/stereo_tools.glade:322
+#: data/ui/stereo_tools.glade:830 data/ui/webrtc.glade:651
 msgid "Input"
 msgstr "Ulaz"
 
-#: data/ui/autogain.glade:443 data/ui/autogain.glade:862
-#: data/ui/bass_enhancer.glade:536 data/ui/compressor.glade:988
-#: data/ui/convolver.glade:519 data/ui/crossfeed.glade:214
-#: data/ui/crystalizer.glade:270 data/ui/deesser.glade:607
-#: data/ui/delay.glade:250 data/ui/equalizer.glade:557
-#: data/ui/exciter.glade:542 data/ui/filter.glade:411 data/ui/gate.glade:572
-#: data/ui/limiter.glade:626 data/ui/loudness.glade:292
-#: data/ui/loudness.glade:352 data/ui/maximizer.glade:279
+#: data/ui/autogain.glade:449 data/ui/autogain.glade:866
+#: data/ui/bass_enhancer.glade:537 data/ui/compressor.glade:991
+#: data/ui/convolver.glade:520 data/ui/crossfeed.glade:213
+#: data/ui/crystalizer.glade:220 data/ui/deesser.glade:608
+#: data/ui/delay.glade:251 data/ui/equalizer.glade:558
+#: data/ui/exciter.glade:541 data/ui/filter.glade:412 data/ui/gate.glade:625
+#: data/ui/limiter.glade:628 data/ui/loudness.glade:333
+#: data/ui/loudness.glade:394 data/ui/maximizer.glade:282
 #: data/ui/multiband_compressor.glade:794
-#: data/ui/multiband_compressor.glade:1171
-#: data/ui/multiband_compressor.glade:1549
-#: data/ui/multiband_compressor.glade:1927
-#: data/ui/multiband_compressor.glade:2015 data/ui/multiband_gate.glade:851
-#: data/ui/multiband_gate.glade:1260 data/ui/multiband_gate.glade:1670
-#: data/ui/multiband_gate.glade:2080 data/ui/multiband_gate.glade:2168
-#: data/ui/pitch.glade:376 data/ui/presets_menu.glade:146
-#: data/ui/reverb.glade:673 data/ui/stereo_tools.glade:800
-#: data/ui/stereo_tools.glade:843 data/ui/webrtc.glade:664
+#: data/ui/multiband_compressor.glade:1173
+#: data/ui/multiband_compressor.glade:1553
+#: data/ui/multiband_compressor.glade:1933
+#: data/ui/multiband_compressor.glade:2021 data/ui/multiband_gate.glade:852
+#: data/ui/multiband_gate.glade:1264 data/ui/multiband_gate.glade:1677
+#: data/ui/multiband_gate.glade:2090 data/ui/multiband_gate.glade:2178
+#: data/ui/pitch.glade:377 data/ui/presets_menu.glade:146
+#: data/ui/reverb.glade:676 data/ui/stereo_tools.glade:801
+#: data/ui/stereo_tools.glade:844 data/ui/webrtc.glade:665
 msgid "Output"
 msgstr "Izlaz"
 
-#: data/ui/autogain.glade:744
+#: data/ui/autogain.glade:748
 msgid "Relative"
 msgstr "Relativno"
 
-#: data/ui/autogain.glade:757 data/ui/compressor.glade:1154
-#: data/ui/deesser.glade:321
+#: data/ui/autogain.glade:761 data/ui/compressor.glade:1157
 msgid "Gain"
 msgstr "Pojačanje"
 
-#: data/ui/autogain.glade:823
+#: data/ui/autogain.glade:827
 msgid "Loudness"
 msgstr "Glasnoća"
 
-#: data/ui/autogain.glade:876
+#: data/ui/autogain.glade:880
 msgid "Range"
 msgstr "Raspon"
 
-#: data/ui/autogain.glade:945 data/ui/bass_enhancer.glade:655
-#: data/ui/compressor.glade:1299 data/ui/convolver.glade:703
-#: data/ui/crossfeed.glade:395 data/ui/crystalizer.glade:566
-#: data/ui/deesser.glade:898 data/ui/delay.glade:434
-#: data/ui/equalizer.glade:743 data/ui/equalizer_band.glade:182
-#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:661
-#: data/ui/filter.glade:595 data/ui/general_settings.glade:116
-#: data/ui/gate.glade:809 data/ui/limiter.glade:733 data/ui/loudness.glade:573
-#: data/ui/maximizer.glade:516 data/ui/multiband_compressor.glade:2199
-#: data/ui/multiband_gate.glade:2352 data/ui/pitch.glade:560
-#: data/ui/reverb.glade:857 data/ui/stereo_tools.glade:1029
-#: data/ui/webrtc.glade:814
+#: data/ui/autogain.glade:949 data/ui/bass_enhancer.glade:650
+#: data/ui/compressor.glade:1300 data/ui/convolver.glade:702
+#: data/ui/crossfeed.glade:394 data/ui/crystalizer.glade:514
+#: data/ui/deesser.glade:899 data/ui/delay.glade:433
+#: data/ui/equalizer.glade:744 data/ui/equalizer_band.glade:182
+#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:654
+#: data/ui/filter.glade:594 data/ui/general_settings.glade:116
+#: data/ui/gate.glade:862 data/ui/limiter.glade:735 data/ui/loudness.glade:615
+#: data/ui/maximizer.glade:519 data/ui/multiband_compressor.glade:2203
+#: data/ui/multiband_gate.glade:2360 data/ui/pitch.glade:559
+#: data/ui/reverb.glade:858 data/ui/stereo_tools.glade:1028
+#: data/ui/webrtc.glade:815
 msgid "Reset"
 msgstr "Vrati na tvorničke postavke"
 
-#: data/ui/autogain.glade:969
+#: data/ui/autogain.glade:973
 msgid "Based on"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:117
+#: data/ui/bass_enhancer.glade:118
 msgid "Bass Enhancer"
 msgstr "Pojačanje basa"
 
-#: data/ui/bass_enhancer.glade:169 data/ui/compressor.glade:506
-#: data/ui/deesser.glade:188 data/ui/exciter.glade:171
+#: data/ui/bass_enhancer.glade:170 data/ui/compressor.glade:506
+#: data/ui/deesser.glade:185 data/ui/exciter.glade:170
 msgid "Listen"
 msgstr "Poslušaj"
 
-#: data/ui/bass_enhancer.glade:210 data/ui/exciter.glade:213
+#: data/ui/bass_enhancer.glade:211 data/ui/exciter.glade:212
 msgid "3rd"
 msgstr "3."
 
-#: data/ui/bass_enhancer.glade:222 data/ui/exciter.glade:225
+#: data/ui/bass_enhancer.glade:223 data/ui/exciter.glade:224
 msgid "2nd"
 msgstr "2."
 
-#: data/ui/bass_enhancer.glade:234 data/ui/exciter.glade:237
+#: data/ui/bass_enhancer.glade:235 data/ui/exciter.glade:236
 msgid "Blend Harmonics"
 msgstr "Spajanje harmonijskog reda"
 
-#: data/ui/bass_enhancer.glade:266 data/ui/exciter.glade:271
-#: data/ui/reverb.glade:407
+#: data/ui/bass_enhancer.glade:267 data/ui/exciter.glade:270
+#: data/ui/reverb.glade:408
 msgid "Amount"
 msgstr "Jačina"
 
-#: data/ui/bass_enhancer.glade:278 data/ui/bass_enhancer.glade:411
-#: data/ui/exciter.glade:284 data/ui/exciter.glade:417
+#: data/ui/bass_enhancer.glade:279 data/ui/bass_enhancer.glade:413
+#: data/ui/exciter.glade:283 data/ui/exciter.glade:417
 msgid "Harmonics"
 msgstr "Harmonijski red"
 
-#: data/ui/bass_enhancer.glade:290 data/ui/exciter.glade:297
+#: data/ui/bass_enhancer.glade:291 data/ui/exciter.glade:296
 msgid "Scope"
 msgstr "Raspon"
 
-#: data/ui/bass_enhancer.glade:379
+#: data/ui/bass_enhancer.glade:381
 msgid "Floor"
 msgstr "Dno"
 
-#: data/ui/bass_enhancer.glade:679 data/ui/compressor.glade:1323
-#: data/ui/crossfeed.glade:419 data/ui/deesser.glade:922
-#: data/ui/delay.glade:458 data/ui/equalizer.glade:767
-#: data/ui/exciter.glade:685 data/ui/filter.glade:619 data/ui/gate.glade:833
-#: data/ui/limiter.glade:757 data/ui/loudness.glade:542
-#: data/ui/maximizer.glade:540 data/ui/multiband_compressor.glade:2223
-#: data/ui/multiband_gate.glade:2376 data/ui/pitch.glade:584
-#: data/ui/reverb.glade:881 data/ui/stereo_tools.glade:1053
-#: data/ui/webrtc.glade:838
+#: data/ui/bass_enhancer.glade:674 data/ui/compressor.glade:1324
+#: data/ui/crossfeed.glade:418 data/ui/deesser.glade:923
+#: data/ui/delay.glade:457 data/ui/equalizer.glade:768
+#: data/ui/exciter.glade:678 data/ui/filter.glade:618 data/ui/gate.glade:886
+#: data/ui/limiter.glade:759 data/ui/loudness.glade:584
+#: data/ui/maximizer.glade:543 data/ui/multiband_compressor.glade:2227
+#: data/ui/multiband_gate.glade:2384 data/ui/pitch.glade:583
+#: data/ui/reverb.glade:882 data/ui/stereo_tools.glade:1052
+#: data/ui/webrtc.glade:839
 msgid "Provided by"
 msgstr ""
 
@@ -376,141 +375,141 @@ msgstr "Izlazni efekti"
 msgid "Show Blocklisted Apps in Main Tab"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:32 data/ui/equalizer_band.glade:152
-#: data/ui/filter.glade:280
+#: data/ui/calibration_signals.glade:30 data/ui/equalizer_band.glade:152
+#: data/ui/filter.glade:281
 msgid "Frequency"
 msgstr "Frekvencija"
 
-#: data/ui/calibration_signals.glade:64
+#: data/ui/calibration_signals.glade:62
 msgid "Volume"
 msgstr "Glasnoća"
 
-#: data/ui/calibration_signals.glade:108
+#: data/ui/calibration_signals.glade:106
 msgid "Sine"
 msgstr "Sinus"
 
-#: data/ui/calibration_signals.glade:109
+#: data/ui/calibration_signals.glade:107
 msgid "Square"
 msgstr "Kvadrat"
 
-#: data/ui/calibration_signals.glade:110
+#: data/ui/calibration_signals.glade:108
 msgid "Saw"
 msgstr "Pila"
 
-#: data/ui/calibration_signals.glade:111
+#: data/ui/calibration_signals.glade:109
 msgid "Triangle"
 msgstr "Trokut"
 
-#: data/ui/calibration_signals.glade:112
+#: data/ui/calibration_signals.glade:110
 #, fuzzy
 msgid "Silence"
 msgstr "Tišina"
 
-#: data/ui/calibration_signals.glade:113
+#: data/ui/calibration_signals.glade:111
 msgid "White Noise"
 msgstr "Bijeli šum"
 
-#: data/ui/calibration_signals.glade:114
+#: data/ui/calibration_signals.glade:112
 msgid "Pink Noise"
 msgstr "Rozi šum"
 
-#: data/ui/calibration_signals.glade:115
+#: data/ui/calibration_signals.glade:113
 msgid "Sine Table"
 msgstr "Sinus tablica"
 
-#: data/ui/calibration_signals.glade:116
+#: data/ui/calibration_signals.glade:114
 msgid "Ticks"
 msgstr "Otkucaji"
 
-#: data/ui/calibration_signals.glade:117
+#: data/ui/calibration_signals.glade:115
 msgid "Gaussian Noise"
 msgstr "Gaussov šum"
 
-#: data/ui/calibration_signals.glade:118
+#: data/ui/calibration_signals.glade:116
 msgid "Red Noise"
 msgstr "Crveni šum"
 
-#: data/ui/calibration_signals.glade:119
+#: data/ui/calibration_signals.glade:117
 msgid "Blue Noise"
 msgstr "Plavi šum"
 
-#: data/ui/calibration_signals.glade:120
+#: data/ui/calibration_signals.glade:118
 msgid "Violet Noise"
 msgstr "Ljubičasti šum"
 
-#: data/ui/calibration_mic.glade:29
+#: data/ui/calibration_mic.glade:28
 msgid "Window"
 msgstr "Prozor"
 
-#: data/ui/calibration_mic.glade:70
+#: data/ui/calibration_mic.glade:69
 msgid "Measure Noise"
 msgstr "Izmjeri šum"
 
-#: data/ui/calibration_mic.glade:99
+#: data/ui/calibration_mic.glade:98
 msgid "Subtract Noise"
 msgstr "Izdvoji šum"
 
-#: data/ui/compressor.glade:292 data/ui/deesser.glade:483
-#: data/ui/gate.glade:370 data/ui/maximizer.glade:152
-#: data/ui/multiband_compressor.glade:609
+#: data/ui/compressor.glade:290 data/ui/deesser.glade:482
+#: data/ui/gate.glade:413 data/ui/maximizer.glade:153
+#: data/ui/multiband_compressor.glade:607
 #: data/ui/multiband_compressor.glade:983
-#: data/ui/multiband_compressor.glade:1361
-#: data/ui/multiband_compressor.glade:1739 data/ui/multiband_gate.glade:633
-#: data/ui/multiband_gate.glade:1040 data/ui/multiband_gate.glade:1450
-#: data/ui/multiband_gate.glade:1860
+#: data/ui/multiband_compressor.glade:1363
+#: data/ui/multiband_compressor.glade:1743 data/ui/multiband_gate.glade:631
+#: data/ui/multiband_gate.glade:1041 data/ui/multiband_gate.glade:1454
+#: data/ui/multiband_gate.glade:1867
 msgid "Threshold"
 msgstr "Prag"
 
-#: data/ui/compressor.glade:325 data/ui/deesser.glade:516
-#: data/ui/gate.glade:403 data/ui/multiband_compressor.glade:642
-#: data/ui/multiband_compressor.glade:1017
-#: data/ui/multiband_compressor.glade:1395
-#: data/ui/multiband_compressor.glade:1773 data/ui/multiband_gate.glade:666
-#: data/ui/multiband_gate.glade:1074 data/ui/multiband_gate.glade:1484
-#: data/ui/multiband_gate.glade:1894
+#: data/ui/compressor.glade:324 data/ui/deesser.glade:516
+#: data/ui/gate.glade:449 data/ui/multiband_compressor.glade:641
+#: data/ui/multiband_compressor.glade:1018
+#: data/ui/multiband_compressor.glade:1398
+#: data/ui/multiband_compressor.glade:1778 data/ui/multiband_gate.glade:665
+#: data/ui/multiband_gate.glade:1076 data/ui/multiband_gate.glade:1489
+#: data/ui/multiband_gate.glade:1902
 msgid "Ratio"
 msgstr "Omjer"
 
-#: data/ui/compressor.glade:357 data/ui/gate.glade:435
-#: data/ui/multiband_compressor.glade:674
-#: data/ui/multiband_compressor.glade:1050
-#: data/ui/multiband_compressor.glade:1428
-#: data/ui/multiband_compressor.glade:1806 data/ui/multiband_gate.glade:698
-#: data/ui/multiband_gate.glade:1107 data/ui/multiband_gate.glade:1517
-#: data/ui/multiband_gate.glade:1927
+#: data/ui/compressor.glade:356 data/ui/gate.glade:483
+#: data/ui/multiband_compressor.glade:673
+#: data/ui/multiband_compressor.glade:1051
+#: data/ui/multiband_compressor.glade:1431
+#: data/ui/multiband_compressor.glade:1811 data/ui/multiband_gate.glade:697
+#: data/ui/multiband_gate.glade:1109 data/ui/multiband_gate.glade:1522
+#: data/ui/multiband_gate.glade:1935
 #, fuzzy
 msgid "Knee"
 msgstr "Koljeno"
 
-#: data/ui/compressor.glade:391 data/ui/deesser.glade:547
-#: data/ui/gate.glade:469 data/ui/multiband_compressor.glade:708
-#: data/ui/multiband_compressor.glade:1085
-#: data/ui/multiband_compressor.glade:1463
-#: data/ui/multiband_compressor.glade:1841 data/ui/multiband_gate.glade:732
-#: data/ui/multiband_gate.glade:1142 data/ui/multiband_gate.glade:1552
-#: data/ui/multiband_gate.glade:1962
+#: data/ui/compressor.glade:390 data/ui/deesser.glade:547
+#: data/ui/gate.glade:519 data/ui/multiband_compressor.glade:707
+#: data/ui/multiband_compressor.glade:1086
+#: data/ui/multiband_compressor.glade:1466
+#: data/ui/multiband_compressor.glade:1846 data/ui/multiband_gate.glade:731
+#: data/ui/multiband_gate.glade:1144 data/ui/multiband_gate.glade:1557
+#: data/ui/multiband_gate.glade:1970
 #, fuzzy
 msgid "Makeup"
 msgstr "Dorada"
 
-#: data/ui/compressor.glade:425 data/ui/gate.glade:336
-#: data/ui/limiter.glade:310 data/ui/maximizer.glade:178
-#: data/ui/multiband_compressor.glade:575
+#: data/ui/compressor.glade:425 data/ui/gate.glade:377
+#: data/ui/limiter.glade:311 data/ui/maximizer.glade:179
+#: data/ui/multiband_compressor.glade:573
 #: data/ui/multiband_compressor.glade:948
-#: data/ui/multiband_compressor.glade:1326
-#: data/ui/multiband_compressor.glade:1704 data/ui/multiband_gate.glade:599
-#: data/ui/multiband_gate.glade:1005 data/ui/multiband_gate.glade:1415
-#: data/ui/multiband_gate.glade:1825
+#: data/ui/multiband_compressor.glade:1328
+#: data/ui/multiband_compressor.glade:1708 data/ui/multiband_gate.glade:597
+#: data/ui/multiband_gate.glade:1006 data/ui/multiband_gate.glade:1419
+#: data/ui/multiband_gate.glade:1832
 msgid "Release"
 msgstr "Vrijeme prijelaza"
 
-#: data/ui/compressor.glade:438 data/ui/gate.glade:302
-#: data/ui/multiband_compressor.glade:541
+#: data/ui/compressor.glade:438 data/ui/gate.glade:341
+#: data/ui/multiband_compressor.glade:539
 #: data/ui/multiband_compressor.glade:913
-#: data/ui/multiband_compressor.glade:1291
-#: data/ui/multiband_compressor.glade:1669 data/ui/multiband_gate.glade:565
-#: data/ui/multiband_gate.glade:970 data/ui/multiband_gate.glade:1380
-#: data/ui/multiband_gate.glade:1790
+#: data/ui/multiband_compressor.glade:1293
+#: data/ui/multiband_compressor.glade:1673 data/ui/multiband_gate.glade:563
+#: data/ui/multiband_gate.glade:971 data/ui/multiband_gate.glade:1384
+#: data/ui/multiband_gate.glade:1797
 msgid "Attack"
 msgstr "Pokretanje"
 
@@ -527,223 +526,222 @@ msgstr ""
 msgid "Compression Mode"
 msgstr "Kompresija"
 
-#: data/ui/compressor.glade:551
+#: data/ui/compressor.glade:552
 #, fuzzy
 msgid "Pre-amplification"
 msgstr "Aplikacije"
 
-#: data/ui/compressor.glade:585
+#: data/ui/compressor.glade:586
 msgid "Reactivity"
 msgstr ""
 
-#: data/ui/compressor.glade:619 data/ui/limiter.glade:323
+#: data/ui/compressor.glade:620 data/ui/limiter.glade:324
 msgid "Lookahead"
 msgstr "Preduhvatiti"
 
-#: data/ui/compressor.glade:632
+#: data/ui/compressor.glade:633
 msgid "Feed-forward"
 msgstr ""
 
-#: data/ui/compressor.glade:633
+#: data/ui/compressor.glade:634
 #, fuzzy
 msgid "Feed-back"
 msgstr "Dovod zvuka"
 
-#: data/ui/compressor.glade:647 data/ui/equalizer_band.glade:48
+#: data/ui/compressor.glade:648 data/ui/equalizer_band.glade:48
 msgid "Type"
 msgstr ""
 
-#: data/ui/compressor.glade:661 data/ui/deesser.glade:244
-#: data/ui/deesser.glade:354 data/ui/gate.glade:257
-#: data/ui/multiband_compressor.glade:514
+#: data/ui/compressor.glade:662 data/ui/deesser.glade:241
+#: data/ui/gate.glade:213 data/ui/multiband_compressor.glade:512
 #: data/ui/multiband_compressor.glade:886
-#: data/ui/multiband_compressor.glade:1264
-#: data/ui/multiband_compressor.glade:1642 data/ui/multiband_gate.glade:538
-#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1353
-#: data/ui/multiband_gate.glade:1763
+#: data/ui/multiband_compressor.glade:1266
+#: data/ui/multiband_compressor.glade:1646 data/ui/multiband_gate.glade:536
+#: data/ui/multiband_gate.glade:944 data/ui/multiband_gate.glade:1357
+#: data/ui/multiband_gate.glade:1770
 msgid "Peak"
 msgstr "Vrhunac"
 
-#: data/ui/compressor.glade:662 data/ui/deesser.glade:243
-#: data/ui/gate.glade:256 data/ui/multiband_compressor.glade:513
+#: data/ui/compressor.glade:663 data/ui/deesser.glade:240
+#: data/ui/gate.glade:212 data/ui/multiband_compressor.glade:511
 #: data/ui/multiband_compressor.glade:885
-#: data/ui/multiband_compressor.glade:1263
-#: data/ui/multiband_compressor.glade:1641 data/ui/multiband_gate.glade:537
-#: data/ui/multiband_gate.glade:942 data/ui/multiband_gate.glade:1352
-#: data/ui/multiband_gate.glade:1762
+#: data/ui/multiband_compressor.glade:1265
+#: data/ui/multiband_compressor.glade:1645 data/ui/multiband_gate.glade:535
+#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1356
+#: data/ui/multiband_gate.glade:1769
 msgid "RMS"
 msgstr "RMS"
 
-#: data/ui/compressor.glade:663
+#: data/ui/compressor.glade:664
 #, fuzzy
 msgid "Low-Pass"
 msgstr "Nizak prolaz"
 
-#: data/ui/compressor.glade:664
+#: data/ui/compressor.glade:665
 msgid "Uniform"
 msgstr ""
 
-#: data/ui/compressor.glade:678 data/ui/deesser.glade:230
-#: data/ui/equalizer.glade:224 data/ui/equalizer_band.glade:79
-#: data/ui/multiband_compressor.glade:324 data/ui/multiband_gate.glade:348
-#: data/ui/stereo_tools.glade:485 data/ui/webrtc.glade:376
+#: data/ui/compressor.glade:679 data/ui/deesser.glade:227
+#: data/ui/equalizer.glade:225 data/ui/equalizer_band.glade:79
+#: data/ui/multiband_compressor.glade:322 data/ui/multiband_gate.glade:346
+#: data/ui/stereo_tools.glade:486 data/ui/webrtc.glade:377
 msgid "Mode"
 msgstr "Način"
 
-#: data/ui/compressor.glade:692
+#: data/ui/compressor.glade:693
 #, fuzzy
 msgid "Middle"
 msgstr "Srednji nivo"
 
-#: data/ui/compressor.glade:693
+#: data/ui/compressor.glade:694
 #, fuzzy
 msgid "Side"
 msgstr "Strana"
 
-#: data/ui/compressor.glade:694 data/ui/delay.glade:157
-#: data/ui/equalizer.glade:474 data/ui/stereo_tools.glade:548
+#: data/ui/compressor.glade:695 data/ui/delay.glade:158
+#: data/ui/equalizer.glade:475 data/ui/stereo_tools.glade:549
 msgid "Left"
 msgstr "Lijevo"
 
-#: data/ui/compressor.glade:695 data/ui/delay.glade:189
-#: data/ui/equalizer.glade:515 data/ui/stereo_tools.glade:620
+#: data/ui/compressor.glade:696 data/ui/delay.glade:190
+#: data/ui/equalizer.glade:516 data/ui/stereo_tools.glade:621
 msgid "Right"
 msgstr "Desno"
 
-#: data/ui/compressor.glade:709
+#: data/ui/compressor.glade:710
 #, fuzzy
 msgid "Source"
 msgstr "Izvor"
 
-#: data/ui/compressor.glade:725 data/ui/compressor.glade:1167
+#: data/ui/compressor.glade:726 data/ui/compressor.glade:1170
 #, fuzzy
 msgid "Sidechain"
 msgstr "Postranični ulaz"
 
-#: data/ui/compressor.glade:821
+#: data/ui/compressor.glade:824
 msgid "Relative Release Threshold"
 msgstr ""
 
-#: data/ui/compressor.glade:832
+#: data/ui/compressor.glade:835
 #, fuzzy
 msgid "Boost Threshold"
 msgstr "Prag"
 
-#: data/ui/compressor.glade:843
+#: data/ui/compressor.glade:846
 #, fuzzy
 msgid "High-pass Frequency"
 msgstr "Prigušivanje visokih frekvencija"
 
-#: data/ui/compressor.glade:854
+#: data/ui/compressor.glade:857
 #, fuzzy
 msgid "Low-pass Frequency"
 msgstr "Izračunaj frekvencije"
 
-#: data/ui/compressor.glade:865
+#: data/ui/compressor.glade:868
 #, fuzzy
 msgid "High-pass Filter Mode"
 msgstr "Filter visokog prolaza"
 
-#: data/ui/compressor.glade:876
+#: data/ui/compressor.glade:879
 msgid "Low-pass Filter Mode"
 msgstr ""
 
-#: data/ui/compressor.glade:889 data/ui/compressor.glade:906
+#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
 #: data/ui/equalizer_band.glade:60
 msgid "Off"
 msgstr ""
 
-#: data/ui/compressor.glade:890 data/ui/compressor.glade:907
+#: data/ui/compressor.glade:893 data/ui/compressor.glade:910
 #, fuzzy
 msgid "12 dB/oct"
 msgstr "12dB/oct niski prolaz"
 
-#: data/ui/compressor.glade:891 data/ui/compressor.glade:908
+#: data/ui/compressor.glade:894 data/ui/compressor.glade:911
 #, fuzzy
 msgid "24 dB/oct"
 msgstr "24dB/oct niski prolaz"
 
-#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
+#: data/ui/compressor.glade:895 data/ui/compressor.glade:912
 #, fuzzy
 msgid "36 dB/oct"
 msgstr "36dB/oct niski prolaz"
 
-#: data/ui/compressor.glade:932
+#: data/ui/compressor.glade:935
 #, fuzzy
 msgid "Advanced"
 msgstr "Napredne postavke"
 
-#: data/ui/compressor.glade:1243
+#: data/ui/compressor.glade:1244
 msgid "Curve"
 msgstr ""
 
-#: data/ui/convolver.glade:91
+#: data/ui/convolver.glade:92
 msgid "Convolver"
 msgstr "Konvolver"
 
-#: data/ui/convolver.glade:125
+#: data/ui/convolver.glade:126
 #, fuzzy
 msgid "Import Impulse"
 msgstr "Učitaj impuls"
 
-#: data/ui/convolver.glade:129
+#: data/ui/convolver.glade:130
 msgid "Import Impulse Response File"
 msgstr "Učitaj datoteku reakcije impulsa"
 
-#: data/ui/convolver.glade:247
+#: data/ui/convolver.glade:248
 msgid "L"
 msgstr "L"
 
-#: data/ui/convolver.glade:261
+#: data/ui/convolver.glade:262
 msgid "R"
 msgstr "D"
 
-#: data/ui/convolver.glade:324
+#: data/ui/convolver.glade:325
 #, fuzzy
 msgid "Duration"
 msgstr "Trajanje"
 
-#: data/ui/convolver.glade:335
+#: data/ui/convolver.glade:336
 #, fuzzy
 msgid "Samples"
 msgstr "Semplovi"
 
-#: data/ui/convolver.glade:367 src/convolver_ui.cpp:283
+#: data/ui/convolver.glade:368 src/convolver_ui.cpp:283
 #, fuzzy
 msgid "Impulse Response"
 msgstr "Reakcija impulsa"
 
-#: data/ui/convolver.glade:389
+#: data/ui/convolver.glade:390
 #, fuzzy
 msgid "Select the impulse Response File"
 msgstr "Odaberite datoteku reakcije impulsa"
 
-#: data/ui/convolver.glade:409 src/spectrum_settings_ui.cpp:176
+#: data/ui/convolver.glade:410 src/spectrum_settings_ui.cpp:176
 msgid "Spectrum"
 msgstr "Spektar"
 
-#: data/ui/convolver.glade:450
+#: data/ui/convolver.glade:451
 #, fuzzy
 msgid "Stereo Width"
 msgstr "Stereo širina"
 
-#: data/ui/crossfeed.glade:63
+#: data/ui/crossfeed.glade:62
 msgid "Jmeier"
 msgstr ""
 
-#: data/ui/crossfeed.glade:76 data/ui/filter.glade:183 data/ui/reverb.glade:259
+#: data/ui/crossfeed.glade:75 data/ui/filter.glade:184 data/ui/reverb.glade:260
 msgid "Default"
 msgstr "Tvorničke postavke"
 
-#: data/ui/crossfeed.glade:89
+#: data/ui/crossfeed.glade:88
 msgid "Cmoy"
 msgstr "Cmoy"
 
-#: data/ui/crossfeed.glade:120
+#: data/ui/crossfeed.glade:119
 msgid "Cutoff"
 msgstr "Prekid"
 
-#: data/ui/crossfeed.glade:153
+#: data/ui/crossfeed.glade:152
 msgid "Feed"
 msgstr "Dovod zvuka"
 
@@ -751,122 +749,138 @@ msgstr "Dovod zvuka"
 msgid "Crossfeed"
 msgstr "Križno spajanje"
 
-#: data/ui/crystalizer.glade:115
+#: data/ui/crystalizer.glade:92
 #, fuzzy
 msgid "Crystalizer"
 msgstr "Kristalizator"
 
-#: data/ui/crystalizer.glade:187
+#: data/ui/crystalizer.glade:137
 #, fuzzy
 msgid "Aggressive Mode"
 msgstr "Kompresija"
 
-#: data/ui/crystalizer.glade:447
+#: data/ui/crystalizer.glade:395
 #, fuzzy
 msgid "Loudness Range"
 msgstr "Glasnoća"
 
-#: data/ui/crystalizer.glade:466
+#: data/ui/crystalizer.glade:414
 msgid "Before"
 msgstr ""
 
-#: data/ui/crystalizer.glade:479
+#: data/ui/crystalizer.glade:427
 msgid "After"
 msgstr ""
 
 #: data/ui/crystalizer_band.glade:27 data/ui/equalizer_band.glade:313
-#: data/ui/stereo_tools.glade:574 data/ui/stereo_tools.glade:633
+#: data/ui/stereo_tools.glade:575 data/ui/stereo_tools.glade:634
 msgid "Mute"
 msgstr "Bezvučno"
 
-#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:483
+#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:481
 #: data/ui/multiband_compressor.glade:855
-#: data/ui/multiband_compressor.glade:1233
-#: data/ui/multiband_compressor.glade:1611 data/ui/multiband_gate.glade:507
-#: data/ui/multiband_gate.glade:912 data/ui/multiband_gate.glade:1322
-#: data/ui/multiband_gate.glade:1732
+#: data/ui/multiband_compressor.glade:1235
+#: data/ui/multiband_compressor.glade:1615 data/ui/multiband_gate.glade:505
+#: data/ui/multiband_gate.glade:913 data/ui/multiband_gate.glade:1326
+#: data/ui/multiband_gate.glade:1739
 msgid "Bypass"
 msgstr "Premosnica"
 
-#: data/ui/deesser.glade:128
+#: data/ui/deesser.glade:127
 msgid "Deesser"
 msgstr "De-esiranje"
 
-#: data/ui/deesser.glade:216 data/ui/gate.glade:195
+#: data/ui/deesser.glade:213 data/ui/gate.glade:198
 msgid "Detection"
 msgstr "Detekcija"
 
-#: data/ui/deesser.glade:258
+#: data/ui/deesser.glade:255
 msgid "Wide"
 msgstr "Široko"
 
-#: data/ui/deesser.glade:259 data/ui/deesser.glade:288
+#: data/ui/deesser.glade:256
 #, fuzzy
 msgid "Split"
 msgstr "Razdvojeno"
 
-#: data/ui/deesser.glade:407
-msgid "Level"
+#: data/ui/deesser.glade:285
+#, fuzzy
+msgid "F1 Split"
+msgstr "Razdvojeno"
+
+#: data/ui/deesser.glade:318
+#, fuzzy
+msgid "F1 Gain"
+msgstr "Pojačanje"
+
+#: data/ui/deesser.glade:352
+#, fuzzy
+msgid "F2 Peak"
+msgstr "Vrhunac"
+
+#: data/ui/deesser.glade:406
+#, fuzzy
+msgid "F2 Level"
 msgstr "Razina"
 
-#: data/ui/deesser.glade:420
+#: data/ui/deesser.glade:419
 #, fuzzy
-msgid "Peak Q"
+msgid "F2 Peak Q"
 msgstr "Vrhunac Q"
 
-#: data/ui/deesser.glade:452
+#: data/ui/deesser.glade:451
 msgid "Laxity"
 msgstr "Popustljivost"
 
-#: data/ui/deesser.glade:778 data/ui/multiband_gate.glade:767
-#: data/ui/multiband_gate.glade:1197 data/ui/multiband_gate.glade:1607
-#: data/ui/multiband_gate.glade:2017
+#: data/ui/deesser.glade:779 data/ui/multiband_gate.glade:767
+#: data/ui/multiband_gate.glade:1201 data/ui/multiband_gate.glade:1614
+#: data/ui/multiband_gate.glade:2027
 msgid "Reduction"
 msgstr "Smanjenje"
 
-#: data/ui/deesser.glade:791
+#: data/ui/deesser.glade:792
 #, fuzzy
 msgid "Detected"
 msgstr "Detektirano"
 
-#: data/ui/delay.glade:91
+#: data/ui/delay.glade:92
 msgid "Delay"
 msgstr "Kašnjenje"
 
-#: data/ui/equalizer.glade:44
+#: data/ui/equalizer.glade:45
 msgid "Equalizer"
 msgstr "Ekvalizator"
 
-#: data/ui/equalizer.glade:153
+#: data/ui/equalizer.glade:154
 #, fuzzy
 msgid "Split Channels"
 msgstr "Kanali"
 
-#: data/ui/equalizer.glade:179
+#: data/ui/equalizer.glade:180
 msgid "IIR"
 msgstr ""
 
-#: data/ui/equalizer.glade:180
+#: data/ui/equalizer.glade:181
 msgid "FIR"
 msgstr ""
 
-#: data/ui/equalizer.glade:181
+#: data/ui/equalizer.glade:182
 msgid "FFT"
 msgstr ""
 
-#: data/ui/equalizer.glade:211
+#: data/ui/equalizer.glade:212
 msgid "Bands"
 msgstr "Broj raspona"
 
-#: data/ui/equalizer.glade:233
+#: data/ui/equalizer.glade:234
 msgid "Flat Response"
 msgstr "Ravan izlaz"
 
-#: data/ui/equalizer.glade:248
+#: data/ui/equalizer.glade:249
 msgid "Calculate Frequencies"
 msgstr "Izračunaj frekvencije"
 
-#: data/ui/equalizer.glade:262
+#: data/ui/equalizer.glade:263
 #, fuzzy
 msgid "Import APO Presets"
 msgstr "Učitaj predloške"
@@ -896,7 +910,7 @@ msgstr "Niski shelf"
 msgid "Notch"
 msgstr ""
 
-#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:314
+#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:315
 msgid "Resonance"
 msgstr "Rezonancija"
 
@@ -940,12 +954,12 @@ msgstr "Kvaliteta"
 msgid "Width"
 msgstr "Širina"
 
-#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:496
+#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:494
 #: data/ui/multiband_compressor.glade:868
-#: data/ui/multiband_compressor.glade:1246
-#: data/ui/multiband_compressor.glade:1624 data/ui/multiband_gate.glade:520
-#: data/ui/multiband_gate.glade:925 data/ui/multiband_gate.glade:1335
-#: data/ui/multiband_gate.glade:1745
+#: data/ui/multiband_compressor.glade:1248
+#: data/ui/multiband_compressor.glade:1628 data/ui/multiband_gate.glade:518
+#: data/ui/multiband_gate.glade:926 data/ui/multiband_gate.glade:1339
+#: data/ui/multiband_gate.glade:1752
 msgid "Solo"
 msgstr "Solo"
 
@@ -953,81 +967,81 @@ msgstr "Solo"
 msgid "Apply"
 msgstr ""
 
-#: data/ui/exciter.glade:117
+#: data/ui/exciter.glade:118
 msgid "Exciter"
 msgstr "Uzbuđivač"
 
-#: data/ui/exciter.glade:384 data/ui/maximizer.glade:165
+#: data/ui/exciter.glade:384 data/ui/maximizer.glade:166
 msgid "Ceiling"
 msgstr "Vrh"
 
-#: data/ui/filter.glade:98
+#: data/ui/filter.glade:99
 #, fuzzy
 msgid "Filter"
 msgstr "Filter"
 
-#: data/ui/filter.glade:147
+#: data/ui/filter.glade:148
 #, fuzzy
 msgid "Muted"
 msgstr "Bezvučno"
 
-#: data/ui/filter.glade:159 data/ui/reverb.glade:233
+#: data/ui/filter.glade:160 data/ui/reverb.glade:234
 msgid "Disco"
 msgstr "Disco"
 
-#: data/ui/filter.glade:171
+#: data/ui/filter.glade:172
 msgid "Distant Headphones"
 msgstr "Udaljene slušalice"
 
-#: data/ui/filter.glade:246
+#: data/ui/filter.glade:247
 msgid "12dB/oct Lowpass"
 msgstr "12dB/oct niski prolaz"
 
-#: data/ui/filter.glade:247
+#: data/ui/filter.glade:248
 msgid "24dB/oct Lowpass"
 msgstr "24dB/oct niski prolaz"
 
-#: data/ui/filter.glade:248
+#: data/ui/filter.glade:249
 msgid "36dB/oct Lowpass"
 msgstr "36dB/oct niski prolaz"
 
-#: data/ui/filter.glade:249
+#: data/ui/filter.glade:250
 msgid "12dB/oct Highpass"
 msgstr "12dB/oct visoki prolaz"
 
-#: data/ui/filter.glade:250
+#: data/ui/filter.glade:251
 msgid "24dB/oct Highpass"
 msgstr "24dB/oct visoki prolaz"
 
-#: data/ui/filter.glade:251
+#: data/ui/filter.glade:252
 msgid "36dB/oct Highpass"
 msgstr "36dB/oct visoki prolaz"
 
-#: data/ui/filter.glade:252
+#: data/ui/filter.glade:253
 msgid "6dB/oct Bandpass"
 msgstr "6dB/oct band prolaz"
 
-#: data/ui/filter.glade:253
+#: data/ui/filter.glade:254
 msgid "12dB/oct Bandpass"
 msgstr "12dB/oct band prolaz"
 
-#: data/ui/filter.glade:254
+#: data/ui/filter.glade:255
 msgid "18dB/oct Bandpass"
 msgstr "18dB/oct band prolaz"
 
-#: data/ui/filter.glade:255
+#: data/ui/filter.glade:256
 msgid "6dB/oct Bandreject"
 msgstr "6dB/oct odbijanje banda"
 
-#: data/ui/filter.glade:256
+#: data/ui/filter.glade:257
 msgid "12dB/oct Bandreject"
 msgstr "12dB/oct odbijanje banda"
 
-#: data/ui/filter.glade:257
+#: data/ui/filter.glade:258
 msgid "18dB/oct Bandreject"
 msgstr "18dB/oct odbijanje banda"
 
-#: data/ui/filter.glade:349
+#: data/ui/filter.glade:350
 msgid "Inertia"
 msgstr "Inercija"
 
@@ -1072,52 +1086,53 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: data/ui/gate.glade:98
+#: data/ui/gate.glade:99
 msgid "Gate"
 msgstr "Vrata"
 
-#: data/ui/gate.glade:209
+#: data/ui/gate.glade:240
+#, fuzzy
+msgid "Maximum Gain Reduction"
+msgstr "Ograničenje pojačanja"
+
+#: data/ui/gate.glade:289
 msgid "Stereo Link"
 msgstr "Stereo veza"
 
-#: data/ui/gate.glade:222 data/ui/maximizer.glade:293
-msgid "Gain Reduction"
-msgstr "Ograničenje pojačanja"
-
-#: data/ui/gate.glade:273
+#: data/ui/gate.glade:304
 #, fuzzy
 msgid "Average"
 msgstr "Prosjek"
 
-#: data/ui/gate.glade:274
+#: data/ui/gate.glade:305
 #, fuzzy
 msgid "Maximum"
 msgstr "Maksimum"
 
-#: data/ui/gate.glade:525
+#: data/ui/gate.glade:578
 #, fuzzy
 msgid "Input Level"
 msgstr "Ulazni uređaj"
 
-#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:811
-#: data/ui/multiband_gate.glade:1220 data/ui/multiband_gate.glade:1630
-#: data/ui/multiband_gate.glade:2040
+#: data/ui/gate.glade:797 data/ui/multiband_gate.glade:812
+#: data/ui/multiband_gate.glade:1224 data/ui/multiband_gate.glade:1637
+#: data/ui/multiband_gate.glade:2050
 msgid "Gating"
 msgstr ""
 
-#: data/ui/limiter.glade:97 data/ui/webrtc.glade:421
+#: data/ui/limiter.glade:98 data/ui/webrtc.glade:422
 msgid "Limiter"
 msgstr "Graničnik"
 
-#: data/ui/limiter.glade:176
+#: data/ui/limiter.glade:175
 msgid "Automatic Smoothing Control"
 msgstr ""
 
-#: data/ui/limiter.glade:190
+#: data/ui/limiter.glade:189
 msgid "Automatic Leveling"
 msgstr ""
 
-#: data/ui/limiter.glade:222
+#: data/ui/limiter.glade:221
 msgid "Input Gain"
 msgstr "Pojačanje ulaza"
 
@@ -1125,146 +1140,150 @@ msgstr "Pojačanje ulaza"
 msgid "Limit"
 msgstr "Granica"
 
-#: data/ui/limiter.glade:358
+#: data/ui/limiter.glade:359
 msgid "Oversampling"
 msgstr "Jači sampling"
 
-#: data/ui/limiter.glade:411
+#: data/ui/limiter.glade:413
 #, fuzzy
 msgid "Output Gain"
 msgstr "Pojačanje ulaza"
 
-#: data/ui/limiter.glade:429
+#: data/ui/limiter.glade:431
 msgid "ASC"
 msgstr "ASC"
 
-#: data/ui/limiter.glade:584
+#: data/ui/limiter.glade:586
 msgid "Attenuation"
 msgstr "Prigušenje"
 
-#: data/ui/loudness.glade:91
+#: data/ui/loudness.glade:92
 msgid "Loudness Compensator"
 msgstr ""
 
-#: data/ui/loudness.glade:147
-msgid "Standard"
-msgstr ""
-
-#: data/ui/loudness.glade:161
-msgid "Flat"
-msgstr ""
-
-#: data/ui/loudness.glade:162
-msgid "ISO226-2003"
-msgstr ""
-
-#: data/ui/loudness.glade:163
-msgid "Fletcher-Munson"
-msgstr ""
-
-#: data/ui/loudness.glade:164
-msgid "Robinson-Dadson"
-msgstr ""
-
-#: data/ui/loudness.glade:174
-msgid "Reference Signal"
-msgstr ""
-
-#: data/ui/loudness.glade:199
+#: data/ui/loudness.glade:155
 #, fuzzy
 msgid "FFT Size"
 msgstr "Veličina okvira"
 
-#: data/ui/maximizer.glade:96
+#: data/ui/loudness.glade:205
+msgid "Standard"
+msgstr ""
+
+#: data/ui/loudness.glade:220
+msgid "Flat"
+msgstr ""
+
+#: data/ui/loudness.glade:221
+msgid "ISO226-2003"
+msgstr ""
+
+#: data/ui/loudness.glade:222
+msgid "Fletcher-Munson"
+msgstr ""
+
+#: data/ui/loudness.glade:223
+msgid "Robinson-Dadson"
+msgstr ""
+
+#: data/ui/loudness.glade:259
+msgid "Reference Signal"
+msgstr ""
+
+#: data/ui/maximizer.glade:97
 msgid "Maximizer"
 msgstr "Maksimizer"
 
-#: data/ui/multiband_compressor.glade:140
+#: data/ui/maximizer.glade:296
+msgid "Gain Reduction"
+msgstr "Ograničenje pojačanja"
+
+#: data/ui/multiband_compressor.glade:141
 #, fuzzy
 msgid "Multiband Compressor"
 msgstr "Višerasponski kompresor"
 
-#: data/ui/multiband_compressor.glade:338 data/ui/multiband_gate.glade:362
+#: data/ui/multiband_compressor.glade:336 data/ui/multiband_gate.glade:360
 msgid "LR4"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:339 data/ui/multiband_gate.glade:363
+#: data/ui/multiband_compressor.glade:337 data/ui/multiband_gate.glade:361
 msgid "LR8"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:353 data/ui/multiband_gate.glade:377
+#: data/ui/multiband_compressor.glade:351 data/ui/multiband_gate.glade:375
 #, fuzzy
 msgid "Split 1/2"
 msgstr "Razdvojeno 1/2"
 
-#: data/ui/multiband_compressor.glade:366 data/ui/multiband_gate.glade:390
+#: data/ui/multiband_compressor.glade:364 data/ui/multiband_gate.glade:388
 #, fuzzy
 msgid "Split 2/3"
 msgstr "Razdvojeno 2/3"
 
-#: data/ui/multiband_compressor.glade:379 data/ui/multiband_gate.glade:403
+#: data/ui/multiband_compressor.glade:377 data/ui/multiband_gate.glade:401
 #, fuzzy
 msgid "Split 3/4"
 msgstr "Razdvojeno 3/4"
 
 #: data/ui/multiband_compressor.glade:754
-#: data/ui/multiband_compressor.glade:1131
-#: data/ui/multiband_compressor.glade:1509
-#: data/ui/multiband_compressor.glade:1887
+#: data/ui/multiband_compressor.glade:1133
+#: data/ui/multiband_compressor.glade:1513
+#: data/ui/multiband_compressor.glade:1893
 #, fuzzy
 msgid "Compression"
 msgstr "Kompresija"
 
-#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:894
+#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:895
 #, fuzzy
 msgid "Sub Band"
 msgstr "Sub band"
 
-#: data/ui/multiband_compressor.glade:1214 data/ui/multiband_gate.glade:1303
+#: data/ui/multiband_compressor.glade:1216 data/ui/multiband_gate.glade:1307
 #, fuzzy
 msgid "Low Band"
 msgstr "Niski band"
 
-#: data/ui/multiband_compressor.glade:1592 data/ui/multiband_gate.glade:1713
+#: data/ui/multiband_compressor.glade:1596 data/ui/multiband_gate.glade:1720
 #, fuzzy
 msgid "Mid Band"
 msgstr "Srednji band"
 
-#: data/ui/multiband_compressor.glade:1970 data/ui/multiband_gate.glade:2123
+#: data/ui/multiband_compressor.glade:1976 data/ui/multiband_gate.glade:2133
 #, fuzzy
 msgid "High Band"
 msgstr "Visoki band"
 
-#: data/ui/multiband_gate.glade:140
+#: data/ui/multiband_gate.glade:141
 #, fuzzy
 msgid "Multiband Gate"
 msgstr "Višerasponska vrata"
 
-#: data/ui/pitch.glade:103
+#: data/ui/pitch.glade:104
 msgid "Pitch"
 msgstr "Visina"
 
-#: data/ui/pitch.glade:178
+#: data/ui/pitch.glade:179
 msgid "Cents"
 msgstr "Centi"
 
-#: data/ui/pitch.glade:209
+#: data/ui/pitch.glade:210
 msgid "Semitones"
 msgstr "Polustepeni"
 
-#: data/ui/pitch.glade:240
+#: data/ui/pitch.glade:241
 msgid "Octaves"
 msgstr "Oktave"
 
-#: data/ui/pitch.glade:271
+#: data/ui/pitch.glade:272
 msgid "Crispness"
 msgstr "Oštrina"
 
-#: data/ui/pitch.glade:311
+#: data/ui/pitch.glade:312
 msgid "Faster"
 msgstr "Brže"
 
-#: data/ui/pitch.glade:325
+#: data/ui/pitch.glade:326
 msgid "Preserve Formant"
 msgstr "Sačuvaj formant"
 
@@ -1368,88 +1387,88 @@ msgstr ""
 msgid "Pipeline Output"
 msgstr "Ekvalizator - Izlaz"
 
-#: data/ui/reverb.glade:131
+#: data/ui/reverb.glade:132
 msgid "Reverberation"
 msgstr "Reverberacija"
 
-#: data/ui/reverb.glade:181
+#: data/ui/reverb.glade:182
 #, fuzzy
 msgid "Ambience"
 msgstr "Ambijent"
 
-#: data/ui/reverb.glade:194
+#: data/ui/reverb.glade:195
 msgid "Empty Walls"
 msgstr "Prazna soba"
 
-#: data/ui/reverb.glade:207
+#: data/ui/reverb.glade:208
 #, fuzzy
 msgid "Room"
 msgstr "Soba"
 
-#: data/ui/reverb.glade:220
+#: data/ui/reverb.glade:221
 msgid "Large Empty Hall"
 msgstr "Velika prazna dvorana"
 
-#: data/ui/reverb.glade:246
+#: data/ui/reverb.glade:247
 msgid "Large Occupied Hall"
 msgstr "Velika popunjena dvorana"
 
-#: data/ui/reverb.glade:361
+#: data/ui/reverb.glade:362
 #, fuzzy
 msgid "Pre Delay"
 msgstr "Prijevremeno kašnjenje"
 
-#: data/ui/reverb.glade:374
+#: data/ui/reverb.glade:375
 msgid "Decay Time"
 msgstr "Vrijeme opadanja intenziteta signala"
 
-#: data/ui/reverb.glade:439
+#: data/ui/reverb.glade:441
 msgid "Dry"
 msgstr "Suhoća"
 
-#: data/ui/reverb.glade:471
+#: data/ui/reverb.glade:474
 msgid "Bass Cut"
 msgstr "Odrezivanje basa"
 
-#: data/ui/reverb.glade:522
+#: data/ui/reverb.glade:525
 msgid "Treble Cut"
 msgstr "Odrezivanje trebla"
 
-#: data/ui/reverb.glade:565
+#: data/ui/reverb.glade:568
 msgid "Diffusion"
 msgstr "Difuzija"
 
-#: data/ui/reverb.glade:577
+#: data/ui/reverb.glade:580
 msgid "Room Size"
 msgstr "Veličina sobe"
 
-#: data/ui/reverb.glade:590
+#: data/ui/reverb.glade:593
 #, fuzzy
 msgid "Small"
 msgstr "Mala"
 
-#: data/ui/reverb.glade:591
+#: data/ui/reverb.glade:594
 msgid "Medium"
 msgstr "Osrednja"
 
-#: data/ui/reverb.glade:592
+#: data/ui/reverb.glade:595
 #, fuzzy
 msgid "Large"
 msgstr "Velika"
 
-#: data/ui/reverb.glade:593
+#: data/ui/reverb.glade:596
 msgid "Tunnel"
 msgstr "Tunel"
 
-#: data/ui/reverb.glade:594
+#: data/ui/reverb.glade:597
 msgid "Large/smooth"
 msgstr "Velika/glatko"
 
-#: data/ui/reverb.glade:595
+#: data/ui/reverb.glade:598
 msgid "Experimental"
 msgstr "Eksperimentalna"
 
-#: data/ui/reverb.glade:608
+#: data/ui/reverb.glade:611
 msgid "High Frequency Damping"
 msgstr "Prigušivanje visokih frekvencija"
 
@@ -1529,25 +1548,25 @@ msgstr "Visina"
 msgid "Points"
 msgstr "Broj traka"
 
-#: data/ui/stereo_tools.glade:109
+#: data/ui/stereo_tools.glade:110
 #, fuzzy
 msgid "Stereo Tools"
 msgstr "Stereo alati"
 
-#: data/ui/stereo_tools.glade:231
+#: data/ui/stereo_tools.glade:230
 msgid "Softclip"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:255 data/ui/stereo_tools.glade:671
+#: data/ui/stereo_tools.glade:254 data/ui/stereo_tools.glade:672
 msgid "Balance"
 msgstr "Ravnoteža"
 
-#: data/ui/stereo_tools.glade:287
+#: data/ui/stereo_tools.glade:286
 #, fuzzy
 msgid "S/C Level"
 msgstr "S/C Razina"
 
-#: data/ui/stereo_tools.glade:345
+#: data/ui/stereo_tools.glade:344
 #, fuzzy
 msgid "Side Level"
 msgstr "Stranična razina"
@@ -1557,152 +1576,152 @@ msgstr "Stranična razina"
 msgid "Side Balance"
 msgstr "Stranična ravnoteža"
 
-#: data/ui/stereo_tools.glade:428
+#: data/ui/stereo_tools.glade:429
 #, fuzzy
 msgid "Middle Level"
 msgstr "Srednji nivo"
 
-#: data/ui/stereo_tools.glade:441
+#: data/ui/stereo_tools.glade:442
 #, fuzzy
 msgid "Middle Panorama"
 msgstr "Srednja panorama"
 
-#: data/ui/stereo_tools.glade:499
+#: data/ui/stereo_tools.glade:500
 msgid "LR > LR (Stereo Default)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:500
+#: data/ui/stereo_tools.glade:501
 msgid "LR > MS (Stereo to Mid-Side)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:501
+#: data/ui/stereo_tools.glade:502
 msgid "MS > LR (Mid-Side to Stereo)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:502
+#: data/ui/stereo_tools.glade:503
 msgid "LR > LL (Mono Left Channel)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:503
+#: data/ui/stereo_tools.glade:504
 msgid "LR > RR (Mono Right Channel)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:504
+#: data/ui/stereo_tools.glade:505
 msgid "LR > L+R (Mono Sum L+R)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:505
+#: data/ui/stereo_tools.glade:506
 msgid "LR > RL (Stereo Flip Channels)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:522
+#: data/ui/stereo_tools.glade:523
 #, fuzzy
 msgid "Stereo Matrix"
 msgstr "Stereo matrica"
 
-#: data/ui/stereo_tools.glade:561 data/ui/stereo_tools.glade:602
+#: data/ui/stereo_tools.glade:562 data/ui/stereo_tools.glade:603
 msgid "Invert Phase"
 msgstr "Inverzija faze"
 
-#: data/ui/stereo_tools.glade:703
+#: data/ui/stereo_tools.glade:704
 #, fuzzy
 msgid "Delay L/R"
 msgstr "Kašnjenje L/D"
 
-#: data/ui/stereo_tools.glade:737
+#: data/ui/stereo_tools.glade:738
 #, fuzzy
 msgid "Stereo Base"
 msgstr "Stereo baza"
 
-#: data/ui/stereo_tools.glade:770
+#: data/ui/stereo_tools.glade:771
 #, fuzzy
 msgid "Stereo Phase"
 msgstr "Stereo faza"
 
-#: data/ui/webrtc.glade:97
+#: data/ui/webrtc.glade:98
 msgid "WebRTC"
 msgstr ""
 
-#: data/ui/webrtc.glade:163 data/ui/webrtc.glade:283 data/ui/webrtc.glade:353
-#: data/ui/webrtc.glade:523
+#: data/ui/webrtc.glade:164 data/ui/webrtc.glade:284 data/ui/webrtc.glade:354
+#: data/ui/webrtc.glade:524
 msgid "Enable"
 msgstr "Omogući"
 
-#: data/ui/webrtc.glade:184
+#: data/ui/webrtc.glade:185
 msgid "Extended Filter"
 msgstr "Prošireni filter"
 
-#: data/ui/webrtc.glade:197
+#: data/ui/webrtc.glade:198
 msgid "Delay Agnostic"
 msgstr ""
 
-#: data/ui/webrtc.glade:209
+#: data/ui/webrtc.glade:210
 msgid "High Pass Filter"
 msgstr "Filter visokog prolaza"
 
-#: data/ui/webrtc.glade:238 data/ui/webrtc.glade:306
+#: data/ui/webrtc.glade:239 data/ui/webrtc.glade:307
 #, fuzzy
 msgid "Suppresion Level"
 msgstr "Razina supresije"
 
-#: data/ui/webrtc.glade:251 data/ui/webrtc.glade:319 data/ui/webrtc.glade:575
+#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
 msgid "Low"
 msgstr "Nisko"
 
-#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
+#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
 msgid "Moderate"
 msgstr "Umjereno"
 
-#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
+#: data/ui/webrtc.glade:254 data/ui/webrtc.glade:322 data/ui/webrtc.glade:578
 msgid "High"
 msgstr "Visoko"
 
-#: data/ui/webrtc.glade:270
+#: data/ui/webrtc.glade:271
 msgid "Echo Canceller"
 msgstr "Poništenje jeke"
 
-#: data/ui/webrtc.glade:322
+#: data/ui/webrtc.glade:323
 #, fuzzy
 msgid "Very High"
 msgstr "Jako visoko"
 
-#: data/ui/webrtc.glade:339
+#: data/ui/webrtc.glade:340
 msgid "Noise Suppressor"
 msgstr "Supresija buke"
 
-#: data/ui/webrtc.glade:389
+#: data/ui/webrtc.glade:390
 msgid "Adaptive Digital"
 msgstr ""
 
-#: data/ui/webrtc.glade:390
+#: data/ui/webrtc.glade:391
 msgid "Fixed Digital"
 msgstr ""
 
-#: data/ui/webrtc.glade:407
+#: data/ui/webrtc.glade:408
 msgid "Gain Controller"
 msgstr "Kontrola pojačanja"
 
-#: data/ui/webrtc.glade:445
+#: data/ui/webrtc.glade:446
 msgid "Target Level"
 msgstr "Ciljana razina"
 
-#: data/ui/webrtc.glade:475
+#: data/ui/webrtc.glade:476
 msgid "Maximum Gain"
 msgstr "Najveće pojačanje"
 
-#: data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:549
 msgid "Detection Likelihood"
 msgstr "Vjerojatnost detekcije"
 
-#: data/ui/webrtc.glade:561
+#: data/ui/webrtc.glade:562
 msgid "Frame Size"
 msgstr "Veličina okvira"
 
-#: data/ui/webrtc.glade:574
+#: data/ui/webrtc.glade:575
 msgid "Very Low"
 msgstr "Vrlo nisko"
 
-#: data/ui/webrtc.glade:611
+#: data/ui/webrtc.glade:612
 msgid "Voice Detector"
 msgstr "Detektor glasa"
 
@@ -1803,3 +1822,7 @@ msgstr "Općenito"
 #: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
+
+#, fuzzy
+#~ msgid "Gain Detection"
+#~ msgstr "Ograničenje pojačanja"

--- a/po/id_ID.po
+++ b/po/id_ID.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pulseeffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-22 15:29+0200\n"
+"POT-Creation-Date: 2020-08-24 16:51+0200\n"
 "PO-Revision-Date: 2019-01-17 18:30+0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -84,8 +84,8 @@ msgid "Input Limiter"
 msgstr "Pembatas Masukan"
 
 #: data/com.github.wwmm.pulseeffects.appdata.xml.in:52
-#: data/ui/compressor.glade:111 data/ui/compressor.glade:494
-#: data/ui/webrtc.glade:509
+#: data/ui/compressor.glade:112 data/ui/compressor.glade:494
+#: data/ui/webrtc.glade:510
 msgid "Compressor"
 msgstr "Kompresor"
 
@@ -117,12 +117,12 @@ msgstr "Aplikasi"
 msgid "Format"
 msgstr "Format Resampling"
 
-#: data/ui/app_info.glade:75 data/ui/convolver.glade:283
+#: data/ui/app_info.glade:75 data/ui/convolver.glade:284
 msgid "Rate"
 msgstr "Rataan Frekuensi"
 
 #: data/ui/app_info.glade:102 data/ui/pulse_info.glade:238
-#: data/ui/stereo_tools.glade:653
+#: data/ui/stereo_tools.glade:654
 msgid "Channels"
 msgstr "Total Kanal"
 
@@ -161,7 +161,7 @@ msgstr "Uji Sinyal"
 msgid "Global Bypass"
 msgstr "Bypass"
 
-#: data/ui/application.glade:170 data/ui/equalizer.glade:277
+#: data/ui/application.glade:170 data/ui/equalizer.glade:278
 #: data/ui/general_settings.glade:107
 msgid "Settings"
 msgstr "Setelan"
@@ -170,171 +170,170 @@ msgstr "Setelan"
 msgid "Help"
 msgstr "Bantuan"
 
-#: data/ui/application.glade:215 data/ui/crossfeed.glade:49
-#: data/ui/equalizer.glade:333 data/ui/filter.glade:230
-#: data/ui/reverb.glade:310 src/presets_menu_ui.cpp:113
+#: data/ui/application.glade:215 data/ui/crossfeed.glade:48
+#: data/ui/equalizer.glade:334 data/ui/filter.glade:231
+#: data/ui/reverb.glade:311 src/presets_menu_ui.cpp:113
 #: src/presets_menu_ui.cpp:258 src/presets_menu_ui.cpp:275
 msgid "Presets"
 msgstr "Preset"
 
-#: data/ui/autogain.glade:91
+#: data/ui/autogain.glade:92
 msgid "Auto Gain"
 msgstr "Gain Otomatis"
 
-#: data/ui/autogain.glade:171
+#: data/ui/autogain.glade:172
 msgid "Reset History"
 msgstr ""
 
-#: data/ui/autogain.glade:183
+#: data/ui/autogain.glade:184
 #, fuzzy
 msgid "Detect Silence"
 msgstr "Deteksi"
 
-#: data/ui/autogain.glade:195
+#: data/ui/autogain.glade:196
 #, fuzzy
 msgid "Use Geometric Mean"
 msgstr "Terapkan Gradien warna"
 
-#: data/ui/autogain.glade:233
+#: data/ui/autogain.glade:234
 msgid "Target"
 msgstr "Target"
 
-#: data/ui/autogain.glade:283 data/ui/autogain.glade:627
+#: data/ui/autogain.glade:286 data/ui/autogain.glade:631
 msgid "Momentary"
 msgstr "Efek Sejenak"
 
-#: data/ui/autogain.glade:298 data/ui/autogain.glade:640
+#: data/ui/autogain.glade:301 data/ui/autogain.glade:644
 msgid "Short Term"
 msgstr "Waktu Singkat"
 
-#: data/ui/autogain.glade:313 data/ui/autogain.glade:653
+#: data/ui/autogain.glade:316 data/ui/autogain.glade:657
 msgid "Integrated"
 msgstr "Terintegrasi"
 
-#: data/ui/autogain.glade:388
+#: data/ui/autogain.glade:394
 msgid "Weights"
 msgstr "Tinggi"
 
-#: data/ui/autogain.glade:428 data/ui/autogain.glade:917
-#: data/ui/bass_enhancer.glade:504 data/ui/compressor.glade:974
-#: data/ui/convolver.glade:504 data/ui/crossfeed.glade:200
-#: data/ui/crystalizer.glade:255 data/ui/deesser.glade:593
-#: data/ui/delay.glade:236 data/ui/equalizer.glade:543
-#: data/ui/exciter.glade:510 data/ui/filter.glade:396 data/ui/gate.glade:558
-#: data/ui/limiter.glade:483 data/ui/loudness.glade:259
-#: data/ui/loudness.glade:338 data/ui/maximizer.glade:265
-#: data/ui/multiband_compressor.glade:2000 data/ui/multiband_gate.glade:2153
-#: data/ui/pitch.glade:362 data/ui/presets_menu.glade:255
-#: data/ui/reverb.glade:658 data/ui/stereo_tools.glade:323
-#: data/ui/stereo_tools.glade:829 data/ui/webrtc.glade:650
+#: data/ui/autogain.glade:434 data/ui/autogain.glade:921
+#: data/ui/bass_enhancer.glade:506 data/ui/compressor.glade:977
+#: data/ui/convolver.glade:505 data/ui/crossfeed.glade:199
+#: data/ui/crystalizer.glade:205 data/ui/deesser.glade:594
+#: data/ui/delay.glade:237 data/ui/equalizer.glade:544
+#: data/ui/exciter.glade:510 data/ui/filter.glade:397 data/ui/gate.glade:611
+#: data/ui/limiter.glade:485 data/ui/loudness.glade:299
+#: data/ui/loudness.glade:380 data/ui/maximizer.glade:268
+#: data/ui/multiband_compressor.glade:2006 data/ui/multiband_gate.glade:2163
+#: data/ui/pitch.glade:363 data/ui/presets_menu.glade:255
+#: data/ui/reverb.glade:661 data/ui/stereo_tools.glade:322
+#: data/ui/stereo_tools.glade:830 data/ui/webrtc.glade:651
 msgid "Input"
 msgstr "Masukan"
 
-#: data/ui/autogain.glade:443 data/ui/autogain.glade:862
-#: data/ui/bass_enhancer.glade:536 data/ui/compressor.glade:988
-#: data/ui/convolver.glade:519 data/ui/crossfeed.glade:214
-#: data/ui/crystalizer.glade:270 data/ui/deesser.glade:607
-#: data/ui/delay.glade:250 data/ui/equalizer.glade:557
-#: data/ui/exciter.glade:542 data/ui/filter.glade:411 data/ui/gate.glade:572
-#: data/ui/limiter.glade:626 data/ui/loudness.glade:292
-#: data/ui/loudness.glade:352 data/ui/maximizer.glade:279
+#: data/ui/autogain.glade:449 data/ui/autogain.glade:866
+#: data/ui/bass_enhancer.glade:537 data/ui/compressor.glade:991
+#: data/ui/convolver.glade:520 data/ui/crossfeed.glade:213
+#: data/ui/crystalizer.glade:220 data/ui/deesser.glade:608
+#: data/ui/delay.glade:251 data/ui/equalizer.glade:558
+#: data/ui/exciter.glade:541 data/ui/filter.glade:412 data/ui/gate.glade:625
+#: data/ui/limiter.glade:628 data/ui/loudness.glade:333
+#: data/ui/loudness.glade:394 data/ui/maximizer.glade:282
 #: data/ui/multiband_compressor.glade:794
-#: data/ui/multiband_compressor.glade:1171
-#: data/ui/multiband_compressor.glade:1549
-#: data/ui/multiband_compressor.glade:1927
-#: data/ui/multiband_compressor.glade:2015 data/ui/multiband_gate.glade:851
-#: data/ui/multiband_gate.glade:1260 data/ui/multiband_gate.glade:1670
-#: data/ui/multiband_gate.glade:2080 data/ui/multiband_gate.glade:2168
-#: data/ui/pitch.glade:376 data/ui/presets_menu.glade:146
-#: data/ui/reverb.glade:673 data/ui/stereo_tools.glade:800
-#: data/ui/stereo_tools.glade:843 data/ui/webrtc.glade:664
+#: data/ui/multiband_compressor.glade:1173
+#: data/ui/multiband_compressor.glade:1553
+#: data/ui/multiband_compressor.glade:1933
+#: data/ui/multiband_compressor.glade:2021 data/ui/multiband_gate.glade:852
+#: data/ui/multiband_gate.glade:1264 data/ui/multiband_gate.glade:1677
+#: data/ui/multiband_gate.glade:2090 data/ui/multiband_gate.glade:2178
+#: data/ui/pitch.glade:377 data/ui/presets_menu.glade:146
+#: data/ui/reverb.glade:676 data/ui/stereo_tools.glade:801
+#: data/ui/stereo_tools.glade:844 data/ui/webrtc.glade:665
 msgid "Output"
 msgstr "Output"
 
-#: data/ui/autogain.glade:744
+#: data/ui/autogain.glade:748
 msgid "Relative"
 msgstr "Relatif"
 
-#: data/ui/autogain.glade:757 data/ui/compressor.glade:1154
-#: data/ui/deesser.glade:321
+#: data/ui/autogain.glade:761 data/ui/compressor.glade:1157
 msgid "Gain"
 msgstr "Besar Gain"
 
-#: data/ui/autogain.glade:823
+#: data/ui/autogain.glade:827
 msgid "Loudness"
 msgstr "Kelantangan"
 
-#: data/ui/autogain.glade:876
+#: data/ui/autogain.glade:880
 msgid "Range"
 msgstr "Rentang"
 
-#: data/ui/autogain.glade:945 data/ui/bass_enhancer.glade:655
-#: data/ui/compressor.glade:1299 data/ui/convolver.glade:703
-#: data/ui/crossfeed.glade:395 data/ui/crystalizer.glade:566
-#: data/ui/deesser.glade:898 data/ui/delay.glade:434
-#: data/ui/equalizer.glade:743 data/ui/equalizer_band.glade:182
-#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:661
-#: data/ui/filter.glade:595 data/ui/general_settings.glade:116
-#: data/ui/gate.glade:809 data/ui/limiter.glade:733 data/ui/loudness.glade:573
-#: data/ui/maximizer.glade:516 data/ui/multiband_compressor.glade:2199
-#: data/ui/multiband_gate.glade:2352 data/ui/pitch.glade:560
-#: data/ui/reverb.glade:857 data/ui/stereo_tools.glade:1029
-#: data/ui/webrtc.glade:814
+#: data/ui/autogain.glade:949 data/ui/bass_enhancer.glade:650
+#: data/ui/compressor.glade:1300 data/ui/convolver.glade:702
+#: data/ui/crossfeed.glade:394 data/ui/crystalizer.glade:514
+#: data/ui/deesser.glade:899 data/ui/delay.glade:433
+#: data/ui/equalizer.glade:744 data/ui/equalizer_band.glade:182
+#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:654
+#: data/ui/filter.glade:594 data/ui/general_settings.glade:116
+#: data/ui/gate.glade:862 data/ui/limiter.glade:735 data/ui/loudness.glade:615
+#: data/ui/maximizer.glade:519 data/ui/multiband_compressor.glade:2203
+#: data/ui/multiband_gate.glade:2360 data/ui/pitch.glade:559
+#: data/ui/reverb.glade:858 data/ui/stereo_tools.glade:1028
+#: data/ui/webrtc.glade:815
 msgid "Reset"
 msgstr "Atur Ulang"
 
-#: data/ui/autogain.glade:969
+#: data/ui/autogain.glade:973
 msgid "Based on"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:117
+#: data/ui/bass_enhancer.glade:118
 msgid "Bass Enhancer"
 msgstr "Penguat Bass"
 
-#: data/ui/bass_enhancer.glade:169 data/ui/compressor.glade:506
-#: data/ui/deesser.glade:188 data/ui/exciter.glade:171
+#: data/ui/bass_enhancer.glade:170 data/ui/compressor.glade:506
+#: data/ui/deesser.glade:185 data/ui/exciter.glade:170
 msgid "Listen"
 msgstr "Uji Pengaturan"
 
-#: data/ui/bass_enhancer.glade:210 data/ui/exciter.glade:213
+#: data/ui/bass_enhancer.glade:211 data/ui/exciter.glade:212
 msgid "3rd"
 msgstr "Ketiga"
 
-#: data/ui/bass_enhancer.glade:222 data/ui/exciter.glade:225
+#: data/ui/bass_enhancer.glade:223 data/ui/exciter.glade:224
 msgid "2nd"
 msgstr "Kedua"
 
-#: data/ui/bass_enhancer.glade:234 data/ui/exciter.glade:237
+#: data/ui/bass_enhancer.glade:235 data/ui/exciter.glade:236
 msgid "Blend Harmonics"
 msgstr "Pencampuran Harmonik"
 
-#: data/ui/bass_enhancer.glade:266 data/ui/exciter.glade:271
-#: data/ui/reverb.glade:407
+#: data/ui/bass_enhancer.glade:267 data/ui/exciter.glade:270
+#: data/ui/reverb.glade:408
 msgid "Amount"
 msgstr "Besaran"
 
-#: data/ui/bass_enhancer.glade:278 data/ui/bass_enhancer.glade:411
-#: data/ui/exciter.glade:284 data/ui/exciter.glade:417
+#: data/ui/bass_enhancer.glade:279 data/ui/bass_enhancer.glade:413
+#: data/ui/exciter.glade:283 data/ui/exciter.glade:417
 msgid "Harmonics"
 msgstr "Harmonik"
 
-#: data/ui/bass_enhancer.glade:290 data/ui/exciter.glade:297
+#: data/ui/bass_enhancer.glade:291 data/ui/exciter.glade:296
 msgid "Scope"
 msgstr "Frekuensi Target Bass"
 
-#: data/ui/bass_enhancer.glade:379
+#: data/ui/bass_enhancer.glade:381
 msgid "Floor"
 msgstr "Monitor Lantai"
 
-#: data/ui/bass_enhancer.glade:679 data/ui/compressor.glade:1323
-#: data/ui/crossfeed.glade:419 data/ui/deesser.glade:922
-#: data/ui/delay.glade:458 data/ui/equalizer.glade:767
-#: data/ui/exciter.glade:685 data/ui/filter.glade:619 data/ui/gate.glade:833
-#: data/ui/limiter.glade:757 data/ui/loudness.glade:542
-#: data/ui/maximizer.glade:540 data/ui/multiband_compressor.glade:2223
-#: data/ui/multiband_gate.glade:2376 data/ui/pitch.glade:584
-#: data/ui/reverb.glade:881 data/ui/stereo_tools.glade:1053
-#: data/ui/webrtc.glade:838
+#: data/ui/bass_enhancer.glade:674 data/ui/compressor.glade:1324
+#: data/ui/crossfeed.glade:418 data/ui/deesser.glade:923
+#: data/ui/delay.glade:457 data/ui/equalizer.glade:768
+#: data/ui/exciter.glade:678 data/ui/filter.glade:618 data/ui/gate.glade:886
+#: data/ui/limiter.glade:759 data/ui/loudness.glade:584
+#: data/ui/maximizer.glade:543 data/ui/multiband_compressor.glade:2227
+#: data/ui/multiband_gate.glade:2384 data/ui/pitch.glade:583
+#: data/ui/reverb.glade:882 data/ui/stereo_tools.glade:1052
+#: data/ui/webrtc.glade:839
 msgid "Provided by"
 msgstr ""
 
@@ -369,138 +368,138 @@ msgstr "Efek Luaran"
 msgid "Show Blocklisted Apps in Main Tab"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:32 data/ui/equalizer_band.glade:152
-#: data/ui/filter.glade:280
+#: data/ui/calibration_signals.glade:30 data/ui/equalizer_band.glade:152
+#: data/ui/filter.glade:281
 msgid "Frequency"
 msgstr "Frekuensi"
 
-#: data/ui/calibration_signals.glade:64
+#: data/ui/calibration_signals.glade:62
 msgid "Volume"
 msgstr "Volume"
 
-#: data/ui/calibration_signals.glade:108
+#: data/ui/calibration_signals.glade:106
 msgid "Sine"
 msgstr "Sinus"
 
-#: data/ui/calibration_signals.glade:109
+#: data/ui/calibration_signals.glade:107
 msgid "Square"
 msgstr "Kotak"
 
-#: data/ui/calibration_signals.glade:110
+#: data/ui/calibration_signals.glade:108
 msgid "Saw"
 msgstr "Gergaji"
 
-#: data/ui/calibration_signals.glade:111
+#: data/ui/calibration_signals.glade:109
 msgid "Triangle"
 msgstr "Segitiga"
 
-#: data/ui/calibration_signals.glade:112
+#: data/ui/calibration_signals.glade:110
 msgid "Silence"
 msgstr "Diam"
 
-#: data/ui/calibration_signals.glade:113
+#: data/ui/calibration_signals.glade:111
 msgid "White Noise"
 msgstr "Derau Putih"
 
-#: data/ui/calibration_signals.glade:114
+#: data/ui/calibration_signals.glade:112
 msgid "Pink Noise"
 msgstr "Derau Merah Muda"
 
-#: data/ui/calibration_signals.glade:115
+#: data/ui/calibration_signals.glade:113
 msgid "Sine Table"
 msgstr "Tabel Sinus"
 
-#: data/ui/calibration_signals.glade:116
+#: data/ui/calibration_signals.glade:114
 msgid "Ticks"
 msgstr "Ketukan per Detik"
 
-#: data/ui/calibration_signals.glade:117
+#: data/ui/calibration_signals.glade:115
 msgid "Gaussian Noise"
 msgstr "Derau Gaussia"
 
-#: data/ui/calibration_signals.glade:118
+#: data/ui/calibration_signals.glade:116
 msgid "Red Noise"
 msgstr "Derau Merah"
 
-#: data/ui/calibration_signals.glade:119
+#: data/ui/calibration_signals.glade:117
 msgid "Blue Noise"
 msgstr "Derau Biru"
 
-#: data/ui/calibration_signals.glade:120
+#: data/ui/calibration_signals.glade:118
 msgid "Violet Noise"
 msgstr "Derau Ungu"
 
-#: data/ui/calibration_mic.glade:29
+#: data/ui/calibration_mic.glade:28
 msgid "Window"
 msgstr "Jendela"
 
-#: data/ui/calibration_mic.glade:70
+#: data/ui/calibration_mic.glade:69
 msgid "Measure Noise"
 msgstr "Ukur Derau"
 
-#: data/ui/calibration_mic.glade:99
+#: data/ui/calibration_mic.glade:98
 msgid "Subtract Noise"
 msgstr "Kurangi Derau"
 
-#: data/ui/compressor.glade:292 data/ui/deesser.glade:483
-#: data/ui/gate.glade:370 data/ui/maximizer.glade:152
-#: data/ui/multiband_compressor.glade:609
+#: data/ui/compressor.glade:290 data/ui/deesser.glade:482
+#: data/ui/gate.glade:413 data/ui/maximizer.glade:153
+#: data/ui/multiband_compressor.glade:607
 #: data/ui/multiband_compressor.glade:983
-#: data/ui/multiband_compressor.glade:1361
-#: data/ui/multiband_compressor.glade:1739 data/ui/multiband_gate.glade:633
-#: data/ui/multiband_gate.glade:1040 data/ui/multiband_gate.glade:1450
-#: data/ui/multiband_gate.glade:1860
+#: data/ui/multiband_compressor.glade:1363
+#: data/ui/multiband_compressor.glade:1743 data/ui/multiband_gate.glade:631
+#: data/ui/multiband_gate.glade:1041 data/ui/multiband_gate.glade:1454
+#: data/ui/multiband_gate.glade:1867
 msgid "Threshold"
 msgstr "Ambang Batas"
 
-#: data/ui/compressor.glade:325 data/ui/deesser.glade:516
-#: data/ui/gate.glade:403 data/ui/multiband_compressor.glade:642
-#: data/ui/multiband_compressor.glade:1017
-#: data/ui/multiband_compressor.glade:1395
-#: data/ui/multiband_compressor.glade:1773 data/ui/multiband_gate.glade:666
-#: data/ui/multiband_gate.glade:1074 data/ui/multiband_gate.glade:1484
-#: data/ui/multiband_gate.glade:1894
+#: data/ui/compressor.glade:324 data/ui/deesser.glade:516
+#: data/ui/gate.glade:449 data/ui/multiband_compressor.glade:641
+#: data/ui/multiband_compressor.glade:1018
+#: data/ui/multiband_compressor.glade:1398
+#: data/ui/multiband_compressor.glade:1778 data/ui/multiband_gate.glade:665
+#: data/ui/multiband_gate.glade:1076 data/ui/multiband_gate.glade:1489
+#: data/ui/multiband_gate.glade:1902
 msgid "Ratio"
 msgstr "Rasio"
 
-#: data/ui/compressor.glade:357 data/ui/gate.glade:435
-#: data/ui/multiband_compressor.glade:674
-#: data/ui/multiband_compressor.glade:1050
-#: data/ui/multiband_compressor.glade:1428
-#: data/ui/multiband_compressor.glade:1806 data/ui/multiband_gate.glade:698
-#: data/ui/multiband_gate.glade:1107 data/ui/multiband_gate.glade:1517
-#: data/ui/multiband_gate.glade:1927
+#: data/ui/compressor.glade:356 data/ui/gate.glade:483
+#: data/ui/multiband_compressor.glade:673
+#: data/ui/multiband_compressor.glade:1051
+#: data/ui/multiband_compressor.glade:1431
+#: data/ui/multiband_compressor.glade:1811 data/ui/multiband_gate.glade:697
+#: data/ui/multiband_gate.glade:1109 data/ui/multiband_gate.glade:1522
+#: data/ui/multiband_gate.glade:1935
 msgid "Knee"
 msgstr "Knee"
 
-#: data/ui/compressor.glade:391 data/ui/deesser.glade:547
-#: data/ui/gate.glade:469 data/ui/multiband_compressor.glade:708
-#: data/ui/multiband_compressor.glade:1085
-#: data/ui/multiband_compressor.glade:1463
-#: data/ui/multiband_compressor.glade:1841 data/ui/multiband_gate.glade:732
-#: data/ui/multiband_gate.glade:1142 data/ui/multiband_gate.glade:1552
-#: data/ui/multiband_gate.glade:1962
+#: data/ui/compressor.glade:390 data/ui/deesser.glade:547
+#: data/ui/gate.glade:519 data/ui/multiband_compressor.glade:707
+#: data/ui/multiband_compressor.glade:1086
+#: data/ui/multiband_compressor.glade:1466
+#: data/ui/multiband_compressor.glade:1846 data/ui/multiband_gate.glade:731
+#: data/ui/multiband_gate.glade:1144 data/ui/multiband_gate.glade:1557
+#: data/ui/multiband_gate.glade:1970
 msgid "Makeup"
 msgstr "Penguatan"
 
-#: data/ui/compressor.glade:425 data/ui/gate.glade:336
-#: data/ui/limiter.glade:310 data/ui/maximizer.glade:178
-#: data/ui/multiband_compressor.glade:575
+#: data/ui/compressor.glade:425 data/ui/gate.glade:377
+#: data/ui/limiter.glade:311 data/ui/maximizer.glade:179
+#: data/ui/multiband_compressor.glade:573
 #: data/ui/multiband_compressor.glade:948
-#: data/ui/multiband_compressor.glade:1326
-#: data/ui/multiband_compressor.glade:1704 data/ui/multiband_gate.glade:599
-#: data/ui/multiband_gate.glade:1005 data/ui/multiband_gate.glade:1415
-#: data/ui/multiband_gate.glade:1825
+#: data/ui/multiband_compressor.glade:1328
+#: data/ui/multiband_compressor.glade:1708 data/ui/multiband_gate.glade:597
+#: data/ui/multiband_gate.glade:1006 data/ui/multiband_gate.glade:1419
+#: data/ui/multiband_gate.glade:1832
 msgid "Release"
 msgstr "Rilis"
 
-#: data/ui/compressor.glade:438 data/ui/gate.glade:302
-#: data/ui/multiband_compressor.glade:541
+#: data/ui/compressor.glade:438 data/ui/gate.glade:341
+#: data/ui/multiband_compressor.glade:539
 #: data/ui/multiband_compressor.glade:913
-#: data/ui/multiband_compressor.glade:1291
-#: data/ui/multiband_compressor.glade:1669 data/ui/multiband_gate.glade:565
-#: data/ui/multiband_gate.glade:970 data/ui/multiband_gate.glade:1380
-#: data/ui/multiband_gate.glade:1790
+#: data/ui/multiband_compressor.glade:1293
+#: data/ui/multiband_compressor.glade:1673 data/ui/multiband_gate.glade:563
+#: data/ui/multiband_gate.glade:971 data/ui/multiband_gate.glade:1384
+#: data/ui/multiband_gate.glade:1797
 msgid "Attack"
 msgstr "Attack"
 
@@ -517,213 +516,212 @@ msgstr "Kompresi Mengangkat"
 msgid "Compression Mode"
 msgstr "Modus Kompresi"
 
-#: data/ui/compressor.glade:551
+#: data/ui/compressor.glade:552
 #, fuzzy
 msgid "Pre-amplification"
 msgstr "Pra-Amplifikasi"
 
-#: data/ui/compressor.glade:585
+#: data/ui/compressor.glade:586
 msgid "Reactivity"
 msgstr "Pengaktifan Ulang"
 
-#: data/ui/compressor.glade:619 data/ui/limiter.glade:323
+#: data/ui/compressor.glade:620 data/ui/limiter.glade:324
 msgid "Lookahead"
 msgstr "Lookahead"
 
-#: data/ui/compressor.glade:632
+#: data/ui/compressor.glade:633
 msgid "Feed-forward"
 msgstr "Feed-forward"
 
-#: data/ui/compressor.glade:633
+#: data/ui/compressor.glade:634
 #, fuzzy
 msgid "Feed-back"
 msgstr "Volume Penyuapan"
 
-#: data/ui/compressor.glade:647 data/ui/equalizer_band.glade:48
+#: data/ui/compressor.glade:648 data/ui/equalizer_band.glade:48
 msgid "Type"
 msgstr "Tipe"
 
-#: data/ui/compressor.glade:661 data/ui/deesser.glade:244
-#: data/ui/deesser.glade:354 data/ui/gate.glade:257
-#: data/ui/multiband_compressor.glade:514
+#: data/ui/compressor.glade:662 data/ui/deesser.glade:241
+#: data/ui/gate.glade:213 data/ui/multiband_compressor.glade:512
 #: data/ui/multiband_compressor.glade:886
-#: data/ui/multiband_compressor.glade:1264
-#: data/ui/multiband_compressor.glade:1642 data/ui/multiband_gate.glade:538
-#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1353
-#: data/ui/multiband_gate.glade:1763
+#: data/ui/multiband_compressor.glade:1266
+#: data/ui/multiband_compressor.glade:1646 data/ui/multiband_gate.glade:536
+#: data/ui/multiband_gate.glade:944 data/ui/multiband_gate.glade:1357
+#: data/ui/multiband_gate.glade:1770
 msgid "Peak"
 msgstr "Peak"
 
-#: data/ui/compressor.glade:662 data/ui/deesser.glade:243
-#: data/ui/gate.glade:256 data/ui/multiband_compressor.glade:513
+#: data/ui/compressor.glade:663 data/ui/deesser.glade:240
+#: data/ui/gate.glade:212 data/ui/multiband_compressor.glade:511
 #: data/ui/multiband_compressor.glade:885
-#: data/ui/multiband_compressor.glade:1263
-#: data/ui/multiband_compressor.glade:1641 data/ui/multiband_gate.glade:537
-#: data/ui/multiband_gate.glade:942 data/ui/multiband_gate.glade:1352
-#: data/ui/multiband_gate.glade:1762
+#: data/ui/multiband_compressor.glade:1265
+#: data/ui/multiband_compressor.glade:1645 data/ui/multiband_gate.glade:535
+#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1356
+#: data/ui/multiband_gate.glade:1769
 msgid "RMS"
 msgstr "RMS"
 
-#: data/ui/compressor.glade:663
+#: data/ui/compressor.glade:664
 #, fuzzy
 msgid "Low-Pass"
 msgstr "Band Rendah"
 
-#: data/ui/compressor.glade:664
+#: data/ui/compressor.glade:665
 msgid "Uniform"
 msgstr "Uniform"
 
-#: data/ui/compressor.glade:678 data/ui/deesser.glade:230
-#: data/ui/equalizer.glade:224 data/ui/equalizer_band.glade:79
-#: data/ui/multiband_compressor.glade:324 data/ui/multiband_gate.glade:348
-#: data/ui/stereo_tools.glade:485 data/ui/webrtc.glade:376
+#: data/ui/compressor.glade:679 data/ui/deesser.glade:227
+#: data/ui/equalizer.glade:225 data/ui/equalizer_band.glade:79
+#: data/ui/multiband_compressor.glade:322 data/ui/multiband_gate.glade:346
+#: data/ui/stereo_tools.glade:486 data/ui/webrtc.glade:377
 msgid "Mode"
 msgstr "Modus"
 
-#: data/ui/compressor.glade:692
+#: data/ui/compressor.glade:693
 #, fuzzy
 msgid "Middle"
 msgstr "Volume Kanal Tengah"
 
-#: data/ui/compressor.glade:693
+#: data/ui/compressor.glade:694
 msgid "Side"
 msgstr "Volume Kanal Sisi"
 
-#: data/ui/compressor.glade:694 data/ui/delay.glade:157
-#: data/ui/equalizer.glade:474 data/ui/stereo_tools.glade:548
+#: data/ui/compressor.glade:695 data/ui/delay.glade:158
+#: data/ui/equalizer.glade:475 data/ui/stereo_tools.glade:549
 msgid "Left"
 msgstr "Kiri"
 
-#: data/ui/compressor.glade:695 data/ui/delay.glade:189
-#: data/ui/equalizer.glade:515 data/ui/stereo_tools.glade:620
+#: data/ui/compressor.glade:696 data/ui/delay.glade:190
+#: data/ui/equalizer.glade:516 data/ui/stereo_tools.glade:621
 msgid "Right"
 msgstr "Kanan"
 
-#: data/ui/compressor.glade:709
+#: data/ui/compressor.glade:710
 msgid "Source"
 msgstr "Sumber"
 
-#: data/ui/compressor.glade:725 data/ui/compressor.glade:1167
+#: data/ui/compressor.glade:726 data/ui/compressor.glade:1170
 msgid "Sidechain"
 msgstr "Sidechain"
 
-#: data/ui/compressor.glade:821
+#: data/ui/compressor.glade:824
 msgid "Relative Release Threshold"
 msgstr ""
 
-#: data/ui/compressor.glade:832
+#: data/ui/compressor.glade:835
 #, fuzzy
 msgid "Boost Threshold"
 msgstr "Ambang Batas"
 
-#: data/ui/compressor.glade:843
+#: data/ui/compressor.glade:846
 #, fuzzy
 msgid "High-pass Frequency"
 msgstr "Frekuensi Tinggi"
 
-#: data/ui/compressor.glade:854
+#: data/ui/compressor.glade:857
 #, fuzzy
 msgid "Low-pass Frequency"
 msgstr "Frekuensi Terendah"
 
-#: data/ui/compressor.glade:865
+#: data/ui/compressor.glade:868
 #, fuzzy
 msgid "High-pass Filter Mode"
 msgstr "Filter High Pass"
 
-#: data/ui/compressor.glade:876
+#: data/ui/compressor.glade:879
 msgid "Low-pass Filter Mode"
 msgstr ""
 
-#: data/ui/compressor.glade:889 data/ui/compressor.glade:906
+#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
 #: data/ui/equalizer_band.glade:60
 msgid "Off"
 msgstr "Mati"
 
-#: data/ui/compressor.glade:890 data/ui/compressor.glade:907
+#: data/ui/compressor.glade:893 data/ui/compressor.glade:910
 #, fuzzy
 msgid "12 dB/oct"
 msgstr "Lowpass 12dB/oktaf"
 
-#: data/ui/compressor.glade:891 data/ui/compressor.glade:908
+#: data/ui/compressor.glade:894 data/ui/compressor.glade:911
 #, fuzzy
 msgid "24 dB/oct"
 msgstr "Lowpass 24dB/oktaf"
 
-#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
+#: data/ui/compressor.glade:895 data/ui/compressor.glade:912
 #, fuzzy
 msgid "36 dB/oct"
 msgstr "Lowpass 36dB/oktaf"
 
-#: data/ui/compressor.glade:932
+#: data/ui/compressor.glade:935
 msgid "Advanced"
 msgstr ""
 
-#: data/ui/compressor.glade:1243
+#: data/ui/compressor.glade:1244
 msgid "Curve"
 msgstr "Bentuk Kurva"
 
-#: data/ui/convolver.glade:91
+#: data/ui/convolver.glade:92
 msgid "Convolver"
 msgstr "Konvolver"
 
-#: data/ui/convolver.glade:125
+#: data/ui/convolver.glade:126
 msgid "Import Impulse"
 msgstr "Muat Impuls"
 
-#: data/ui/convolver.glade:129
+#: data/ui/convolver.glade:130
 msgid "Import Impulse Response File"
 msgstr "Muat Berkas Respons Impuls"
 
-#: data/ui/convolver.glade:247
+#: data/ui/convolver.glade:248
 msgid "L"
 msgstr "Kiri"
 
-#: data/ui/convolver.glade:261
+#: data/ui/convolver.glade:262
 msgid "R"
 msgstr "Kanan"
 
-#: data/ui/convolver.glade:324
+#: data/ui/convolver.glade:325
 msgid "Duration"
 msgstr "Durasi"
 
-#: data/ui/convolver.glade:335
+#: data/ui/convolver.glade:336
 msgid "Samples"
 msgstr "Jumlah Sampel"
 
-#: data/ui/convolver.glade:367 src/convolver_ui.cpp:283
+#: data/ui/convolver.glade:368 src/convolver_ui.cpp:283
 msgid "Impulse Response"
 msgstr "Respons Impuls"
 
-#: data/ui/convolver.glade:389
+#: data/ui/convolver.glade:390
 msgid "Select the impulse Response File"
 msgstr "Pilih Berkas Repons Impuls"
 
-#: data/ui/convolver.glade:409 src/spectrum_settings_ui.cpp:176
+#: data/ui/convolver.glade:410 src/spectrum_settings_ui.cpp:176
 msgid "Spectrum"
 msgstr "Spektrum"
 
-#: data/ui/convolver.glade:450
+#: data/ui/convolver.glade:451
 msgid "Stereo Width"
 msgstr "Lebar Stereo"
 
-#: data/ui/crossfeed.glade:63
+#: data/ui/crossfeed.glade:62
 msgid "Jmeier"
 msgstr "J. Meier"
 
-#: data/ui/crossfeed.glade:76 data/ui/filter.glade:183 data/ui/reverb.glade:259
+#: data/ui/crossfeed.glade:75 data/ui/filter.glade:184 data/ui/reverb.glade:260
 msgid "Default"
 msgstr "Aturan Bawaan"
 
-#: data/ui/crossfeed.glade:89
+#: data/ui/crossfeed.glade:88
 msgid "Cmoy"
 msgstr "C. Moy"
 
-#: data/ui/crossfeed.glade:120
+#: data/ui/crossfeed.glade:119
 msgid "Cutoff"
 msgstr "Frekuensi Potong"
 
-#: data/ui/crossfeed.glade:153
+#: data/ui/crossfeed.glade:152
 msgid "Feed"
 msgstr "Volume Penyuapan"
 
@@ -731,118 +729,135 @@ msgstr "Volume Penyuapan"
 msgid "Crossfeed"
 msgstr "Crossfeed"
 
-#: data/ui/crystalizer.glade:115
+#: data/ui/crystalizer.glade:92
 msgid "Crystalizer"
 msgstr "Pengkristal Suara"
 
-#: data/ui/crystalizer.glade:187
+#: data/ui/crystalizer.glade:137
 #, fuzzy
 msgid "Aggressive Mode"
 msgstr "Modus Agresif"
 
-#: data/ui/crystalizer.glade:447
+#: data/ui/crystalizer.glade:395
 #, fuzzy
 msgid "Loudness Range"
 msgstr "Rentang Kelantangan"
 
-#: data/ui/crystalizer.glade:466
+#: data/ui/crystalizer.glade:414
 msgid "Before"
 msgstr "Sebelum"
 
-#: data/ui/crystalizer.glade:479
+#: data/ui/crystalizer.glade:427
 msgid "After"
 msgstr "Sesudah"
 
 #: data/ui/crystalizer_band.glade:27 data/ui/equalizer_band.glade:313
-#: data/ui/stereo_tools.glade:574 data/ui/stereo_tools.glade:633
+#: data/ui/stereo_tools.glade:575 data/ui/stereo_tools.glade:634
 msgid "Mute"
 msgstr "Bungkam"
 
-#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:483
+#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:481
 #: data/ui/multiband_compressor.glade:855
-#: data/ui/multiband_compressor.glade:1233
-#: data/ui/multiband_compressor.glade:1611 data/ui/multiband_gate.glade:507
-#: data/ui/multiband_gate.glade:912 data/ui/multiband_gate.glade:1322
-#: data/ui/multiband_gate.glade:1732
+#: data/ui/multiband_compressor.glade:1235
+#: data/ui/multiband_compressor.glade:1615 data/ui/multiband_gate.glade:505
+#: data/ui/multiband_gate.glade:913 data/ui/multiband_gate.glade:1326
+#: data/ui/multiband_gate.glade:1739
 msgid "Bypass"
 msgstr "Bypass"
 
-#: data/ui/deesser.glade:128
+#: data/ui/deesser.glade:127
 msgid "Deesser"
 msgstr "Penghilang Desis"
 
-#: data/ui/deesser.glade:216 data/ui/gate.glade:195
+#: data/ui/deesser.glade:213 data/ui/gate.glade:198
 msgid "Detection"
 msgstr "Deteksi"
 
-#: data/ui/deesser.glade:258
+#: data/ui/deesser.glade:255
 msgid "Wide"
 msgstr "Luas"
 
-#: data/ui/deesser.glade:259 data/ui/deesser.glade:288
+#: data/ui/deesser.glade:256
 msgid "Split"
 msgstr "Pisah"
 
-#: data/ui/deesser.glade:407
-msgid "Level"
+#: data/ui/deesser.glade:285
+#, fuzzy
+msgid "F1 Split"
+msgstr "Pisah"
+
+#: data/ui/deesser.glade:318
+#, fuzzy
+msgid "F1 Gain"
+msgstr "Besar Gain"
+
+#: data/ui/deesser.glade:352
+#, fuzzy
+msgid "F2 Peak"
+msgstr "Peak"
+
+#: data/ui/deesser.glade:406
+#, fuzzy
+msgid "F2 Level"
 msgstr "Level"
 
-#: data/ui/deesser.glade:420
-msgid "Peak Q"
+#: data/ui/deesser.glade:419
+#, fuzzy
+msgid "F2 Peak Q"
 msgstr "Peak Q"
 
-#: data/ui/deesser.glade:452
+#: data/ui/deesser.glade:451
 msgid "Laxity"
 msgstr "Laksitas"
 
-#: data/ui/deesser.glade:778 data/ui/multiband_gate.glade:767
-#: data/ui/multiband_gate.glade:1197 data/ui/multiband_gate.glade:1607
-#: data/ui/multiband_gate.glade:2017
+#: data/ui/deesser.glade:779 data/ui/multiband_gate.glade:767
+#: data/ui/multiband_gate.glade:1201 data/ui/multiband_gate.glade:1614
+#: data/ui/multiband_gate.glade:2027
 msgid "Reduction"
 msgstr "Pengurangan"
 
-#: data/ui/deesser.glade:791
+#: data/ui/deesser.glade:792
 msgid "Detected"
 msgstr "Terlacak"
 
-#: data/ui/delay.glade:91
+#: data/ui/delay.glade:92
 #, fuzzy
 msgid "Delay"
 msgstr "Penundaan"
 
-#: data/ui/equalizer.glade:44
+#: data/ui/equalizer.glade:45
 msgid "Equalizer"
 msgstr "Ekualiser"
 
-#: data/ui/equalizer.glade:153
+#: data/ui/equalizer.glade:154
 msgid "Split Channels"
 msgstr "Pisahkan Kanal"
 
-#: data/ui/equalizer.glade:179
+#: data/ui/equalizer.glade:180
 msgid "IIR"
 msgstr "IIR"
 
-#: data/ui/equalizer.glade:180
+#: data/ui/equalizer.glade:181
 msgid "FIR"
 msgstr "FIR"
 
-#: data/ui/equalizer.glade:181
+#: data/ui/equalizer.glade:182
 msgid "FFT"
 msgstr "FFT"
 
-#: data/ui/equalizer.glade:211
+#: data/ui/equalizer.glade:212
 msgid "Bands"
 msgstr "Jumlah Band"
 
-#: data/ui/equalizer.glade:233
+#: data/ui/equalizer.glade:234
 msgid "Flat Response"
 msgstr "Respons Datar"
 
-#: data/ui/equalizer.glade:248
+#: data/ui/equalizer.glade:249
 msgid "Calculate Frequencies"
 msgstr "Hitung Frekuensi"
 
-#: data/ui/equalizer.glade:262
+#: data/ui/equalizer.glade:263
 #, fuzzy
 msgid "Import APO Presets"
 msgstr "Muat Preset"
@@ -873,7 +888,7 @@ msgstr "Low Shelf"
 msgid "Notch"
 msgstr ""
 
-#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:314
+#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:315
 msgid "Resonance"
 msgstr "Resonansi"
 
@@ -917,12 +932,12 @@ msgstr "Kualitas"
 msgid "Width"
 msgstr "Lebar"
 
-#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:496
+#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:494
 #: data/ui/multiband_compressor.glade:868
-#: data/ui/multiband_compressor.glade:1246
-#: data/ui/multiband_compressor.glade:1624 data/ui/multiband_gate.glade:520
-#: data/ui/multiband_gate.glade:925 data/ui/multiband_gate.glade:1335
-#: data/ui/multiband_gate.glade:1745
+#: data/ui/multiband_compressor.glade:1248
+#: data/ui/multiband_compressor.glade:1628 data/ui/multiband_gate.glade:518
+#: data/ui/multiband_gate.glade:926 data/ui/multiband_gate.glade:1339
+#: data/ui/multiband_gate.glade:1752
 msgid "Solo"
 msgstr "Solo"
 
@@ -930,79 +945,79 @@ msgstr "Solo"
 msgid "Apply"
 msgstr "Terapkan"
 
-#: data/ui/exciter.glade:117
+#: data/ui/exciter.glade:118
 msgid "Exciter"
 msgstr "Penguat Frekuensi Tinggi"
 
-#: data/ui/exciter.glade:384 data/ui/maximizer.glade:165
+#: data/ui/exciter.glade:384 data/ui/maximizer.glade:166
 msgid "Ceiling"
 msgstr "Langit-langit"
 
-#: data/ui/filter.glade:98
+#: data/ui/filter.glade:99
 msgid "Filter"
 msgstr "Filter"
 
-#: data/ui/filter.glade:147
+#: data/ui/filter.glade:148
 msgid "Muted"
 msgstr "Dibungkam"
 
-#: data/ui/filter.glade:159 data/ui/reverb.glade:233
+#: data/ui/filter.glade:160 data/ui/reverb.glade:234
 msgid "Disco"
 msgstr "Disko"
 
-#: data/ui/filter.glade:171
+#: data/ui/filter.glade:172
 msgid "Distant Headphones"
 msgstr "Headphone Berjarak"
 
-#: data/ui/filter.glade:246
+#: data/ui/filter.glade:247
 msgid "12dB/oct Lowpass"
 msgstr "Lowpass 12dB/oktaf"
 
-#: data/ui/filter.glade:247
+#: data/ui/filter.glade:248
 msgid "24dB/oct Lowpass"
 msgstr "Lowpass 24dB/oktaf"
 
-#: data/ui/filter.glade:248
+#: data/ui/filter.glade:249
 msgid "36dB/oct Lowpass"
 msgstr "Lowpass 36dB/oktaf"
 
-#: data/ui/filter.glade:249
+#: data/ui/filter.glade:250
 msgid "12dB/oct Highpass"
 msgstr "Highpass 12dB/oktaf"
 
-#: data/ui/filter.glade:250
+#: data/ui/filter.glade:251
 msgid "24dB/oct Highpass"
 msgstr "Highpass 24dB/oktaf"
 
-#: data/ui/filter.glade:251
+#: data/ui/filter.glade:252
 msgid "36dB/oct Highpass"
 msgstr "Highpass 36dB/oktaf"
 
-#: data/ui/filter.glade:252
+#: data/ui/filter.glade:253
 msgid "6dB/oct Bandpass"
 msgstr "Bandpass 6dB/oktaf"
 
-#: data/ui/filter.glade:253
+#: data/ui/filter.glade:254
 msgid "12dB/oct Bandpass"
 msgstr "Bandpass 12dB/oktaf"
 
-#: data/ui/filter.glade:254
+#: data/ui/filter.glade:255
 msgid "18dB/oct Bandpass"
 msgstr "Bandpass 18dB/oktaf"
 
-#: data/ui/filter.glade:255
+#: data/ui/filter.glade:256
 msgid "6dB/oct Bandreject"
 msgstr "Bandreject 6dB/oktaf"
 
-#: data/ui/filter.glade:256
+#: data/ui/filter.glade:257
 msgid "12dB/oct Bandreject"
 msgstr "Bandpass 12dB/oktaf"
 
-#: data/ui/filter.glade:257
+#: data/ui/filter.glade:258
 msgid "18dB/oct Bandreject"
 msgstr "Bandpass 18dB/oktaf"
 
-#: data/ui/filter.glade:349
+#: data/ui/filter.glade:350
 msgid "Inertia"
 msgstr "Kelembaman"
 
@@ -1046,50 +1061,51 @@ msgstr "Proses Semua Input"
 msgid "Priority"
 msgstr "Atur Prioritas"
 
-#: data/ui/gate.glade:98
+#: data/ui/gate.glade:99
 msgid "Gate"
 msgstr "Gate"
 
-#: data/ui/gate.glade:209
+#: data/ui/gate.glade:240
+#, fuzzy
+msgid "Maximum Gain Reduction"
+msgstr "Pengurangan Kuatan"
+
+#: data/ui/gate.glade:289
 msgid "Stereo Link"
 msgstr "Penautan Stereo"
 
-#: data/ui/gate.glade:222 data/ui/maximizer.glade:293
-msgid "Gain Reduction"
-msgstr "Pengurangan Kuatan"
-
-#: data/ui/gate.glade:273
+#: data/ui/gate.glade:304
 msgid "Average"
 msgstr "Rata-Rata"
 
-#: data/ui/gate.glade:274
+#: data/ui/gate.glade:305
 msgid "Maximum"
 msgstr "Maksimal"
 
-#: data/ui/gate.glade:525
+#: data/ui/gate.glade:578
 #, fuzzy
 msgid "Input Level"
 msgstr "Pembatas Masukan"
 
-#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:811
-#: data/ui/multiband_gate.glade:1220 data/ui/multiband_gate.glade:1630
-#: data/ui/multiband_gate.glade:2040
+#: data/ui/gate.glade:797 data/ui/multiband_gate.glade:812
+#: data/ui/multiband_gate.glade:1224 data/ui/multiband_gate.glade:1637
+#: data/ui/multiband_gate.glade:2050
 msgid "Gating"
 msgstr "Gating"
 
-#: data/ui/limiter.glade:97 data/ui/webrtc.glade:421
+#: data/ui/limiter.glade:98 data/ui/webrtc.glade:422
 msgid "Limiter"
 msgstr "Pembatas"
 
-#: data/ui/limiter.glade:176
+#: data/ui/limiter.glade:175
 msgid "Automatic Smoothing Control"
 msgstr ""
 
-#: data/ui/limiter.glade:190
+#: data/ui/limiter.glade:189
 msgid "Automatic Leveling"
 msgstr ""
 
-#: data/ui/limiter.glade:222
+#: data/ui/limiter.glade:221
 msgid "Input Gain"
 msgstr "Gain Input"
 
@@ -1097,136 +1113,140 @@ msgstr "Gain Input"
 msgid "Limit"
 msgstr "Batas"
 
-#: data/ui/limiter.glade:358
+#: data/ui/limiter.glade:359
 msgid "Oversampling"
 msgstr "Peningkat Sampling"
 
-#: data/ui/limiter.glade:411
+#: data/ui/limiter.glade:413
 #, fuzzy
 msgid "Output Gain"
 msgstr "Gain Input"
 
-#: data/ui/limiter.glade:429
+#: data/ui/limiter.glade:431
 msgid "ASC"
 msgstr "ASC"
 
-#: data/ui/limiter.glade:584
+#: data/ui/limiter.glade:586
 msgid "Attenuation"
 msgstr "Atenuasi"
 
-#: data/ui/loudness.glade:91
+#: data/ui/loudness.glade:92
 msgid "Loudness Compensator"
 msgstr ""
 
-#: data/ui/loudness.glade:147
-msgid "Standard"
-msgstr ""
-
-#: data/ui/loudness.glade:161
-msgid "Flat"
-msgstr ""
-
-#: data/ui/loudness.glade:162
-msgid "ISO226-2003"
-msgstr ""
-
-#: data/ui/loudness.glade:163
-msgid "Fletcher-Munson"
-msgstr ""
-
-#: data/ui/loudness.glade:164
-msgid "Robinson-Dadson"
-msgstr ""
-
-#: data/ui/loudness.glade:174
-msgid "Reference Signal"
-msgstr ""
-
-#: data/ui/loudness.glade:199
+#: data/ui/loudness.glade:155
 #, fuzzy
 msgid "FFT Size"
 msgstr "Ukuran Bingkai"
 
-#: data/ui/maximizer.glade:96
+#: data/ui/loudness.glade:205
+msgid "Standard"
+msgstr ""
+
+#: data/ui/loudness.glade:220
+msgid "Flat"
+msgstr ""
+
+#: data/ui/loudness.glade:221
+msgid "ISO226-2003"
+msgstr ""
+
+#: data/ui/loudness.glade:222
+msgid "Fletcher-Munson"
+msgstr ""
+
+#: data/ui/loudness.glade:223
+msgid "Robinson-Dadson"
+msgstr ""
+
+#: data/ui/loudness.glade:259
+msgid "Reference Signal"
+msgstr ""
+
+#: data/ui/maximizer.glade:97
 msgid "Maximizer"
 msgstr "Pemaksimal Gain"
 
-#: data/ui/multiband_compressor.glade:140
+#: data/ui/maximizer.glade:296
+msgid "Gain Reduction"
+msgstr "Pengurangan Kuatan"
+
+#: data/ui/multiband_compressor.glade:141
 msgid "Multiband Compressor"
 msgstr "Kompresor Multiband"
 
-#: data/ui/multiband_compressor.glade:338 data/ui/multiband_gate.glade:362
+#: data/ui/multiband_compressor.glade:336 data/ui/multiband_gate.glade:360
 msgid "LR4"
 msgstr "LR4"
 
-#: data/ui/multiband_compressor.glade:339 data/ui/multiband_gate.glade:363
+#: data/ui/multiband_compressor.glade:337 data/ui/multiband_gate.glade:361
 msgid "LR8"
 msgstr "LR8"
 
-#: data/ui/multiband_compressor.glade:353 data/ui/multiband_gate.glade:377
+#: data/ui/multiband_compressor.glade:351 data/ui/multiband_gate.glade:375
 msgid "Split 1/2"
 msgstr "Split 1/2"
 
-#: data/ui/multiband_compressor.glade:366 data/ui/multiband_gate.glade:390
+#: data/ui/multiband_compressor.glade:364 data/ui/multiband_gate.glade:388
 msgid "Split 2/3"
 msgstr "Split 2/3"
 
-#: data/ui/multiband_compressor.glade:379 data/ui/multiband_gate.glade:403
+#: data/ui/multiband_compressor.glade:377 data/ui/multiband_gate.glade:401
 msgid "Split 3/4"
 msgstr "Split 3/4"
 
 #: data/ui/multiband_compressor.glade:754
-#: data/ui/multiband_compressor.glade:1131
-#: data/ui/multiband_compressor.glade:1509
-#: data/ui/multiband_compressor.glade:1887
+#: data/ui/multiband_compressor.glade:1133
+#: data/ui/multiband_compressor.glade:1513
+#: data/ui/multiband_compressor.glade:1893
 msgid "Compression"
 msgstr "Kompresi"
 
-#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:894
+#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:895
 msgid "Sub Band"
 msgstr "Band Sub"
 
-#: data/ui/multiband_compressor.glade:1214 data/ui/multiband_gate.glade:1303
+#: data/ui/multiband_compressor.glade:1216 data/ui/multiband_gate.glade:1307
 msgid "Low Band"
 msgstr "Band Rendah"
 
-#: data/ui/multiband_compressor.glade:1592 data/ui/multiband_gate.glade:1713
+#: data/ui/multiband_compressor.glade:1596 data/ui/multiband_gate.glade:1720
 msgid "Mid Band"
 msgstr "Band Tengah"
 
-#: data/ui/multiband_compressor.glade:1970 data/ui/multiband_gate.glade:2123
+#: data/ui/multiband_compressor.glade:1976 data/ui/multiband_gate.glade:2133
 msgid "High Band"
 msgstr "Band Tinggi"
 
-#: data/ui/multiband_gate.glade:140
+#: data/ui/multiband_gate.glade:141
 msgid "Multiband Gate"
 msgstr "Multiband Gate"
 
-#: data/ui/pitch.glade:103
+#: data/ui/pitch.glade:104
 msgid "Pitch"
 msgstr "Nada"
 
-#: data/ui/pitch.glade:178
+#: data/ui/pitch.glade:179
 msgid "Cents"
 msgstr "Sen"
 
-#: data/ui/pitch.glade:209
+#: data/ui/pitch.glade:210
 msgid "Semitones"
 msgstr "Seminada"
 
-#: data/ui/pitch.glade:240
+#: data/ui/pitch.glade:241
 msgid "Octaves"
 msgstr "Oktav"
 
-#: data/ui/pitch.glade:271
+#: data/ui/pitch.glade:272
 msgid "Crispness"
 msgstr "Kerenyahan"
 
-#: data/ui/pitch.glade:311
+#: data/ui/pitch.glade:312
 msgid "Faster"
 msgstr "Lebih Cepat"
 
-#: data/ui/pitch.glade:325
+#: data/ui/pitch.glade:326
 msgid "Preserve Formant"
 msgstr "Jaga Bentuk"
 
@@ -1327,83 +1347,83 @@ msgstr ""
 msgid "Pipeline Output"
 msgstr ""
 
-#: data/ui/reverb.glade:131
+#: data/ui/reverb.glade:132
 msgid "Reverberation"
 msgstr "Penggemaan"
 
-#: data/ui/reverb.glade:181
+#: data/ui/reverb.glade:182
 msgid "Ambience"
 msgstr "Suasana"
 
-#: data/ui/reverb.glade:194
+#: data/ui/reverb.glade:195
 msgid "Empty Walls"
 msgstr "Tembok Kosong"
 
-#: data/ui/reverb.glade:207
+#: data/ui/reverb.glade:208
 msgid "Room"
 msgstr "Ruangan"
 
-#: data/ui/reverb.glade:220
+#: data/ui/reverb.glade:221
 msgid "Large Empty Hall"
 msgstr "Aula Besar Kosong"
 
-#: data/ui/reverb.glade:246
+#: data/ui/reverb.glade:247
 msgid "Large Occupied Hall"
 msgstr "Aula Besar Terisi Penuh"
 
-#: data/ui/reverb.glade:361
+#: data/ui/reverb.glade:362
 msgid "Pre Delay"
 msgstr "Pra Tunda"
 
-#: data/ui/reverb.glade:374
+#: data/ui/reverb.glade:375
 msgid "Decay Time"
 msgstr "Waktu Decay"
 
-#: data/ui/reverb.glade:439
+#: data/ui/reverb.glade:441
 msgid "Dry"
 msgstr "Dry"
 
-#: data/ui/reverb.glade:471
+#: data/ui/reverb.glade:474
 msgid "Bass Cut"
 msgstr "Potong Bass"
 
-#: data/ui/reverb.glade:522
+#: data/ui/reverb.glade:525
 msgid "Treble Cut"
 msgstr "Potong Treble"
 
-#: data/ui/reverb.glade:565
+#: data/ui/reverb.glade:568
 msgid "Diffusion"
 msgstr "Difusi"
 
-#: data/ui/reverb.glade:577
+#: data/ui/reverb.glade:580
 msgid "Room Size"
 msgstr "Ukuran Ruangan"
 
-#: data/ui/reverb.glade:590
+#: data/ui/reverb.glade:593
 msgid "Small"
 msgstr "Kecil"
 
-#: data/ui/reverb.glade:591
+#: data/ui/reverb.glade:594
 msgid "Medium"
 msgstr "Sedang"
 
-#: data/ui/reverb.glade:592
+#: data/ui/reverb.glade:595
 msgid "Large"
 msgstr "Besar"
 
-#: data/ui/reverb.glade:593
+#: data/ui/reverb.glade:596
 msgid "Tunnel"
 msgstr "Terowongan"
 
-#: data/ui/reverb.glade:594
+#: data/ui/reverb.glade:597
 msgid "Large/smooth"
 msgstr "Besar/Halus"
 
-#: data/ui/reverb.glade:595
+#: data/ui/reverb.glade:598
 msgid "Experimental"
 msgstr "Eksperimental"
 
-#: data/ui/reverb.glade:608
+#: data/ui/reverb.glade:611
 msgid "High Frequency Damping"
 msgstr "Pembasahan Frekuensi Tinggi"
 
@@ -1480,23 +1500,23 @@ msgstr "Tinggi"
 msgid "Points"
 msgstr "Titik"
 
-#: data/ui/stereo_tools.glade:109
+#: data/ui/stereo_tools.glade:110
 msgid "Stereo Tools"
 msgstr "Pengolah Stereo"
 
-#: data/ui/stereo_tools.glade:231
+#: data/ui/stereo_tools.glade:230
 msgid "Softclip"
 msgstr "Kliping Lunak"
 
-#: data/ui/stereo_tools.glade:255 data/ui/stereo_tools.glade:671
+#: data/ui/stereo_tools.glade:254 data/ui/stereo_tools.glade:672
 msgid "Balance"
 msgstr "Keseimbangan"
 
-#: data/ui/stereo_tools.glade:287
+#: data/ui/stereo_tools.glade:286
 msgid "S/C Level"
 msgstr "Level Sisi/Tengah"
 
-#: data/ui/stereo_tools.glade:345
+#: data/ui/stereo_tools.glade:344
 msgid "Side Level"
 msgstr "Volume Kanal Sisi"
 
@@ -1504,144 +1524,144 @@ msgstr "Volume Kanal Sisi"
 msgid "Side Balance"
 msgstr "Keseimbangan Sisi"
 
-#: data/ui/stereo_tools.glade:428
+#: data/ui/stereo_tools.glade:429
 msgid "Middle Level"
 msgstr "Volume Kanal Tengah"
 
-#: data/ui/stereo_tools.glade:441
+#: data/ui/stereo_tools.glade:442
 msgid "Middle Panorama"
 msgstr "Panorama Kanal Tengah"
 
-#: data/ui/stereo_tools.glade:499
+#: data/ui/stereo_tools.glade:500
 msgid "LR > LR (Stereo Default)"
 msgstr "Kiri-Kanan > Kiri-Kanan (Stereo Standar)"
 
-#: data/ui/stereo_tools.glade:500
+#: data/ui/stereo_tools.glade:501
 msgid "LR > MS (Stereo to Mid-Side)"
 msgstr "Kiri-Kanan > Tengah (Stereo ke Sisi Tengah)"
 
-#: data/ui/stereo_tools.glade:501
+#: data/ui/stereo_tools.glade:502
 msgid "MS > LR (Mid-Side to Stereo)"
 msgstr "Tengah > Kiri-Kanan (Sisi Tengah ke Stereo)"
 
-#: data/ui/stereo_tools.glade:502
+#: data/ui/stereo_tools.glade:503
 msgid "LR > LL (Mono Left Channel)"
 msgstr "Kiri-Kanan > Kiri-Kiri (Kanal Kiri Mono)"
 
-#: data/ui/stereo_tools.glade:503
+#: data/ui/stereo_tools.glade:504
 msgid "LR > RR (Mono Right Channel)"
 msgstr "Kiri-Kanan > Kanan-kanan (Kanal Kanan Mono)"
 
-#: data/ui/stereo_tools.glade:504
+#: data/ui/stereo_tools.glade:505
 msgid "LR > L+R (Mono Sum L+R)"
 msgstr "Kiri-Kanan > Kiri+Kanan (Kiri Mono + Kanan Mono)"
 
-#: data/ui/stereo_tools.glade:505
+#: data/ui/stereo_tools.glade:506
 msgid "LR > RL (Stereo Flip Channels)"
 msgstr "Kiri-Kanan > Kanan-Kiri (Pembalikan Setereo)"
 
-#: data/ui/stereo_tools.glade:522
+#: data/ui/stereo_tools.glade:523
 msgid "Stereo Matrix"
 msgstr "Matriks Stereo"
 
-#: data/ui/stereo_tools.glade:561 data/ui/stereo_tools.glade:602
+#: data/ui/stereo_tools.glade:562 data/ui/stereo_tools.glade:603
 msgid "Invert Phase"
 msgstr "Balikkan Phase"
 
-#: data/ui/stereo_tools.glade:703
+#: data/ui/stereo_tools.glade:704
 msgid "Delay L/R"
 msgstr "Penundaan Kiri/Kanan"
 
-#: data/ui/stereo_tools.glade:737
+#: data/ui/stereo_tools.glade:738
 msgid "Stereo Base"
 msgstr "Basis Stereo"
 
-#: data/ui/stereo_tools.glade:770
+#: data/ui/stereo_tools.glade:771
 msgid "Stereo Phase"
 msgstr "Phase Stereo"
 
-#: data/ui/webrtc.glade:97
+#: data/ui/webrtc.glade:98
 msgid "WebRTC"
 msgstr ""
 
-#: data/ui/webrtc.glade:163 data/ui/webrtc.glade:283 data/ui/webrtc.glade:353
-#: data/ui/webrtc.glade:523
+#: data/ui/webrtc.glade:164 data/ui/webrtc.glade:284 data/ui/webrtc.glade:354
+#: data/ui/webrtc.glade:524
 msgid "Enable"
 msgstr "Hidupkan"
 
-#: data/ui/webrtc.glade:184
+#: data/ui/webrtc.glade:185
 msgid "Extended Filter"
 msgstr "Filter Diperluas"
 
-#: data/ui/webrtc.glade:197
+#: data/ui/webrtc.glade:198
 msgid "Delay Agnostic"
 msgstr "Penundaan Agnosti"
 
-#: data/ui/webrtc.glade:209
+#: data/ui/webrtc.glade:210
 msgid "High Pass Filter"
 msgstr "Filter High Pass"
 
-#: data/ui/webrtc.glade:238 data/ui/webrtc.glade:306
+#: data/ui/webrtc.glade:239 data/ui/webrtc.glade:307
 msgid "Suppresion Level"
 msgstr "Tingkat Supresi"
 
-#: data/ui/webrtc.glade:251 data/ui/webrtc.glade:319 data/ui/webrtc.glade:575
+#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
 msgid "Low"
 msgstr "Rendah"
 
-#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
+#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
 msgid "Moderate"
 msgstr "Sedang"
 
-#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
+#: data/ui/webrtc.glade:254 data/ui/webrtc.glade:322 data/ui/webrtc.glade:578
 msgid "High"
 msgstr "Tinggi"
 
-#: data/ui/webrtc.glade:270
+#: data/ui/webrtc.glade:271
 msgid "Echo Canceller"
 msgstr "Penghilang Gema"
 
-#: data/ui/webrtc.glade:322
+#: data/ui/webrtc.glade:323
 msgid "Very High"
 msgstr "Sangat Tinggi"
 
-#: data/ui/webrtc.glade:339
+#: data/ui/webrtc.glade:340
 msgid "Noise Suppressor"
 msgstr "Supresor Derau"
 
-#: data/ui/webrtc.glade:389
+#: data/ui/webrtc.glade:390
 msgid "Adaptive Digital"
 msgstr "Digital Adaptif"
 
-#: data/ui/webrtc.glade:390
+#: data/ui/webrtc.glade:391
 msgid "Fixed Digital"
 msgstr "Digital Tetap"
 
-#: data/ui/webrtc.glade:407
+#: data/ui/webrtc.glade:408
 msgid "Gain Controller"
 msgstr "Pengatur Angkatan"
 
-#: data/ui/webrtc.glade:445
+#: data/ui/webrtc.glade:446
 msgid "Target Level"
 msgstr "Target Tingkat"
 
-#: data/ui/webrtc.glade:475
+#: data/ui/webrtc.glade:476
 msgid "Maximum Gain"
 msgstr "Angkatan Maksimal"
 
-#: data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:549
 msgid "Detection Likelihood"
 msgstr "Lacak Keberadaan Vokal"
 
-#: data/ui/webrtc.glade:561
+#: data/ui/webrtc.glade:562
 msgid "Frame Size"
 msgstr "Ukuran Bingkai"
 
-#: data/ui/webrtc.glade:574
+#: data/ui/webrtc.glade:575
 msgid "Very Low"
 msgstr "Sangat Rendah"
 
-#: data/ui/webrtc.glade:611
+#: data/ui/webrtc.glade:612
 msgid "Voice Detector"
 msgstr "Pelacak Vokal"
 
@@ -1738,6 +1758,10 @@ msgstr "Umum"
 #: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
+
+#, fuzzy
+#~ msgid "Gain Detection"
+#~ msgstr "Pengurangan Kuatan"
 
 #~ msgid "Scale"
 #~ msgstr "Skala"

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-22 15:29+0200\n"
+"POT-Creation-Date: 2020-08-24 16:51+0200\n"
 "PO-Revision-Date: 2019-03-28 17:38+0100\n"
 "Last-Translator: Gianluca Boiano <morf3089@gmail.com>\n"
 "Language-Team: \n"
@@ -87,8 +87,8 @@ msgid "Input Limiter"
 msgstr "Limitatore Ingresso"
 
 #: data/com.github.wwmm.pulseeffects.appdata.xml.in:52
-#: data/ui/compressor.glade:111 data/ui/compressor.glade:494
-#: data/ui/webrtc.glade:509
+#: data/ui/compressor.glade:112 data/ui/compressor.glade:494
+#: data/ui/webrtc.glade:510
 msgid "Compressor"
 msgstr "Compressore"
 
@@ -120,12 +120,12 @@ msgstr "Applicazioni"
 msgid "Format"
 msgstr "Formato"
 
-#: data/ui/app_info.glade:75 data/ui/convolver.glade:283
+#: data/ui/app_info.glade:75 data/ui/convolver.glade:284
 msgid "Rate"
 msgstr "Frequenza"
 
 #: data/ui/app_info.glade:102 data/ui/pulse_info.glade:238
-#: data/ui/stereo_tools.glade:653
+#: data/ui/stereo_tools.glade:654
 msgid "Channels"
 msgstr "Canali"
 
@@ -162,7 +162,7 @@ msgstr "Segnali di Test"
 msgid "Global Bypass"
 msgstr "Bypass Globale"
 
-#: data/ui/application.glade:170 data/ui/equalizer.glade:277
+#: data/ui/application.glade:170 data/ui/equalizer.glade:278
 #: data/ui/general_settings.glade:107
 msgid "Settings"
 msgstr "Impostazioni"
@@ -171,169 +171,168 @@ msgstr "Impostazioni"
 msgid "Help"
 msgstr "Aiuto"
 
-#: data/ui/application.glade:215 data/ui/crossfeed.glade:49
-#: data/ui/equalizer.glade:333 data/ui/filter.glade:230
-#: data/ui/reverb.glade:310 src/presets_menu_ui.cpp:113
+#: data/ui/application.glade:215 data/ui/crossfeed.glade:48
+#: data/ui/equalizer.glade:334 data/ui/filter.glade:231
+#: data/ui/reverb.glade:311 src/presets_menu_ui.cpp:113
 #: src/presets_menu_ui.cpp:258 src/presets_menu_ui.cpp:275
 msgid "Presets"
 msgstr "Profili"
 
-#: data/ui/autogain.glade:91
+#: data/ui/autogain.glade:92
 msgid "Auto Gain"
 msgstr "Auto Guadagno"
 
-#: data/ui/autogain.glade:171
+#: data/ui/autogain.glade:172
 msgid "Reset History"
 msgstr "Reset Cronologia"
 
-#: data/ui/autogain.glade:183
+#: data/ui/autogain.glade:184
 msgid "Detect Silence"
 msgstr "Rilevazione Silenzio"
 
-#: data/ui/autogain.glade:195
+#: data/ui/autogain.glade:196
 msgid "Use Geometric Mean"
 msgstr "Usa Media Geometrica"
 
-#: data/ui/autogain.glade:233
+#: data/ui/autogain.glade:234
 msgid "Target"
 msgstr "Livello"
 
-#: data/ui/autogain.glade:283 data/ui/autogain.glade:627
+#: data/ui/autogain.glade:286 data/ui/autogain.glade:631
 msgid "Momentary"
 msgstr "Momentaneo"
 
-#: data/ui/autogain.glade:298 data/ui/autogain.glade:640
+#: data/ui/autogain.glade:301 data/ui/autogain.glade:644
 msgid "Short Term"
 msgstr "Breve Termine"
 
-#: data/ui/autogain.glade:313 data/ui/autogain.glade:653
+#: data/ui/autogain.glade:316 data/ui/autogain.glade:657
 msgid "Integrated"
 msgstr "Integrato"
 
-#: data/ui/autogain.glade:388
+#: data/ui/autogain.glade:394
 msgid "Weights"
 msgstr "Ampiezze"
 
-#: data/ui/autogain.glade:428 data/ui/autogain.glade:917
-#: data/ui/bass_enhancer.glade:504 data/ui/compressor.glade:974
-#: data/ui/convolver.glade:504 data/ui/crossfeed.glade:200
-#: data/ui/crystalizer.glade:255 data/ui/deesser.glade:593
-#: data/ui/delay.glade:236 data/ui/equalizer.glade:543
-#: data/ui/exciter.glade:510 data/ui/filter.glade:396 data/ui/gate.glade:558
-#: data/ui/limiter.glade:483 data/ui/loudness.glade:259
-#: data/ui/loudness.glade:338 data/ui/maximizer.glade:265
-#: data/ui/multiband_compressor.glade:2000 data/ui/multiband_gate.glade:2153
-#: data/ui/pitch.glade:362 data/ui/presets_menu.glade:255
-#: data/ui/reverb.glade:658 data/ui/stereo_tools.glade:323
-#: data/ui/stereo_tools.glade:829 data/ui/webrtc.glade:650
+#: data/ui/autogain.glade:434 data/ui/autogain.glade:921
+#: data/ui/bass_enhancer.glade:506 data/ui/compressor.glade:977
+#: data/ui/convolver.glade:505 data/ui/crossfeed.glade:199
+#: data/ui/crystalizer.glade:205 data/ui/deesser.glade:594
+#: data/ui/delay.glade:237 data/ui/equalizer.glade:544
+#: data/ui/exciter.glade:510 data/ui/filter.glade:397 data/ui/gate.glade:611
+#: data/ui/limiter.glade:485 data/ui/loudness.glade:299
+#: data/ui/loudness.glade:380 data/ui/maximizer.glade:268
+#: data/ui/multiband_compressor.glade:2006 data/ui/multiband_gate.glade:2163
+#: data/ui/pitch.glade:363 data/ui/presets_menu.glade:255
+#: data/ui/reverb.glade:661 data/ui/stereo_tools.glade:322
+#: data/ui/stereo_tools.glade:830 data/ui/webrtc.glade:651
 msgid "Input"
 msgstr "Ingresso"
 
-#: data/ui/autogain.glade:443 data/ui/autogain.glade:862
-#: data/ui/bass_enhancer.glade:536 data/ui/compressor.glade:988
-#: data/ui/convolver.glade:519 data/ui/crossfeed.glade:214
-#: data/ui/crystalizer.glade:270 data/ui/deesser.glade:607
-#: data/ui/delay.glade:250 data/ui/equalizer.glade:557
-#: data/ui/exciter.glade:542 data/ui/filter.glade:411 data/ui/gate.glade:572
-#: data/ui/limiter.glade:626 data/ui/loudness.glade:292
-#: data/ui/loudness.glade:352 data/ui/maximizer.glade:279
+#: data/ui/autogain.glade:449 data/ui/autogain.glade:866
+#: data/ui/bass_enhancer.glade:537 data/ui/compressor.glade:991
+#: data/ui/convolver.glade:520 data/ui/crossfeed.glade:213
+#: data/ui/crystalizer.glade:220 data/ui/deesser.glade:608
+#: data/ui/delay.glade:251 data/ui/equalizer.glade:558
+#: data/ui/exciter.glade:541 data/ui/filter.glade:412 data/ui/gate.glade:625
+#: data/ui/limiter.glade:628 data/ui/loudness.glade:333
+#: data/ui/loudness.glade:394 data/ui/maximizer.glade:282
 #: data/ui/multiband_compressor.glade:794
-#: data/ui/multiband_compressor.glade:1171
-#: data/ui/multiband_compressor.glade:1549
-#: data/ui/multiband_compressor.glade:1927
-#: data/ui/multiband_compressor.glade:2015 data/ui/multiband_gate.glade:851
-#: data/ui/multiband_gate.glade:1260 data/ui/multiband_gate.glade:1670
-#: data/ui/multiband_gate.glade:2080 data/ui/multiband_gate.glade:2168
-#: data/ui/pitch.glade:376 data/ui/presets_menu.glade:146
-#: data/ui/reverb.glade:673 data/ui/stereo_tools.glade:800
-#: data/ui/stereo_tools.glade:843 data/ui/webrtc.glade:664
+#: data/ui/multiband_compressor.glade:1173
+#: data/ui/multiband_compressor.glade:1553
+#: data/ui/multiband_compressor.glade:1933
+#: data/ui/multiband_compressor.glade:2021 data/ui/multiband_gate.glade:852
+#: data/ui/multiband_gate.glade:1264 data/ui/multiband_gate.glade:1677
+#: data/ui/multiband_gate.glade:2090 data/ui/multiband_gate.glade:2178
+#: data/ui/pitch.glade:377 data/ui/presets_menu.glade:146
+#: data/ui/reverb.glade:676 data/ui/stereo_tools.glade:801
+#: data/ui/stereo_tools.glade:844 data/ui/webrtc.glade:665
 msgid "Output"
 msgstr "Uscita"
 
-#: data/ui/autogain.glade:744
+#: data/ui/autogain.glade:748
 msgid "Relative"
 msgstr "Relativo"
 
-#: data/ui/autogain.glade:757 data/ui/compressor.glade:1154
-#: data/ui/deesser.glade:321
+#: data/ui/autogain.glade:761 data/ui/compressor.glade:1157
 msgid "Gain"
 msgstr "Guadagno"
 
-#: data/ui/autogain.glade:823
+#: data/ui/autogain.glade:827
 msgid "Loudness"
 msgstr "Loudness"
 
-#: data/ui/autogain.glade:876
+#: data/ui/autogain.glade:880
 msgid "Range"
 msgstr "Gamma"
 
-#: data/ui/autogain.glade:945 data/ui/bass_enhancer.glade:655
-#: data/ui/compressor.glade:1299 data/ui/convolver.glade:703
-#: data/ui/crossfeed.glade:395 data/ui/crystalizer.glade:566
-#: data/ui/deesser.glade:898 data/ui/delay.glade:434
-#: data/ui/equalizer.glade:743 data/ui/equalizer_band.glade:182
-#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:661
-#: data/ui/filter.glade:595 data/ui/general_settings.glade:116
-#: data/ui/gate.glade:809 data/ui/limiter.glade:733 data/ui/loudness.glade:573
-#: data/ui/maximizer.glade:516 data/ui/multiband_compressor.glade:2199
-#: data/ui/multiband_gate.glade:2352 data/ui/pitch.glade:560
-#: data/ui/reverb.glade:857 data/ui/stereo_tools.glade:1029
-#: data/ui/webrtc.glade:814
+#: data/ui/autogain.glade:949 data/ui/bass_enhancer.glade:650
+#: data/ui/compressor.glade:1300 data/ui/convolver.glade:702
+#: data/ui/crossfeed.glade:394 data/ui/crystalizer.glade:514
+#: data/ui/deesser.glade:899 data/ui/delay.glade:433
+#: data/ui/equalizer.glade:744 data/ui/equalizer_band.glade:182
+#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:654
+#: data/ui/filter.glade:594 data/ui/general_settings.glade:116
+#: data/ui/gate.glade:862 data/ui/limiter.glade:735 data/ui/loudness.glade:615
+#: data/ui/maximizer.glade:519 data/ui/multiband_compressor.glade:2203
+#: data/ui/multiband_gate.glade:2360 data/ui/pitch.glade:559
+#: data/ui/reverb.glade:858 data/ui/stereo_tools.glade:1028
+#: data/ui/webrtc.glade:815
 msgid "Reset"
 msgstr "Reset"
 
-#: data/ui/autogain.glade:969
+#: data/ui/autogain.glade:973
 msgid "Based on"
 msgstr "Basato su"
 
-#: data/ui/bass_enhancer.glade:117
+#: data/ui/bass_enhancer.glade:118
 msgid "Bass Enhancer"
 msgstr "Enfasi Bassi"
 
-#: data/ui/bass_enhancer.glade:169 data/ui/compressor.glade:506
-#: data/ui/deesser.glade:188 data/ui/exciter.glade:171
+#: data/ui/bass_enhancer.glade:170 data/ui/compressor.glade:506
+#: data/ui/deesser.glade:185 data/ui/exciter.glade:170
 msgid "Listen"
 msgstr "Ascolta"
 
-#: data/ui/bass_enhancer.glade:210 data/ui/exciter.glade:213
+#: data/ui/bass_enhancer.glade:211 data/ui/exciter.glade:212
 msgid "3rd"
 msgstr "3a"
 
-#: data/ui/bass_enhancer.glade:222 data/ui/exciter.glade:225
+#: data/ui/bass_enhancer.glade:223 data/ui/exciter.glade:224
 msgid "2nd"
 msgstr "2a"
 
-#: data/ui/bass_enhancer.glade:234 data/ui/exciter.glade:237
+#: data/ui/bass_enhancer.glade:235 data/ui/exciter.glade:236
 msgid "Blend Harmonics"
 msgstr "Mix Armoniche"
 
-#: data/ui/bass_enhancer.glade:266 data/ui/exciter.glade:271
-#: data/ui/reverb.glade:407
+#: data/ui/bass_enhancer.glade:267 data/ui/exciter.glade:270
+#: data/ui/reverb.glade:408
 msgid "Amount"
 msgstr "Quantità"
 
-#: data/ui/bass_enhancer.glade:278 data/ui/bass_enhancer.glade:411
-#: data/ui/exciter.glade:284 data/ui/exciter.glade:417
+#: data/ui/bass_enhancer.glade:279 data/ui/bass_enhancer.glade:413
+#: data/ui/exciter.glade:283 data/ui/exciter.glade:417
 msgid "Harmonics"
 msgstr "Armoniche"
 
-#: data/ui/bass_enhancer.glade:290 data/ui/exciter.glade:297
+#: data/ui/bass_enhancer.glade:291 data/ui/exciter.glade:296
 msgid "Scope"
 msgstr "Soglia"
 
-#: data/ui/bass_enhancer.glade:379
+#: data/ui/bass_enhancer.glade:381
 msgid "Floor"
 msgstr "Limite inferiore"
 
-#: data/ui/bass_enhancer.glade:679 data/ui/compressor.glade:1323
-#: data/ui/crossfeed.glade:419 data/ui/deesser.glade:922
-#: data/ui/delay.glade:458 data/ui/equalizer.glade:767
-#: data/ui/exciter.glade:685 data/ui/filter.glade:619 data/ui/gate.glade:833
-#: data/ui/limiter.glade:757 data/ui/loudness.glade:542
-#: data/ui/maximizer.glade:540 data/ui/multiband_compressor.glade:2223
-#: data/ui/multiband_gate.glade:2376 data/ui/pitch.glade:584
-#: data/ui/reverb.glade:881 data/ui/stereo_tools.glade:1053
-#: data/ui/webrtc.glade:838
+#: data/ui/bass_enhancer.glade:674 data/ui/compressor.glade:1324
+#: data/ui/crossfeed.glade:418 data/ui/deesser.glade:923
+#: data/ui/delay.glade:457 data/ui/equalizer.glade:768
+#: data/ui/exciter.glade:678 data/ui/filter.glade:618 data/ui/gate.glade:886
+#: data/ui/limiter.glade:759 data/ui/loudness.glade:584
+#: data/ui/maximizer.glade:543 data/ui/multiband_compressor.glade:2227
+#: data/ui/multiband_gate.glade:2384 data/ui/pitch.glade:583
+#: data/ui/reverb.glade:882 data/ui/stereo_tools.glade:1052
+#: data/ui/webrtc.glade:839
 msgid "Provided by"
 msgstr "Fornito da"
 
@@ -350,8 +349,7 @@ msgstr "Nome"
 
 #: data/ui/blocklist_settings.glade:85
 msgid "Reconnect the microphone to apply new changes made to the Blocklist"
-msgstr ""
-"Riconnetti il microfono per applicare le modifiche alle App Escluse"
+msgstr "Riconnetti il microfono per applicare le modifiche alle App Escluse"
 
 #: data/ui/blocklist_settings.glade:143 data/ui/pulse_settings.glade:370
 msgid "Input Effects"
@@ -359,8 +357,7 @@ msgstr "Effetti in Ingresso"
 
 #: data/ui/blocklist_settings.glade:239
 msgid "Restart the player to apply new changes made to the Blocklist"
-msgstr ""
-"Riavvia il media player per applicare le modifiche alle App Escluse"
+msgstr "Riavvia il media player per applicare le modifiche alle App Escluse"
 
 #: data/ui/blocklist_settings.glade:250 data/ui/pulse_settings.glade:660
 msgid "Output Effects"
@@ -370,138 +367,138 @@ msgstr "Effetti in Uscita"
 msgid "Show Blocklisted Apps in Main Tab"
 msgstr "Mostra Applicazioni Escluse nella Scheda Principale"
 
-#: data/ui/calibration_signals.glade:32 data/ui/equalizer_band.glade:152
-#: data/ui/filter.glade:280
+#: data/ui/calibration_signals.glade:30 data/ui/equalizer_band.glade:152
+#: data/ui/filter.glade:281
 msgid "Frequency"
 msgstr "Frequenza"
 
-#: data/ui/calibration_signals.glade:64
+#: data/ui/calibration_signals.glade:62
 msgid "Volume"
 msgstr "Volume"
 
-#: data/ui/calibration_signals.glade:108
+#: data/ui/calibration_signals.glade:106
 msgid "Sine"
 msgstr "Sinusoidale"
 
-#: data/ui/calibration_signals.glade:109
+#: data/ui/calibration_signals.glade:107
 msgid "Square"
 msgstr "Quadra"
 
-#: data/ui/calibration_signals.glade:110
+#: data/ui/calibration_signals.glade:108
 msgid "Saw"
 msgstr "A Dente di Sega"
 
-#: data/ui/calibration_signals.glade:111
+#: data/ui/calibration_signals.glade:109
 msgid "Triangle"
 msgstr "Triangolare"
 
-#: data/ui/calibration_signals.glade:112
+#: data/ui/calibration_signals.glade:110
 msgid "Silence"
 msgstr "Silenzio"
 
-#: data/ui/calibration_signals.glade:113
+#: data/ui/calibration_signals.glade:111
 msgid "White Noise"
 msgstr "Rumore bianco"
 
-#: data/ui/calibration_signals.glade:114
+#: data/ui/calibration_signals.glade:112
 msgid "Pink Noise"
 msgstr "Rumore Rosa"
 
-#: data/ui/calibration_signals.glade:115
+#: data/ui/calibration_signals.glade:113
 msgid "Sine Table"
 msgstr "Tabella sinusoidale"
 
-#: data/ui/calibration_signals.glade:116
+#: data/ui/calibration_signals.glade:114
 msgid "Ticks"
 msgstr "Battiti"
 
-#: data/ui/calibration_signals.glade:117
+#: data/ui/calibration_signals.glade:115
 msgid "Gaussian Noise"
 msgstr "Rumore Gaussiano"
 
-#: data/ui/calibration_signals.glade:118
+#: data/ui/calibration_signals.glade:116
 msgid "Red Noise"
 msgstr "Rumore Rosso"
 
-#: data/ui/calibration_signals.glade:119
+#: data/ui/calibration_signals.glade:117
 msgid "Blue Noise"
 msgstr "Rumore Blu"
 
-#: data/ui/calibration_signals.glade:120
+#: data/ui/calibration_signals.glade:118
 msgid "Violet Noise"
 msgstr "Rumore Viola"
 
-#: data/ui/calibration_mic.glade:29
+#: data/ui/calibration_mic.glade:28
 msgid "Window"
 msgstr "Finestra"
 
-#: data/ui/calibration_mic.glade:70
+#: data/ui/calibration_mic.glade:69
 msgid "Measure Noise"
 msgstr "Misura Rumore"
 
-#: data/ui/calibration_mic.glade:99
+#: data/ui/calibration_mic.glade:98
 msgid "Subtract Noise"
 msgstr "Sottrai Rumore"
 
-#: data/ui/compressor.glade:292 data/ui/deesser.glade:483
-#: data/ui/gate.glade:370 data/ui/maximizer.glade:152
-#: data/ui/multiband_compressor.glade:609
+#: data/ui/compressor.glade:290 data/ui/deesser.glade:482
+#: data/ui/gate.glade:413 data/ui/maximizer.glade:153
+#: data/ui/multiband_compressor.glade:607
 #: data/ui/multiband_compressor.glade:983
-#: data/ui/multiband_compressor.glade:1361
-#: data/ui/multiband_compressor.glade:1739 data/ui/multiband_gate.glade:633
-#: data/ui/multiband_gate.glade:1040 data/ui/multiband_gate.glade:1450
-#: data/ui/multiband_gate.glade:1860
+#: data/ui/multiband_compressor.glade:1363
+#: data/ui/multiband_compressor.glade:1743 data/ui/multiband_gate.glade:631
+#: data/ui/multiband_gate.glade:1041 data/ui/multiband_gate.glade:1454
+#: data/ui/multiband_gate.glade:1867
 msgid "Threshold"
 msgstr "Soglia"
 
-#: data/ui/compressor.glade:325 data/ui/deesser.glade:516
-#: data/ui/gate.glade:403 data/ui/multiband_compressor.glade:642
-#: data/ui/multiband_compressor.glade:1017
-#: data/ui/multiband_compressor.glade:1395
-#: data/ui/multiband_compressor.glade:1773 data/ui/multiband_gate.glade:666
-#: data/ui/multiband_gate.glade:1074 data/ui/multiband_gate.glade:1484
-#: data/ui/multiband_gate.glade:1894
+#: data/ui/compressor.glade:324 data/ui/deesser.glade:516
+#: data/ui/gate.glade:449 data/ui/multiband_compressor.glade:641
+#: data/ui/multiband_compressor.glade:1018
+#: data/ui/multiband_compressor.glade:1398
+#: data/ui/multiband_compressor.glade:1778 data/ui/multiband_gate.glade:665
+#: data/ui/multiband_gate.glade:1076 data/ui/multiband_gate.glade:1489
+#: data/ui/multiband_gate.glade:1902
 msgid "Ratio"
 msgstr "Rapporto"
 
-#: data/ui/compressor.glade:357 data/ui/gate.glade:435
-#: data/ui/multiband_compressor.glade:674
-#: data/ui/multiband_compressor.glade:1050
-#: data/ui/multiband_compressor.glade:1428
-#: data/ui/multiband_compressor.glade:1806 data/ui/multiband_gate.glade:698
-#: data/ui/multiband_gate.glade:1107 data/ui/multiband_gate.glade:1517
-#: data/ui/multiband_gate.glade:1927
+#: data/ui/compressor.glade:356 data/ui/gate.glade:483
+#: data/ui/multiband_compressor.glade:673
+#: data/ui/multiband_compressor.glade:1051
+#: data/ui/multiband_compressor.glade:1431
+#: data/ui/multiband_compressor.glade:1811 data/ui/multiband_gate.glade:697
+#: data/ui/multiband_gate.glade:1109 data/ui/multiband_gate.glade:1522
+#: data/ui/multiband_gate.glade:1935
 msgid "Knee"
 msgstr "Curvatura"
 
-#: data/ui/compressor.glade:391 data/ui/deesser.glade:547
-#: data/ui/gate.glade:469 data/ui/multiband_compressor.glade:708
-#: data/ui/multiband_compressor.glade:1085
-#: data/ui/multiband_compressor.glade:1463
-#: data/ui/multiband_compressor.glade:1841 data/ui/multiband_gate.glade:732
-#: data/ui/multiband_gate.glade:1142 data/ui/multiband_gate.glade:1552
-#: data/ui/multiband_gate.glade:1962
+#: data/ui/compressor.glade:390 data/ui/deesser.glade:547
+#: data/ui/gate.glade:519 data/ui/multiband_compressor.glade:707
+#: data/ui/multiband_compressor.glade:1086
+#: data/ui/multiband_compressor.glade:1466
+#: data/ui/multiband_compressor.glade:1846 data/ui/multiband_gate.glade:731
+#: data/ui/multiband_gate.glade:1144 data/ui/multiband_gate.glade:1557
+#: data/ui/multiband_gate.glade:1970
 msgid "Makeup"
 msgstr "Guadagno"
 
-#: data/ui/compressor.glade:425 data/ui/gate.glade:336
-#: data/ui/limiter.glade:310 data/ui/maximizer.glade:178
-#: data/ui/multiband_compressor.glade:575
+#: data/ui/compressor.glade:425 data/ui/gate.glade:377
+#: data/ui/limiter.glade:311 data/ui/maximizer.glade:179
+#: data/ui/multiband_compressor.glade:573
 #: data/ui/multiband_compressor.glade:948
-#: data/ui/multiband_compressor.glade:1326
-#: data/ui/multiband_compressor.glade:1704 data/ui/multiband_gate.glade:599
-#: data/ui/multiband_gate.glade:1005 data/ui/multiband_gate.glade:1415
-#: data/ui/multiband_gate.glade:1825
+#: data/ui/multiband_compressor.glade:1328
+#: data/ui/multiband_compressor.glade:1708 data/ui/multiband_gate.glade:597
+#: data/ui/multiband_gate.glade:1006 data/ui/multiband_gate.glade:1419
+#: data/ui/multiband_gate.glade:1832
 msgid "Release"
 msgstr "Rilascio"
 
-#: data/ui/compressor.glade:438 data/ui/gate.glade:302
-#: data/ui/multiband_compressor.glade:541
+#: data/ui/compressor.glade:438 data/ui/gate.glade:341
+#: data/ui/multiband_compressor.glade:539
 #: data/ui/multiband_compressor.glade:913
-#: data/ui/multiband_compressor.glade:1291
-#: data/ui/multiband_compressor.glade:1669 data/ui/multiband_gate.glade:565
-#: data/ui/multiband_gate.glade:970 data/ui/multiband_gate.glade:1380
-#: data/ui/multiband_gate.glade:1790
+#: data/ui/multiband_compressor.glade:1293
+#: data/ui/multiband_compressor.glade:1673 data/ui/multiband_gate.glade:563
+#: data/ui/multiband_gate.glade:971 data/ui/multiband_gate.glade:1384
+#: data/ui/multiband_gate.glade:1797
 msgid "Attack"
 msgstr "Attacco"
 
@@ -517,202 +514,201 @@ msgstr "Espansiva"
 msgid "Compression Mode"
 msgstr "Modalità di compressione"
 
-#: data/ui/compressor.glade:551
+#: data/ui/compressor.glade:552
 msgid "Pre-amplification"
 msgstr "Pre-amplificazione"
 
-#: data/ui/compressor.glade:585
+#: data/ui/compressor.glade:586
 msgid "Reactivity"
 msgstr "Reattività"
 
-#: data/ui/compressor.glade:619 data/ui/limiter.glade:323
+#: data/ui/compressor.glade:620 data/ui/limiter.glade:324
 msgid "Lookahead"
 msgstr "Lookahead"
 
-#: data/ui/compressor.glade:632
+#: data/ui/compressor.glade:633
 msgid "Feed-forward"
 msgstr "Prelievo in ingresso"
 
-#: data/ui/compressor.glade:633
+#: data/ui/compressor.glade:634
 msgid "Feed-back"
 msgstr "Prelievo in uscita"
 
-#: data/ui/compressor.glade:647 data/ui/equalizer_band.glade:48
+#: data/ui/compressor.glade:648 data/ui/equalizer_band.glade:48
 msgid "Type"
 msgstr "Tipologia"
 
-#: data/ui/compressor.glade:661 data/ui/deesser.glade:244
-#: data/ui/deesser.glade:354 data/ui/gate.glade:257
-#: data/ui/multiband_compressor.glade:514
+#: data/ui/compressor.glade:662 data/ui/deesser.glade:241
+#: data/ui/gate.glade:213 data/ui/multiband_compressor.glade:512
 #: data/ui/multiband_compressor.glade:886
-#: data/ui/multiband_compressor.glade:1264
-#: data/ui/multiband_compressor.glade:1642 data/ui/multiband_gate.glade:538
-#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1353
-#: data/ui/multiband_gate.glade:1763
+#: data/ui/multiband_compressor.glade:1266
+#: data/ui/multiband_compressor.glade:1646 data/ui/multiband_gate.glade:536
+#: data/ui/multiband_gate.glade:944 data/ui/multiband_gate.glade:1357
+#: data/ui/multiband_gate.glade:1770
 msgid "Peak"
 msgstr "Picco"
 
-#: data/ui/compressor.glade:662 data/ui/deesser.glade:243
-#: data/ui/gate.glade:256 data/ui/multiband_compressor.glade:513
+#: data/ui/compressor.glade:663 data/ui/deesser.glade:240
+#: data/ui/gate.glade:212 data/ui/multiband_compressor.glade:511
 #: data/ui/multiband_compressor.glade:885
-#: data/ui/multiband_compressor.glade:1263
-#: data/ui/multiband_compressor.glade:1641 data/ui/multiband_gate.glade:537
-#: data/ui/multiband_gate.glade:942 data/ui/multiband_gate.glade:1352
-#: data/ui/multiband_gate.glade:1762
+#: data/ui/multiband_compressor.glade:1265
+#: data/ui/multiband_compressor.glade:1645 data/ui/multiband_gate.glade:535
+#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1356
+#: data/ui/multiband_gate.glade:1769
 msgid "RMS"
 msgstr "RMS"
 
-#: data/ui/compressor.glade:663
+#: data/ui/compressor.glade:664
 msgid "Low-Pass"
 msgstr "Passa Basso"
 
-#: data/ui/compressor.glade:664
+#: data/ui/compressor.glade:665
 msgid "Uniform"
 msgstr "Uniforme"
 
-#: data/ui/compressor.glade:678 data/ui/deesser.glade:230
-#: data/ui/equalizer.glade:224 data/ui/equalizer_band.glade:79
-#: data/ui/multiband_compressor.glade:324 data/ui/multiband_gate.glade:348
-#: data/ui/stereo_tools.glade:485 data/ui/webrtc.glade:376
+#: data/ui/compressor.glade:679 data/ui/deesser.glade:227
+#: data/ui/equalizer.glade:225 data/ui/equalizer_band.glade:79
+#: data/ui/multiband_compressor.glade:322 data/ui/multiband_gate.glade:346
+#: data/ui/stereo_tools.glade:486 data/ui/webrtc.glade:377
 msgid "Mode"
 msgstr "Modalità"
 
-#: data/ui/compressor.glade:692
+#: data/ui/compressor.glade:693
 msgid "Middle"
 msgstr "Intermedia"
 
-#: data/ui/compressor.glade:693
+#: data/ui/compressor.glade:694
 msgid "Side"
 msgstr "Laterale"
 
-#: data/ui/compressor.glade:694 data/ui/delay.glade:157
-#: data/ui/equalizer.glade:474 data/ui/stereo_tools.glade:548
+#: data/ui/compressor.glade:695 data/ui/delay.glade:158
+#: data/ui/equalizer.glade:475 data/ui/stereo_tools.glade:549
 msgid "Left"
 msgstr "Canale Sinistro"
 
-#: data/ui/compressor.glade:695 data/ui/delay.glade:189
-#: data/ui/equalizer.glade:515 data/ui/stereo_tools.glade:620
+#: data/ui/compressor.glade:696 data/ui/delay.glade:190
+#: data/ui/equalizer.glade:516 data/ui/stereo_tools.glade:621
 msgid "Right"
 msgstr "Canale Destro"
 
-#: data/ui/compressor.glade:709
+#: data/ui/compressor.glade:710
 msgid "Source"
 msgstr "Sorgente"
 
-#: data/ui/compressor.glade:725 data/ui/compressor.glade:1167
+#: data/ui/compressor.glade:726 data/ui/compressor.glade:1170
 msgid "Sidechain"
 msgstr "Sidechain"
 
-#: data/ui/compressor.glade:821
+#: data/ui/compressor.glade:824
 msgid "Relative Release Threshold"
 msgstr "Soglia di Rilascio Relativa"
 
-#: data/ui/compressor.glade:832
+#: data/ui/compressor.glade:835
 msgid "Boost Threshold"
 msgstr "Soglia di Incremento"
 
-#: data/ui/compressor.glade:843
+#: data/ui/compressor.glade:846
 msgid "High-pass Frequency"
 msgstr "Frequenza Passa-Alto"
 
-#: data/ui/compressor.glade:854
+#: data/ui/compressor.glade:857
 msgid "Low-pass Frequency"
 msgstr "Frequenza Passa-Basso"
 
-#: data/ui/compressor.glade:865
+#: data/ui/compressor.glade:868
 msgid "High-pass Filter Mode"
 msgstr "Modalità Filtro Passa-Alto"
 
-#: data/ui/compressor.glade:876
+#: data/ui/compressor.glade:879
 msgid "Low-pass Filter Mode"
 msgstr "Modalità Filtro Passa-Basso"
 
-#: data/ui/compressor.glade:889 data/ui/compressor.glade:906
+#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
 #: data/ui/equalizer_band.glade:60
 msgid "Off"
 msgstr "Inattivo"
 
-#: data/ui/compressor.glade:890 data/ui/compressor.glade:907
+#: data/ui/compressor.glade:893 data/ui/compressor.glade:910
 msgid "12 dB/oct"
 msgstr "12 dB/ott"
 
-#: data/ui/compressor.glade:891 data/ui/compressor.glade:908
+#: data/ui/compressor.glade:894 data/ui/compressor.glade:911
 msgid "24 dB/oct"
 msgstr "24 dB/ott"
 
-#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
+#: data/ui/compressor.glade:895 data/ui/compressor.glade:912
 msgid "36 dB/oct"
 msgstr "36 dB/ott"
 
-#: data/ui/compressor.glade:932
+#: data/ui/compressor.glade:935
 msgid "Advanced"
 msgstr "Avanzate"
 
-#: data/ui/compressor.glade:1243
+#: data/ui/compressor.glade:1244
 msgid "Curve"
 msgstr "Curva"
 
-#: data/ui/convolver.glade:91
+#: data/ui/convolver.glade:92
 msgid "Convolver"
 msgstr "Convolutore"
 
-#: data/ui/convolver.glade:125
+#: data/ui/convolver.glade:126
 msgid "Import Impulse"
 msgstr "Importa Impulso"
 
-#: data/ui/convolver.glade:129
+#: data/ui/convolver.glade:130
 msgid "Import Impulse Response File"
 msgstr "Importa File di Risposta all'Impulso"
 
-#: data/ui/convolver.glade:247
+#: data/ui/convolver.glade:248
 msgid "L"
 msgstr "S"
 
-#: data/ui/convolver.glade:261
+#: data/ui/convolver.glade:262
 msgid "R"
 msgstr "D"
 
-#: data/ui/convolver.glade:324
+#: data/ui/convolver.glade:325
 msgid "Duration"
 msgstr "Durata"
 
-#: data/ui/convolver.glade:335
+#: data/ui/convolver.glade:336
 msgid "Samples"
 msgstr "Campioni"
 
-#: data/ui/convolver.glade:367 src/convolver_ui.cpp:283
+#: data/ui/convolver.glade:368 src/convolver_ui.cpp:283
 msgid "Impulse Response"
 msgstr "Risposta all'Impulso"
 
-#: data/ui/convolver.glade:389
+#: data/ui/convolver.glade:390
 msgid "Select the impulse Response File"
 msgstr "Seleziona il File di Risposta all'impulso"
 
-#: data/ui/convolver.glade:409 src/spectrum_settings_ui.cpp:176
+#: data/ui/convolver.glade:410 src/spectrum_settings_ui.cpp:176
 msgid "Spectrum"
 msgstr "Spettro"
 
-#: data/ui/convolver.glade:450
+#: data/ui/convolver.glade:451
 msgid "Stereo Width"
 msgstr "Ampiezza Stereo"
 
-#: data/ui/crossfeed.glade:63
+#: data/ui/crossfeed.glade:62
 msgid "Jmeier"
 msgstr "Jmeier"
 
-#: data/ui/crossfeed.glade:76 data/ui/filter.glade:183 data/ui/reverb.glade:259
+#: data/ui/crossfeed.glade:75 data/ui/filter.glade:184 data/ui/reverb.glade:260
 msgid "Default"
 msgstr "Predefinito"
 
-#: data/ui/crossfeed.glade:89
+#: data/ui/crossfeed.glade:88
 msgid "Cmoy"
 msgstr "Cmoy"
 
-#: data/ui/crossfeed.glade:120
+#: data/ui/crossfeed.glade:119
 msgid "Cutoff"
 msgstr "Taglio"
 
-#: data/ui/crossfeed.glade:153
+#: data/ui/crossfeed.glade:152
 msgid "Feed"
 msgstr "Feed"
 
@@ -720,115 +716,127 @@ msgstr "Feed"
 msgid "Crossfeed"
 msgstr "Crossfeed"
 
-#: data/ui/crystalizer.glade:115
+#: data/ui/crystalizer.glade:92
 msgid "Crystalizer"
 msgstr "Crystalizer"
 
-#: data/ui/crystalizer.glade:187
+#: data/ui/crystalizer.glade:137
 msgid "Aggressive Mode"
 msgstr "Modalità Aggressiva"
 
-#: data/ui/crystalizer.glade:447
+#: data/ui/crystalizer.glade:395
 msgid "Loudness Range"
 msgstr "Gamma Loudness"
 
-#: data/ui/crystalizer.glade:466
+#: data/ui/crystalizer.glade:414
 msgid "Before"
 msgstr "Prima"
 
-#: data/ui/crystalizer.glade:479
+#: data/ui/crystalizer.glade:427
 msgid "After"
 msgstr "Dopo"
 
 #: data/ui/crystalizer_band.glade:27 data/ui/equalizer_band.glade:313
-#: data/ui/stereo_tools.glade:574 data/ui/stereo_tools.glade:633
+#: data/ui/stereo_tools.glade:575 data/ui/stereo_tools.glade:634
 msgid "Mute"
 msgstr "Muto"
 
-#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:483
+#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:481
 #: data/ui/multiband_compressor.glade:855
-#: data/ui/multiband_compressor.glade:1233
-#: data/ui/multiband_compressor.glade:1611 data/ui/multiband_gate.glade:507
-#: data/ui/multiband_gate.glade:912 data/ui/multiband_gate.glade:1322
-#: data/ui/multiband_gate.glade:1732
+#: data/ui/multiband_compressor.glade:1235
+#: data/ui/multiband_compressor.glade:1615 data/ui/multiband_gate.glade:505
+#: data/ui/multiband_gate.glade:913 data/ui/multiband_gate.glade:1326
+#: data/ui/multiband_gate.glade:1739
 msgid "Bypass"
 msgstr "Bypass"
 
-#: data/ui/deesser.glade:128
+#: data/ui/deesser.glade:127
 msgid "Deesser"
 msgstr "Deesser"
 
-#: data/ui/deesser.glade:216 data/ui/gate.glade:195
+#: data/ui/deesser.glade:213 data/ui/gate.glade:198
 msgid "Detection"
 msgstr "Rilevamento"
 
-#: data/ui/deesser.glade:258
+#: data/ui/deesser.glade:255
 msgid "Wide"
 msgstr "Banda Larga"
 
-#: data/ui/deesser.glade:259 data/ui/deesser.glade:288
+#: data/ui/deesser.glade:256
 msgid "Split"
 msgstr "Split"
 
-#: data/ui/deesser.glade:407
-msgid "Level"
-msgstr "Livello"
+#: data/ui/deesser.glade:285
+msgid "F1 Split"
+msgstr "F1 Split"
 
-#: data/ui/deesser.glade:420
-msgid "Peak Q"
-msgstr "Picco Q"
+#: data/ui/deesser.glade:318
+msgid "F1 Gain"
+msgstr "F1 Guadagno"
 
-#: data/ui/deesser.glade:452
+#: data/ui/deesser.glade:352
+msgid "F2 Peak"
+msgstr "F2 Picco"
+
+#: data/ui/deesser.glade:406
+msgid "F2 Level"
+msgstr "F2 Livello"
+
+#: data/ui/deesser.glade:419
+msgid "F2 Peak Q"
+msgstr "F2 Picco Q"
+
+#: data/ui/deesser.glade:451
 msgid "Laxity"
 msgstr "Trascuranza"
 
-#: data/ui/deesser.glade:778 data/ui/multiband_gate.glade:767
-#: data/ui/multiband_gate.glade:1197 data/ui/multiband_gate.glade:1607
-#: data/ui/multiband_gate.glade:2017
+#: data/ui/deesser.glade:779 data/ui/multiband_gate.glade:767
+#: data/ui/multiband_gate.glade:1201 data/ui/multiband_gate.glade:1614
+#: data/ui/multiband_gate.glade:2027
 msgid "Reduction"
 msgstr "Riduzione"
 
-#: data/ui/deesser.glade:791
+#: data/ui/deesser.glade:792
 msgid "Detected"
 msgstr "Rilevato"
 
-#: data/ui/delay.glade:91
+#: data/ui/delay.glade:92
 msgid "Delay"
 msgstr "Delay"
 
-#: data/ui/equalizer.glade:44
+#: data/ui/equalizer.glade:45
 msgid "Equalizer"
 msgstr "Equalizzatore"
 
-#: data/ui/equalizer.glade:153
+#: data/ui/equalizer.glade:154
 msgid "Split Channels"
 msgstr "Separa Canali"
 
-#: data/ui/equalizer.glade:179
+#: data/ui/equalizer.glade:180
 msgid "IIR"
 msgstr "IIR"
 
-#: data/ui/equalizer.glade:180
+#: data/ui/equalizer.glade:181
 msgid "FIR"
 msgstr "FIR"
 
-#: data/ui/equalizer.glade:181
+#: data/ui/equalizer.glade:182
 msgid "FFT"
 msgstr "FFT"
 
-#: data/ui/equalizer.glade:211
+#: data/ui/equalizer.glade:212
 msgid "Bands"
 msgstr "Bande"
 
-#: data/ui/equalizer.glade:233
+#: data/ui/equalizer.glade:234
 msgid "Flat Response"
 msgstr "Risposta Piatta"
 
-#: data/ui/equalizer.glade:248
+#: data/ui/equalizer.glade:249
 msgid "Calculate Frequencies"
 msgstr "Calcola Frequenze"
 
-#: data/ui/equalizer.glade:262
+#: data/ui/equalizer.glade:263
 msgid "Import APO Presets"
 msgstr "Importa Profili APO"
 
@@ -856,7 +864,7 @@ msgstr "Sotto Soglia"
 msgid "Notch"
 msgstr "Elimina Banda"
 
-#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:314
+#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:315
 msgid "Resonance"
 msgstr "Risonanza"
 
@@ -900,12 +908,12 @@ msgstr "Qualità"
 msgid "Width"
 msgstr "Ampiezza"
 
-#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:496
+#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:494
 #: data/ui/multiband_compressor.glade:868
-#: data/ui/multiband_compressor.glade:1246
-#: data/ui/multiband_compressor.glade:1624 data/ui/multiband_gate.glade:520
-#: data/ui/multiband_gate.glade:925 data/ui/multiband_gate.glade:1335
-#: data/ui/multiband_gate.glade:1745
+#: data/ui/multiband_compressor.glade:1248
+#: data/ui/multiband_compressor.glade:1628 data/ui/multiband_gate.glade:518
+#: data/ui/multiband_gate.glade:926 data/ui/multiband_gate.glade:1339
+#: data/ui/multiband_gate.glade:1752
 msgid "Solo"
 msgstr "Isola"
 
@@ -913,79 +921,79 @@ msgstr "Isola"
 msgid "Apply"
 msgstr "Applica"
 
-#: data/ui/exciter.glade:117
+#: data/ui/exciter.glade:118
 msgid "Exciter"
 msgstr "Exciter"
 
-#: data/ui/exciter.glade:384 data/ui/maximizer.glade:165
+#: data/ui/exciter.glade:384 data/ui/maximizer.glade:166
 msgid "Ceiling"
 msgstr "Limite Superiore"
 
-#: data/ui/filter.glade:98
+#: data/ui/filter.glade:99
 msgid "Filter"
 msgstr "Filtro"
 
-#: data/ui/filter.glade:147
+#: data/ui/filter.glade:148
 msgid "Muted"
 msgstr "Muto"
 
-#: data/ui/filter.glade:159 data/ui/reverb.glade:233
+#: data/ui/filter.glade:160 data/ui/reverb.glade:234
 msgid "Disco"
 msgstr "Disco"
 
-#: data/ui/filter.glade:171
+#: data/ui/filter.glade:172
 msgid "Distant Headphones"
 msgstr "Cuffie Distanti"
 
-#: data/ui/filter.glade:246
+#: data/ui/filter.glade:247
 msgid "12dB/oct Lowpass"
 msgstr "Passa Basso 12dB/ott"
 
-#: data/ui/filter.glade:247
+#: data/ui/filter.glade:248
 msgid "24dB/oct Lowpass"
 msgstr "Passa Basso 24dB/ott"
 
-#: data/ui/filter.glade:248
+#: data/ui/filter.glade:249
 msgid "36dB/oct Lowpass"
 msgstr "Passa Basso 36dB/ott"
 
-#: data/ui/filter.glade:249
+#: data/ui/filter.glade:250
 msgid "12dB/oct Highpass"
 msgstr "Passa Alto 12dB/ott"
 
-#: data/ui/filter.glade:250
+#: data/ui/filter.glade:251
 msgid "24dB/oct Highpass"
 msgstr "Passa Alto 24dB/ott"
 
-#: data/ui/filter.glade:251
+#: data/ui/filter.glade:252
 msgid "36dB/oct Highpass"
 msgstr "Passa Alto 36dB/ott"
 
-#: data/ui/filter.glade:252
+#: data/ui/filter.glade:253
 msgid "6dB/oct Bandpass"
 msgstr "Passa Banda 6dB/ott"
 
-#: data/ui/filter.glade:253
+#: data/ui/filter.glade:254
 msgid "12dB/oct Bandpass"
 msgstr "Passa Banda 12dB/ott"
 
-#: data/ui/filter.glade:254
+#: data/ui/filter.glade:255
 msgid "18dB/oct Bandpass"
 msgstr "Passa Banda 18dB/ott"
 
-#: data/ui/filter.glade:255
+#: data/ui/filter.glade:256
 msgid "6dB/oct Bandreject"
 msgstr "Elimina Banda 6dB/ott"
 
-#: data/ui/filter.glade:256
+#: data/ui/filter.glade:257
 msgid "12dB/oct Bandreject"
 msgstr "Elimina Banda 12dB/ott"
 
-#: data/ui/filter.glade:257
+#: data/ui/filter.glade:258
 msgid "18dB/oct Bandreject"
 msgstr "Elimina Banda 18dB/ott"
 
-#: data/ui/filter.glade:349
+#: data/ui/filter.glade:350
 msgid "Inertia"
 msgstr "Inerzia"
 
@@ -1029,49 +1037,49 @@ msgstr "Processa Tutto in Ingresso"
 msgid "Priority"
 msgstr "Valore Priorità"
 
-#: data/ui/gate.glade:98
+#: data/ui/gate.glade:99
 msgid "Gate"
 msgstr "Gate"
 
-#: data/ui/gate.glade:209
+#: data/ui/gate.glade:240
+msgid "Maximum Gain Reduction"
+msgstr "Massima Riduzione Guadagno"
+
+#: data/ui/gate.glade:289
 msgid "Stereo Link"
 msgstr "Relazione Canali"
 
-#: data/ui/gate.glade:222 data/ui/maximizer.glade:293
-msgid "Gain Reduction"
-msgstr "Riduzione Guadagno"
-
-#: data/ui/gate.glade:273
+#: data/ui/gate.glade:304
 msgid "Average"
 msgstr "Media"
 
-#: data/ui/gate.glade:274
+#: data/ui/gate.glade:305
 msgid "Maximum"
 msgstr "Massima"
 
-#: data/ui/gate.glade:525
+#: data/ui/gate.glade:578
 msgid "Input Level"
 msgstr "Livello in Ingresso"
 
-#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:811
-#: data/ui/multiband_gate.glade:1220 data/ui/multiband_gate.glade:1630
-#: data/ui/multiband_gate.glade:2040
+#: data/ui/gate.glade:797 data/ui/multiband_gate.glade:812
+#: data/ui/multiband_gate.glade:1224 data/ui/multiband_gate.glade:1637
+#: data/ui/multiband_gate.glade:2050
 msgid "Gating"
 msgstr "Gating"
 
-#: data/ui/limiter.glade:97 data/ui/webrtc.glade:421
+#: data/ui/limiter.glade:98 data/ui/webrtc.glade:422
 msgid "Limiter"
 msgstr "Limitatore"
 
-#: data/ui/limiter.glade:176
+#: data/ui/limiter.glade:175
 msgid "Automatic Smoothing Control"
 msgstr "Controllo Smussamento Automatico"
 
-#: data/ui/limiter.glade:190
+#: data/ui/limiter.glade:189
 msgid "Automatic Leveling"
 msgstr "Livellamento Automatico"
 
-#: data/ui/limiter.glade:222
+#: data/ui/limiter.glade:221
 msgid "Input Gain"
 msgstr "Guadagno in Ingresso"
 
@@ -1079,134 +1087,138 @@ msgstr "Guadagno in Ingresso"
 msgid "Limit"
 msgstr "Limite"
 
-#: data/ui/limiter.glade:358
+#: data/ui/limiter.glade:359
 msgid "Oversampling"
 msgstr "Sovracampionamento"
 
-#: data/ui/limiter.glade:411
+#: data/ui/limiter.glade:413
 msgid "Output Gain"
 msgstr "Guadagno in Uscita"
 
-#: data/ui/limiter.glade:429
+#: data/ui/limiter.glade:431
 msgid "ASC"
 msgstr "ASC"
 
-#: data/ui/limiter.glade:584
+#: data/ui/limiter.glade:586
 msgid "Attenuation"
 msgstr "Attenuazione"
 
-#: data/ui/loudness.glade:91
+#: data/ui/loudness.glade:92
 msgid "Loudness Compensator"
 msgstr "Bilanciamento Loudness"
 
-#: data/ui/loudness.glade:147
-msgid "Standard"
-msgstr "Standard"
-
-#: data/ui/loudness.glade:161
-msgid "Flat"
-msgstr "Flat"
-
-#: data/ui/loudness.glade:162
-msgid "ISO226-2003"
-msgstr "ISO226-2003"
-
-#: data/ui/loudness.glade:163
-msgid "Fletcher-Munson"
-msgstr "Fletcher-Munson"
-
-#: data/ui/loudness.glade:164
-msgid "Robinson-Dadson"
-msgstr "Robinson-Dadson"
-
-#: data/ui/loudness.glade:174
-msgid "Reference Signal"
-msgstr "Segnale di Riferimento"
-
-#: data/ui/loudness.glade:199
+#: data/ui/loudness.glade:155
 msgid "FFT Size"
 msgstr "Dimensione FFT"
 
-#: data/ui/maximizer.glade:96
+#: data/ui/loudness.glade:205
+msgid "Standard"
+msgstr "Standard"
+
+#: data/ui/loudness.glade:220
+msgid "Flat"
+msgstr "Flat"
+
+#: data/ui/loudness.glade:221
+msgid "ISO226-2003"
+msgstr "ISO226-2003"
+
+#: data/ui/loudness.glade:222
+msgid "Fletcher-Munson"
+msgstr "Fletcher-Munson"
+
+#: data/ui/loudness.glade:223
+msgid "Robinson-Dadson"
+msgstr "Robinson-Dadson"
+
+#: data/ui/loudness.glade:259
+msgid "Reference Signal"
+msgstr "Segnale di Riferimento"
+
+#: data/ui/maximizer.glade:97
 msgid "Maximizer"
 msgstr "Maximizer"
 
-#: data/ui/multiband_compressor.glade:140
+#: data/ui/maximizer.glade:296
+msgid "Gain Reduction"
+msgstr "Riduzione Guadagno"
+
+#: data/ui/multiband_compressor.glade:141
 msgid "Multiband Compressor"
 msgstr "Compressore Multibanda"
 
-#: data/ui/multiband_compressor.glade:338 data/ui/multiband_gate.glade:362
+#: data/ui/multiband_compressor.glade:336 data/ui/multiband_gate.glade:360
 msgid "LR4"
 msgstr "LR4"
 
-#: data/ui/multiband_compressor.glade:339 data/ui/multiband_gate.glade:363
+#: data/ui/multiband_compressor.glade:337 data/ui/multiband_gate.glade:361
 msgid "LR8"
 msgstr "LR8"
 
-#: data/ui/multiband_compressor.glade:353 data/ui/multiband_gate.glade:377
+#: data/ui/multiband_compressor.glade:351 data/ui/multiband_gate.glade:375
 msgid "Split 1/2"
 msgstr "Frequenza Split 1/2"
 
-#: data/ui/multiband_compressor.glade:366 data/ui/multiband_gate.glade:390
+#: data/ui/multiband_compressor.glade:364 data/ui/multiband_gate.glade:388
 msgid "Split 2/3"
 msgstr "Frequenza Split 2/3"
 
-#: data/ui/multiband_compressor.glade:379 data/ui/multiband_gate.glade:403
+#: data/ui/multiband_compressor.glade:377 data/ui/multiband_gate.glade:401
 msgid "Split 3/4"
 msgstr "Frequenza Split 3/4"
 
 #: data/ui/multiband_compressor.glade:754
-#: data/ui/multiband_compressor.glade:1131
-#: data/ui/multiband_compressor.glade:1509
-#: data/ui/multiband_compressor.glade:1887
+#: data/ui/multiband_compressor.glade:1133
+#: data/ui/multiband_compressor.glade:1513
+#: data/ui/multiband_compressor.glade:1893
 msgid "Compression"
 msgstr "Compressione"
 
-#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:894
+#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:895
 msgid "Sub Band"
 msgstr "Sottobanda"
 
-#: data/ui/multiband_compressor.glade:1214 data/ui/multiband_gate.glade:1303
+#: data/ui/multiband_compressor.glade:1216 data/ui/multiband_gate.glade:1307
 msgid "Low Band"
 msgstr "Banda Bassa"
 
-#: data/ui/multiband_compressor.glade:1592 data/ui/multiband_gate.glade:1713
+#: data/ui/multiband_compressor.glade:1596 data/ui/multiband_gate.glade:1720
 msgid "Mid Band"
 msgstr "Banda Media"
 
-#: data/ui/multiband_compressor.glade:1970 data/ui/multiband_gate.glade:2123
+#: data/ui/multiband_compressor.glade:1976 data/ui/multiband_gate.glade:2133
 msgid "High Band"
 msgstr "Banda Alta"
 
-#: data/ui/multiband_gate.glade:140
+#: data/ui/multiband_gate.glade:141
 msgid "Multiband Gate"
 msgstr "Gate Multibanda"
 
-#: data/ui/pitch.glade:103
+#: data/ui/pitch.glade:104
 msgid "Pitch"
 msgstr "Intonazione"
 
-#: data/ui/pitch.glade:178
+#: data/ui/pitch.glade:179
 msgid "Cents"
 msgstr "Centesimi"
 
-#: data/ui/pitch.glade:209
+#: data/ui/pitch.glade:210
 msgid "Semitones"
 msgstr "Semitoni"
 
-#: data/ui/pitch.glade:240
+#: data/ui/pitch.glade:241
 msgid "Octaves"
 msgstr "Ottave"
 
-#: data/ui/pitch.glade:271
+#: data/ui/pitch.glade:272
 msgid "Crispness"
 msgstr "Chiarezza"
 
-#: data/ui/pitch.glade:311
+#: data/ui/pitch.glade:312
 msgid "Faster"
 msgstr "Più Veloce"
 
-#: data/ui/pitch.glade:325
+#: data/ui/pitch.glade:326
 msgid "Preserve Formant"
 msgstr "Preserva Formante"
 
@@ -1303,83 +1315,83 @@ msgstr "In Ingresso alla Pipeline"
 msgid "Pipeline Output"
 msgstr "In Uscita alla Pipeline"
 
-#: data/ui/reverb.glade:131
+#: data/ui/reverb.glade:132
 msgid "Reverberation"
 msgstr "Riverbero"
 
-#: data/ui/reverb.glade:181
+#: data/ui/reverb.glade:182
 msgid "Ambience"
 msgstr "Ambiente"
 
-#: data/ui/reverb.glade:194
+#: data/ui/reverb.glade:195
 msgid "Empty Walls"
 msgstr "Mura Vuote"
 
-#: data/ui/reverb.glade:207
+#: data/ui/reverb.glade:208
 msgid "Room"
 msgstr "Stanza"
 
-#: data/ui/reverb.glade:220
+#: data/ui/reverb.glade:221
 msgid "Large Empty Hall"
 msgstr "Sala Grande Vuota"
 
-#: data/ui/reverb.glade:246
+#: data/ui/reverb.glade:247
 msgid "Large Occupied Hall"
 msgstr "Sala Grande Occupata"
 
-#: data/ui/reverb.glade:361
+#: data/ui/reverb.glade:362
 msgid "Pre Delay"
 msgstr "Pre Ritardo"
 
-#: data/ui/reverb.glade:374
+#: data/ui/reverb.glade:375
 msgid "Decay Time"
 msgstr "Tempo di Decadimento"
 
-#: data/ui/reverb.glade:439
+#: data/ui/reverb.glade:441
 msgid "Dry"
 msgstr "Trascuranza"
 
-#: data/ui/reverb.glade:471
+#: data/ui/reverb.glade:474
 msgid "Bass Cut"
 msgstr "Taglio Bassi"
 
-#: data/ui/reverb.glade:522
+#: data/ui/reverb.glade:525
 msgid "Treble Cut"
 msgstr "Taglio Alti"
 
-#: data/ui/reverb.glade:565
+#: data/ui/reverb.glade:568
 msgid "Diffusion"
 msgstr "Diffusione"
 
-#: data/ui/reverb.glade:577
+#: data/ui/reverb.glade:580
 msgid "Room Size"
 msgstr "Dimensione Stanza"
 
-#: data/ui/reverb.glade:590
+#: data/ui/reverb.glade:593
 msgid "Small"
 msgstr "Piccola"
 
-#: data/ui/reverb.glade:591
+#: data/ui/reverb.glade:594
 msgid "Medium"
 msgstr "Media"
 
-#: data/ui/reverb.glade:592
+#: data/ui/reverb.glade:595
 msgid "Large"
 msgstr "Grande"
 
-#: data/ui/reverb.glade:593
+#: data/ui/reverb.glade:596
 msgid "Tunnel"
 msgstr "Tunnel"
 
-#: data/ui/reverb.glade:594
+#: data/ui/reverb.glade:597
 msgid "Large/smooth"
 msgstr "Grande/liscia"
 
-#: data/ui/reverb.glade:595
+#: data/ui/reverb.glade:598
 msgid "Experimental"
 msgstr "Sperimentale"
 
-#: data/ui/reverb.glade:608
+#: data/ui/reverb.glade:611
 msgid "High Frequency Damping"
 msgstr "Smorza Alte Frequenze"
 
@@ -1451,23 +1463,23 @@ msgstr "Altezza"
 msgid "Points"
 msgstr "Punti"
 
-#: data/ui/stereo_tools.glade:109
+#: data/ui/stereo_tools.glade:110
 msgid "Stereo Tools"
 msgstr "Strumenti Stereo"
 
-#: data/ui/stereo_tools.glade:231
+#: data/ui/stereo_tools.glade:230
 msgid "Softclip"
 msgstr "Softclip"
 
-#: data/ui/stereo_tools.glade:255 data/ui/stereo_tools.glade:671
+#: data/ui/stereo_tools.glade:254 data/ui/stereo_tools.glade:672
 msgid "Balance"
 msgstr "Bilanciamento"
 
-#: data/ui/stereo_tools.glade:287
+#: data/ui/stereo_tools.glade:286
 msgid "S/C Level"
 msgstr "Livello S/C"
 
-#: data/ui/stereo_tools.glade:345
+#: data/ui/stereo_tools.glade:344
 msgid "Side Level"
 msgstr "Livello Laterale"
 
@@ -1475,144 +1487,144 @@ msgstr "Livello Laterale"
 msgid "Side Balance"
 msgstr "Bilanciamento Laterale"
 
-#: data/ui/stereo_tools.glade:428
+#: data/ui/stereo_tools.glade:429
 msgid "Middle Level"
 msgstr "Livello Medio"
 
-#: data/ui/stereo_tools.glade:441
+#: data/ui/stereo_tools.glade:442
 msgid "Middle Panorama"
 msgstr "Panorama Medio"
 
-#: data/ui/stereo_tools.glade:499
+#: data/ui/stereo_tools.glade:500
 msgid "LR > LR (Stereo Default)"
 msgstr "LR > LR (Predefinito Stereo)"
 
-#: data/ui/stereo_tools.glade:500
+#: data/ui/stereo_tools.glade:501
 msgid "LR > MS (Stereo to Mid-Side)"
 msgstr "LR > MS (Stereo a Mid-Side)"
 
-#: data/ui/stereo_tools.glade:501
+#: data/ui/stereo_tools.glade:502
 msgid "MS > LR (Mid-Side to Stereo)"
 msgstr "MS > LR (Mid-Side a Stereo)"
 
-#: data/ui/stereo_tools.glade:502
+#: data/ui/stereo_tools.glade:503
 msgid "LR > LL (Mono Left Channel)"
 msgstr "LR > LL (Canale Sinistro Mono)"
 
-#: data/ui/stereo_tools.glade:503
+#: data/ui/stereo_tools.glade:504
 msgid "LR > RR (Mono Right Channel)"
 msgstr "LR > RR (Canale Destro Mono)"
 
-#: data/ui/stereo_tools.glade:504
+#: data/ui/stereo_tools.glade:505
 msgid "LR > L+R (Mono Sum L+R)"
 msgstr "LR > L+R (Somma Canali a Mono)"
 
-#: data/ui/stereo_tools.glade:505
+#: data/ui/stereo_tools.glade:506
 msgid "LR > RL (Stereo Flip Channels)"
 msgstr "LR > RL (Inverti Canali Stereo)"
 
-#: data/ui/stereo_tools.glade:522
+#: data/ui/stereo_tools.glade:523
 msgid "Stereo Matrix"
 msgstr "Matrice Stereo"
 
-#: data/ui/stereo_tools.glade:561 data/ui/stereo_tools.glade:602
+#: data/ui/stereo_tools.glade:562 data/ui/stereo_tools.glade:603
 msgid "Invert Phase"
 msgstr "Inverti Fase"
 
-#: data/ui/stereo_tools.glade:703
+#: data/ui/stereo_tools.glade:704
 msgid "Delay L/R"
 msgstr "Delay Canali"
 
-#: data/ui/stereo_tools.glade:737
+#: data/ui/stereo_tools.glade:738
 msgid "Stereo Base"
 msgstr "Base Stereo"
 
-#: data/ui/stereo_tools.glade:770
+#: data/ui/stereo_tools.glade:771
 msgid "Stereo Phase"
 msgstr "Fase Stereo"
 
-#: data/ui/webrtc.glade:97
+#: data/ui/webrtc.glade:98
 msgid "WebRTC"
 msgstr "WebRTC"
 
-#: data/ui/webrtc.glade:163 data/ui/webrtc.glade:283 data/ui/webrtc.glade:353
-#: data/ui/webrtc.glade:523
+#: data/ui/webrtc.glade:164 data/ui/webrtc.glade:284 data/ui/webrtc.glade:354
+#: data/ui/webrtc.glade:524
 msgid "Enable"
 msgstr "Attiva"
 
-#: data/ui/webrtc.glade:184
+#: data/ui/webrtc.glade:185
 msgid "Extended Filter"
 msgstr "Filtro Esteso"
 
-#: data/ui/webrtc.glade:197
+#: data/ui/webrtc.glade:198
 msgid "Delay Agnostic"
 msgstr "Ritardo Agnostico"
 
-#: data/ui/webrtc.glade:209
+#: data/ui/webrtc.glade:210
 msgid "High Pass Filter"
 msgstr "Filtro Passa Alto"
 
-#: data/ui/webrtc.glade:238 data/ui/webrtc.glade:306
+#: data/ui/webrtc.glade:239 data/ui/webrtc.glade:307
 msgid "Suppresion Level"
 msgstr "Livello Riduzione"
 
-#: data/ui/webrtc.glade:251 data/ui/webrtc.glade:319 data/ui/webrtc.glade:575
+#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
 msgid "Low"
 msgstr "Basso"
 
-#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
+#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
 msgid "Moderate"
 msgstr "Moderato"
 
-#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
+#: data/ui/webrtc.glade:254 data/ui/webrtc.glade:322 data/ui/webrtc.glade:578
 msgid "High"
 msgstr "Alto"
 
-#: data/ui/webrtc.glade:270
+#: data/ui/webrtc.glade:271
 msgid "Echo Canceller"
 msgstr "Rimozione Eco"
 
-#: data/ui/webrtc.glade:322
+#: data/ui/webrtc.glade:323
 msgid "Very High"
 msgstr "Molto Alto"
 
-#: data/ui/webrtc.glade:339
+#: data/ui/webrtc.glade:340
 msgid "Noise Suppressor"
 msgstr "Soppressore Rumore"
 
-#: data/ui/webrtc.glade:389
+#: data/ui/webrtc.glade:390
 msgid "Adaptive Digital"
 msgstr "Digitale Adattivo"
 
-#: data/ui/webrtc.glade:390
+#: data/ui/webrtc.glade:391
 msgid "Fixed Digital"
 msgstr "Digitale Fisso"
 
-#: data/ui/webrtc.glade:407
+#: data/ui/webrtc.glade:408
 msgid "Gain Controller"
 msgstr "Controllo Guadagno"
 
-#: data/ui/webrtc.glade:445
+#: data/ui/webrtc.glade:446
 msgid "Target Level"
 msgstr "Livello Soglia"
 
-#: data/ui/webrtc.glade:475
+#: data/ui/webrtc.glade:476
 msgid "Maximum Gain"
 msgstr "Guadagno Massimo"
 
-#: data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:549
 msgid "Detection Likelihood"
 msgstr "Probabilità Rilevamento"
 
-#: data/ui/webrtc.glade:561
+#: data/ui/webrtc.glade:562
 msgid "Frame Size"
 msgstr "Dimensione frame"
 
-#: data/ui/webrtc.glade:574
+#: data/ui/webrtc.glade:575
 msgid "Very Low"
 msgstr "Molto piccolo"
 
-#: data/ui/webrtc.glade:611
+#: data/ui/webrtc.glade:612
 msgid "Voice Detector"
 msgstr "Rilevatore Voce"
 
@@ -1705,9 +1717,3 @@ msgstr "Generale"
 #: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
-
-#~ msgid "Scale"
-#~ msgstr "Scala"
-
-#~ msgid "Exponent"
-#~ msgstr "Esponente"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PulseEffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-22 15:29+0200\n"
+"POT-Creation-Date: 2020-08-24 16:51+0200\n"
 "PO-Revision-Date: 2018-06-21 21:34+0200\n"
 "Last-Translator: Piotr Komur, pkomur@gmail.com\n"
 "Language-Team: \n"
@@ -88,8 +88,8 @@ msgid "Input Limiter"
 msgstr "Limiter wejścia"
 
 #: data/com.github.wwmm.pulseeffects.appdata.xml.in:52
-#: data/ui/compressor.glade:111 data/ui/compressor.glade:494
-#: data/ui/webrtc.glade:509
+#: data/ui/compressor.glade:112 data/ui/compressor.glade:494
+#: data/ui/webrtc.glade:510
 msgid "Compressor"
 msgstr "Kompresor"
 
@@ -124,12 +124,12 @@ msgid "Format"
 msgstr "Format"
 
 # Próbkowanie?
-#: data/ui/app_info.glade:75 data/ui/convolver.glade:283
+#: data/ui/app_info.glade:75 data/ui/convolver.glade:284
 msgid "Rate"
 msgstr "Częstotliwość"
 
 #: data/ui/app_info.glade:102 data/ui/pulse_info.glade:238
-#: data/ui/stereo_tools.glade:653
+#: data/ui/stereo_tools.glade:654
 msgid "Channels"
 msgstr "Kanały"
 
@@ -166,7 +166,7 @@ msgstr "Sygnały testowe"
 msgid "Global Bypass"
 msgstr ""
 
-#: data/ui/application.glade:170 data/ui/equalizer.glade:277
+#: data/ui/application.glade:170 data/ui/equalizer.glade:278
 #: data/ui/general_settings.glade:107
 msgid "Settings"
 msgstr "Ustawienia"
@@ -175,174 +175,173 @@ msgstr "Ustawienia"
 msgid "Help"
 msgstr ""
 
-#: data/ui/application.glade:215 data/ui/crossfeed.glade:49
-#: data/ui/equalizer.glade:333 data/ui/filter.glade:230
-#: data/ui/reverb.glade:310 src/presets_menu_ui.cpp:113
+#: data/ui/application.glade:215 data/ui/crossfeed.glade:48
+#: data/ui/equalizer.glade:334 data/ui/filter.glade:231
+#: data/ui/reverb.glade:311 src/presets_menu_ui.cpp:113
 #: src/presets_menu_ui.cpp:258 src/presets_menu_ui.cpp:275
 msgid "Presets"
 msgstr "Profile"
 
-#: data/ui/autogain.glade:91
+#: data/ui/autogain.glade:92
 #, fuzzy
 msgid "Auto Gain"
 msgstr "Wzmocnienie wej."
 
-#: data/ui/autogain.glade:171
+#: data/ui/autogain.glade:172
 #, fuzzy
 msgid "Reset History"
 msgstr "Resetuj jakość"
 
-#: data/ui/autogain.glade:183
+#: data/ui/autogain.glade:184
 #, fuzzy
 msgid "Detect Silence"
 msgstr "Wykrycie"
 
-#: data/ui/autogain.glade:195
+#: data/ui/autogain.glade:196
 msgid "Use Geometric Mean"
 msgstr ""
 
-#: data/ui/autogain.glade:233
+#: data/ui/autogain.glade:234
 msgid "Target"
 msgstr "Cel"
 
-#: data/ui/autogain.glade:283 data/ui/autogain.glade:627
+#: data/ui/autogain.glade:286 data/ui/autogain.glade:631
 msgid "Momentary"
 msgstr ""
 
-#: data/ui/autogain.glade:298 data/ui/autogain.glade:640
+#: data/ui/autogain.glade:301 data/ui/autogain.glade:644
 msgid "Short Term"
 msgstr ""
 
-#: data/ui/autogain.glade:313 data/ui/autogain.glade:653
+#: data/ui/autogain.glade:316 data/ui/autogain.glade:657
 msgid "Integrated"
 msgstr ""
 
-#: data/ui/autogain.glade:388
+#: data/ui/autogain.glade:394
 #, fuzzy
 msgid "Weights"
 msgstr "Wysokość"
 
-#: data/ui/autogain.glade:428 data/ui/autogain.glade:917
-#: data/ui/bass_enhancer.glade:504 data/ui/compressor.glade:974
-#: data/ui/convolver.glade:504 data/ui/crossfeed.glade:200
-#: data/ui/crystalizer.glade:255 data/ui/deesser.glade:593
-#: data/ui/delay.glade:236 data/ui/equalizer.glade:543
-#: data/ui/exciter.glade:510 data/ui/filter.glade:396 data/ui/gate.glade:558
-#: data/ui/limiter.glade:483 data/ui/loudness.glade:259
-#: data/ui/loudness.glade:338 data/ui/maximizer.glade:265
-#: data/ui/multiband_compressor.glade:2000 data/ui/multiband_gate.glade:2153
-#: data/ui/pitch.glade:362 data/ui/presets_menu.glade:255
-#: data/ui/reverb.glade:658 data/ui/stereo_tools.glade:323
-#: data/ui/stereo_tools.glade:829 data/ui/webrtc.glade:650
+#: data/ui/autogain.glade:434 data/ui/autogain.glade:921
+#: data/ui/bass_enhancer.glade:506 data/ui/compressor.glade:977
+#: data/ui/convolver.glade:505 data/ui/crossfeed.glade:199
+#: data/ui/crystalizer.glade:205 data/ui/deesser.glade:594
+#: data/ui/delay.glade:237 data/ui/equalizer.glade:544
+#: data/ui/exciter.glade:510 data/ui/filter.glade:397 data/ui/gate.glade:611
+#: data/ui/limiter.glade:485 data/ui/loudness.glade:299
+#: data/ui/loudness.glade:380 data/ui/maximizer.glade:268
+#: data/ui/multiband_compressor.glade:2006 data/ui/multiband_gate.glade:2163
+#: data/ui/pitch.glade:363 data/ui/presets_menu.glade:255
+#: data/ui/reverb.glade:661 data/ui/stereo_tools.glade:322
+#: data/ui/stereo_tools.glade:830 data/ui/webrtc.glade:651
 msgid "Input"
 msgstr "Wejście"
 
-#: data/ui/autogain.glade:443 data/ui/autogain.glade:862
-#: data/ui/bass_enhancer.glade:536 data/ui/compressor.glade:988
-#: data/ui/convolver.glade:519 data/ui/crossfeed.glade:214
-#: data/ui/crystalizer.glade:270 data/ui/deesser.glade:607
-#: data/ui/delay.glade:250 data/ui/equalizer.glade:557
-#: data/ui/exciter.glade:542 data/ui/filter.glade:411 data/ui/gate.glade:572
-#: data/ui/limiter.glade:626 data/ui/loudness.glade:292
-#: data/ui/loudness.glade:352 data/ui/maximizer.glade:279
+#: data/ui/autogain.glade:449 data/ui/autogain.glade:866
+#: data/ui/bass_enhancer.glade:537 data/ui/compressor.glade:991
+#: data/ui/convolver.glade:520 data/ui/crossfeed.glade:213
+#: data/ui/crystalizer.glade:220 data/ui/deesser.glade:608
+#: data/ui/delay.glade:251 data/ui/equalizer.glade:558
+#: data/ui/exciter.glade:541 data/ui/filter.glade:412 data/ui/gate.glade:625
+#: data/ui/limiter.glade:628 data/ui/loudness.glade:333
+#: data/ui/loudness.glade:394 data/ui/maximizer.glade:282
 #: data/ui/multiband_compressor.glade:794
-#: data/ui/multiband_compressor.glade:1171
-#: data/ui/multiband_compressor.glade:1549
-#: data/ui/multiband_compressor.glade:1927
-#: data/ui/multiband_compressor.glade:2015 data/ui/multiband_gate.glade:851
-#: data/ui/multiband_gate.glade:1260 data/ui/multiband_gate.glade:1670
-#: data/ui/multiband_gate.glade:2080 data/ui/multiband_gate.glade:2168
-#: data/ui/pitch.glade:376 data/ui/presets_menu.glade:146
-#: data/ui/reverb.glade:673 data/ui/stereo_tools.glade:800
-#: data/ui/stereo_tools.glade:843 data/ui/webrtc.glade:664
+#: data/ui/multiband_compressor.glade:1173
+#: data/ui/multiband_compressor.glade:1553
+#: data/ui/multiband_compressor.glade:1933
+#: data/ui/multiband_compressor.glade:2021 data/ui/multiband_gate.glade:852
+#: data/ui/multiband_gate.glade:1264 data/ui/multiband_gate.glade:1677
+#: data/ui/multiband_gate.glade:2090 data/ui/multiband_gate.glade:2178
+#: data/ui/pitch.glade:377 data/ui/presets_menu.glade:146
+#: data/ui/reverb.glade:676 data/ui/stereo_tools.glade:801
+#: data/ui/stereo_tools.glade:844 data/ui/webrtc.glade:665
 msgid "Output"
 msgstr "Wyjście"
 
-#: data/ui/autogain.glade:744
+#: data/ui/autogain.glade:748
 msgid "Relative"
 msgstr ""
 
-#: data/ui/autogain.glade:757 data/ui/compressor.glade:1154
-#: data/ui/deesser.glade:321
+#: data/ui/autogain.glade:761 data/ui/compressor.glade:1157
 msgid "Gain"
 msgstr "Wzmocnienie"
 
-#: data/ui/autogain.glade:823
+#: data/ui/autogain.glade:827
 msgid "Loudness"
 msgstr ""
 
-#: data/ui/autogain.glade:876
+#: data/ui/autogain.glade:880
 msgid "Range"
 msgstr ""
 
-#: data/ui/autogain.glade:945 data/ui/bass_enhancer.glade:655
-#: data/ui/compressor.glade:1299 data/ui/convolver.glade:703
-#: data/ui/crossfeed.glade:395 data/ui/crystalizer.glade:566
-#: data/ui/deesser.glade:898 data/ui/delay.glade:434
-#: data/ui/equalizer.glade:743 data/ui/equalizer_band.glade:182
-#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:661
-#: data/ui/filter.glade:595 data/ui/general_settings.glade:116
-#: data/ui/gate.glade:809 data/ui/limiter.glade:733 data/ui/loudness.glade:573
-#: data/ui/maximizer.glade:516 data/ui/multiband_compressor.glade:2199
-#: data/ui/multiband_gate.glade:2352 data/ui/pitch.glade:560
-#: data/ui/reverb.glade:857 data/ui/stereo_tools.glade:1029
-#: data/ui/webrtc.glade:814
+#: data/ui/autogain.glade:949 data/ui/bass_enhancer.glade:650
+#: data/ui/compressor.glade:1300 data/ui/convolver.glade:702
+#: data/ui/crossfeed.glade:394 data/ui/crystalizer.glade:514
+#: data/ui/deesser.glade:899 data/ui/delay.glade:433
+#: data/ui/equalizer.glade:744 data/ui/equalizer_band.glade:182
+#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:654
+#: data/ui/filter.glade:594 data/ui/general_settings.glade:116
+#: data/ui/gate.glade:862 data/ui/limiter.glade:735 data/ui/loudness.glade:615
+#: data/ui/maximizer.glade:519 data/ui/multiband_compressor.glade:2203
+#: data/ui/multiband_gate.glade:2360 data/ui/pitch.glade:559
+#: data/ui/reverb.glade:858 data/ui/stereo_tools.glade:1028
+#: data/ui/webrtc.glade:815
 msgid "Reset"
 msgstr "Zresetuj"
 
-#: data/ui/autogain.glade:969
+#: data/ui/autogain.glade:973
 msgid "Based on"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:117
+#: data/ui/bass_enhancer.glade:118
 msgid "Bass Enhancer"
 msgstr "Wzmacniacz basów"
 
-#: data/ui/bass_enhancer.glade:169 data/ui/compressor.glade:506
-#: data/ui/deesser.glade:188 data/ui/exciter.glade:171
+#: data/ui/bass_enhancer.glade:170 data/ui/compressor.glade:506
+#: data/ui/deesser.glade:185 data/ui/exciter.glade:170
 msgid "Listen"
 msgstr "Słuchaj"
 
-#: data/ui/bass_enhancer.glade:210 data/ui/exciter.glade:213
+#: data/ui/bass_enhancer.glade:211 data/ui/exciter.glade:212
 msgid "3rd"
 msgstr "Trzecie"
 
-#: data/ui/bass_enhancer.glade:222 data/ui/exciter.glade:225
+#: data/ui/bass_enhancer.glade:223 data/ui/exciter.glade:224
 msgid "2nd"
 msgstr "Drugie"
 
 # Wpleć/wmieszaj/dodaj
-#: data/ui/bass_enhancer.glade:234 data/ui/exciter.glade:237
+#: data/ui/bass_enhancer.glade:235 data/ui/exciter.glade:236
 msgid "Blend Harmonics"
 msgstr "Wprowadź harmoniczne"
 
-#: data/ui/bass_enhancer.glade:266 data/ui/exciter.glade:271
-#: data/ui/reverb.glade:407
+#: data/ui/bass_enhancer.glade:267 data/ui/exciter.glade:270
+#: data/ui/reverb.glade:408
 msgid "Amount"
 msgstr "Ilość"
 
-#: data/ui/bass_enhancer.glade:278 data/ui/bass_enhancer.glade:411
-#: data/ui/exciter.glade:284 data/ui/exciter.glade:417
+#: data/ui/bass_enhancer.glade:279 data/ui/bass_enhancer.glade:413
+#: data/ui/exciter.glade:283 data/ui/exciter.glade:417
 msgid "Harmonics"
 msgstr "Harmoniczne"
 
-#: data/ui/bass_enhancer.glade:290 data/ui/exciter.glade:297
+#: data/ui/bass_enhancer.glade:291 data/ui/exciter.glade:296
 msgid "Scope"
 msgstr "Zakres"
 
-#: data/ui/bass_enhancer.glade:379
+#: data/ui/bass_enhancer.glade:381
 msgid "Floor"
 msgstr "Podłoga"
 
-#: data/ui/bass_enhancer.glade:679 data/ui/compressor.glade:1323
-#: data/ui/crossfeed.glade:419 data/ui/deesser.glade:922
-#: data/ui/delay.glade:458 data/ui/equalizer.glade:767
-#: data/ui/exciter.glade:685 data/ui/filter.glade:619 data/ui/gate.glade:833
-#: data/ui/limiter.glade:757 data/ui/loudness.glade:542
-#: data/ui/maximizer.glade:540 data/ui/multiband_compressor.glade:2223
-#: data/ui/multiband_gate.glade:2376 data/ui/pitch.glade:584
-#: data/ui/reverb.glade:881 data/ui/stereo_tools.glade:1053
-#: data/ui/webrtc.glade:838
+#: data/ui/bass_enhancer.glade:674 data/ui/compressor.glade:1324
+#: data/ui/crossfeed.glade:418 data/ui/deesser.glade:923
+#: data/ui/delay.glade:457 data/ui/equalizer.glade:768
+#: data/ui/exciter.glade:678 data/ui/filter.glade:618 data/ui/gate.glade:886
+#: data/ui/limiter.glade:759 data/ui/loudness.glade:584
+#: data/ui/maximizer.glade:543 data/ui/multiband_compressor.glade:2227
+#: data/ui/multiband_gate.glade:2384 data/ui/pitch.glade:583
+#: data/ui/reverb.glade:882 data/ui/stereo_tools.glade:1052
+#: data/ui/webrtc.glade:839
 msgid "Provided by"
 msgstr ""
 
@@ -377,141 +376,141 @@ msgstr "Efekty wyjściowe"
 msgid "Show Blocklisted Apps in Main Tab"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:32 data/ui/equalizer_band.glade:152
-#: data/ui/filter.glade:280
+#: data/ui/calibration_signals.glade:30 data/ui/equalizer_band.glade:152
+#: data/ui/filter.glade:281
 msgid "Frequency"
 msgstr "Częstotliwość"
 
-#: data/ui/calibration_signals.glade:64
+#: data/ui/calibration_signals.glade:62
 msgid "Volume"
 msgstr "Głośność"
 
-#: data/ui/calibration_signals.glade:108
+#: data/ui/calibration_signals.glade:106
 msgid "Sine"
 msgstr "Sinus"
 
-#: data/ui/calibration_signals.glade:109
+#: data/ui/calibration_signals.glade:107
 msgid "Square"
 msgstr "Prostokąt"
 
-#: data/ui/calibration_signals.glade:110
+#: data/ui/calibration_signals.glade:108
 msgid "Saw"
 msgstr "Piła"
 
-#: data/ui/calibration_signals.glade:111
+#: data/ui/calibration_signals.glade:109
 msgid "Triangle"
 msgstr "Trójkąt"
 
-#: data/ui/calibration_signals.glade:112
+#: data/ui/calibration_signals.glade:110
 msgid "Silence"
 msgstr "Cisza"
 
-#: data/ui/calibration_signals.glade:113
+#: data/ui/calibration_signals.glade:111
 msgid "White Noise"
 msgstr "Biały szum"
 
-#: data/ui/calibration_signals.glade:114
+#: data/ui/calibration_signals.glade:112
 msgid "Pink Noise"
 msgstr "Różowy szum"
 
-#: data/ui/calibration_signals.glade:115
+#: data/ui/calibration_signals.glade:113
 msgid "Sine Table"
 msgstr "Sinus tabl."
 
 # tyknięcia, kliknięcia
-#: data/ui/calibration_signals.glade:116
+#: data/ui/calibration_signals.glade:114
 msgid "Ticks"
 msgstr "Działki"
 
-#: data/ui/calibration_signals.glade:117
+#: data/ui/calibration_signals.glade:115
 msgid "Gaussian Noise"
 msgstr "Szum Gaussa"
 
-#: data/ui/calibration_signals.glade:118
+#: data/ui/calibration_signals.glade:116
 msgid "Red Noise"
 msgstr "Szum czerwony"
 
-#: data/ui/calibration_signals.glade:119
+#: data/ui/calibration_signals.glade:117
 msgid "Blue Noise"
 msgstr "Szum niebieski"
 
-#: data/ui/calibration_signals.glade:120
+#: data/ui/calibration_signals.glade:118
 msgid "Violet Noise"
 msgstr " Szum fioletowy"
 
-#: data/ui/calibration_mic.glade:29
+#: data/ui/calibration_mic.glade:28
 msgid "Window"
 msgstr "Okno"
 
-#: data/ui/calibration_mic.glade:70
+#: data/ui/calibration_mic.glade:69
 msgid "Measure Noise"
 msgstr "Mierz szum"
 
-#: data/ui/calibration_mic.glade:99
+#: data/ui/calibration_mic.glade:98
 msgid "Subtract Noise"
 msgstr "Odejmij szum"
 
-#: data/ui/compressor.glade:292 data/ui/deesser.glade:483
-#: data/ui/gate.glade:370 data/ui/maximizer.glade:152
-#: data/ui/multiband_compressor.glade:609
+#: data/ui/compressor.glade:290 data/ui/deesser.glade:482
+#: data/ui/gate.glade:413 data/ui/maximizer.glade:153
+#: data/ui/multiband_compressor.glade:607
 #: data/ui/multiband_compressor.glade:983
-#: data/ui/multiband_compressor.glade:1361
-#: data/ui/multiband_compressor.glade:1739 data/ui/multiband_gate.glade:633
-#: data/ui/multiband_gate.glade:1040 data/ui/multiband_gate.glade:1450
-#: data/ui/multiband_gate.glade:1860
+#: data/ui/multiband_compressor.glade:1363
+#: data/ui/multiband_compressor.glade:1743 data/ui/multiband_gate.glade:631
+#: data/ui/multiband_gate.glade:1041 data/ui/multiband_gate.glade:1454
+#: data/ui/multiband_gate.glade:1867
 msgid "Threshold"
 msgstr "Próg"
 
-#: data/ui/compressor.glade:325 data/ui/deesser.glade:516
-#: data/ui/gate.glade:403 data/ui/multiband_compressor.glade:642
-#: data/ui/multiband_compressor.glade:1017
-#: data/ui/multiband_compressor.glade:1395
-#: data/ui/multiband_compressor.glade:1773 data/ui/multiband_gate.glade:666
-#: data/ui/multiband_gate.glade:1074 data/ui/multiband_gate.glade:1484
-#: data/ui/multiband_gate.glade:1894
+#: data/ui/compressor.glade:324 data/ui/deesser.glade:516
+#: data/ui/gate.glade:449 data/ui/multiband_compressor.glade:641
+#: data/ui/multiband_compressor.glade:1018
+#: data/ui/multiband_compressor.glade:1398
+#: data/ui/multiband_compressor.glade:1778 data/ui/multiband_gate.glade:665
+#: data/ui/multiband_gate.glade:1076 data/ui/multiband_gate.glade:1489
+#: data/ui/multiband_gate.glade:1902
 msgid "Ratio"
 msgstr "Stosunek"
 
-#: data/ui/compressor.glade:357 data/ui/gate.glade:435
-#: data/ui/multiband_compressor.glade:674
-#: data/ui/multiband_compressor.glade:1050
-#: data/ui/multiband_compressor.glade:1428
-#: data/ui/multiband_compressor.glade:1806 data/ui/multiband_gate.glade:698
-#: data/ui/multiband_gate.glade:1107 data/ui/multiband_gate.glade:1517
-#: data/ui/multiband_gate.glade:1927
+#: data/ui/compressor.glade:356 data/ui/gate.glade:483
+#: data/ui/multiband_compressor.glade:673
+#: data/ui/multiband_compressor.glade:1051
+#: data/ui/multiband_compressor.glade:1431
+#: data/ui/multiband_compressor.glade:1811 data/ui/multiband_gate.glade:697
+#: data/ui/multiband_gate.glade:1109 data/ui/multiband_gate.glade:1522
+#: data/ui/multiband_gate.glade:1935
 msgid "Knee"
 msgstr "Kolano"
 
 # Uzupełnienie wzmocnienia/ nadrobienie wzmocnienia, wypełnienie
 # czasem po prostu Output, więc Wyjście albo Wzmocnienie
-#: data/ui/compressor.glade:391 data/ui/deesser.glade:547
-#: data/ui/gate.glade:469 data/ui/multiband_compressor.glade:708
-#: data/ui/multiband_compressor.glade:1085
-#: data/ui/multiband_compressor.glade:1463
-#: data/ui/multiband_compressor.glade:1841 data/ui/multiband_gate.glade:732
-#: data/ui/multiband_gate.glade:1142 data/ui/multiband_gate.glade:1552
-#: data/ui/multiband_gate.glade:1962
+#: data/ui/compressor.glade:390 data/ui/deesser.glade:547
+#: data/ui/gate.glade:519 data/ui/multiband_compressor.glade:707
+#: data/ui/multiband_compressor.glade:1086
+#: data/ui/multiband_compressor.glade:1466
+#: data/ui/multiband_compressor.glade:1846 data/ui/multiband_gate.glade:731
+#: data/ui/multiband_gate.glade:1144 data/ui/multiband_gate.glade:1557
+#: data/ui/multiband_gate.glade:1970
 msgid "Makeup"
 msgstr "Wzmocnienie"
 
-#: data/ui/compressor.glade:425 data/ui/gate.glade:336
-#: data/ui/limiter.glade:310 data/ui/maximizer.glade:178
-#: data/ui/multiband_compressor.glade:575
+#: data/ui/compressor.glade:425 data/ui/gate.glade:377
+#: data/ui/limiter.glade:311 data/ui/maximizer.glade:179
+#: data/ui/multiband_compressor.glade:573
 #: data/ui/multiband_compressor.glade:948
-#: data/ui/multiband_compressor.glade:1326
-#: data/ui/multiband_compressor.glade:1704 data/ui/multiband_gate.glade:599
-#: data/ui/multiband_gate.glade:1005 data/ui/multiband_gate.glade:1415
-#: data/ui/multiband_gate.glade:1825
+#: data/ui/multiband_compressor.glade:1328
+#: data/ui/multiband_compressor.glade:1708 data/ui/multiband_gate.glade:597
+#: data/ui/multiband_gate.glade:1006 data/ui/multiband_gate.glade:1419
+#: data/ui/multiband_gate.glade:1832
 msgid "Release"
 msgstr "Wyzwolenie"
 
-#: data/ui/compressor.glade:438 data/ui/gate.glade:302
-#: data/ui/multiband_compressor.glade:541
+#: data/ui/compressor.glade:438 data/ui/gate.glade:341
+#: data/ui/multiband_compressor.glade:539
 #: data/ui/multiband_compressor.glade:913
-#: data/ui/multiband_compressor.glade:1291
-#: data/ui/multiband_compressor.glade:1669 data/ui/multiband_gate.glade:565
-#: data/ui/multiband_gate.glade:970 data/ui/multiband_gate.glade:1380
-#: data/ui/multiband_gate.glade:1790
+#: data/ui/multiband_compressor.glade:1293
+#: data/ui/multiband_compressor.glade:1673 data/ui/multiband_gate.glade:563
+#: data/ui/multiband_gate.glade:971 data/ui/multiband_gate.glade:1384
+#: data/ui/multiband_gate.glade:1797
 msgid "Attack"
 msgstr "Atak"
 
@@ -529,222 +528,221 @@ msgstr ""
 msgid "Compression Mode"
 msgstr "Kompresor"
 
-#: data/ui/compressor.glade:551
+#: data/ui/compressor.glade:552
 #, fuzzy
 msgid "Pre-amplification"
 msgstr "Programy"
 
-#: data/ui/compressor.glade:585
+#: data/ui/compressor.glade:586
 msgid "Reactivity"
 msgstr "Reaktywność"
 
 # Podgląd, albo "patrz w przód", zapas
-#: data/ui/compressor.glade:619 data/ui/limiter.glade:323
+#: data/ui/compressor.glade:620 data/ui/limiter.glade:324
 msgid "Lookahead"
 msgstr "Lookahead"
 
-#: data/ui/compressor.glade:632
+#: data/ui/compressor.glade:633
 msgid "Feed-forward"
 msgstr ""
 
 # Wejście?
-#: data/ui/compressor.glade:633
+#: data/ui/compressor.glade:634
 #, fuzzy
 msgid "Feed-back"
 msgstr "Feed"
 
-#: data/ui/compressor.glade:647 data/ui/equalizer_band.glade:48
+#: data/ui/compressor.glade:648 data/ui/equalizer_band.glade:48
 msgid "Type"
 msgstr ""
 
-#: data/ui/compressor.glade:661 data/ui/deesser.glade:244
-#: data/ui/deesser.glade:354 data/ui/gate.glade:257
-#: data/ui/multiband_compressor.glade:514
+#: data/ui/compressor.glade:662 data/ui/deesser.glade:241
+#: data/ui/gate.glade:213 data/ui/multiband_compressor.glade:512
 #: data/ui/multiband_compressor.glade:886
-#: data/ui/multiband_compressor.glade:1264
-#: data/ui/multiband_compressor.glade:1642 data/ui/multiband_gate.glade:538
-#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1353
-#: data/ui/multiband_gate.glade:1763
+#: data/ui/multiband_compressor.glade:1266
+#: data/ui/multiband_compressor.glade:1646 data/ui/multiband_gate.glade:536
+#: data/ui/multiband_gate.glade:944 data/ui/multiband_gate.glade:1357
+#: data/ui/multiband_gate.glade:1770
 msgid "Peak"
 msgstr "Szczyt"
 
-#: data/ui/compressor.glade:662 data/ui/deesser.glade:243
-#: data/ui/gate.glade:256 data/ui/multiband_compressor.glade:513
+#: data/ui/compressor.glade:663 data/ui/deesser.glade:240
+#: data/ui/gate.glade:212 data/ui/multiband_compressor.glade:511
 #: data/ui/multiband_compressor.glade:885
-#: data/ui/multiband_compressor.glade:1263
-#: data/ui/multiband_compressor.glade:1641 data/ui/multiband_gate.glade:537
-#: data/ui/multiband_gate.glade:942 data/ui/multiband_gate.glade:1352
-#: data/ui/multiband_gate.glade:1762
+#: data/ui/multiband_compressor.glade:1265
+#: data/ui/multiband_compressor.glade:1645 data/ui/multiband_gate.glade:535
+#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1356
+#: data/ui/multiband_gate.glade:1769
 msgid "RMS"
 msgstr "RMS"
 
-#: data/ui/compressor.glade:663
+#: data/ui/compressor.glade:664
 #, fuzzy
 msgid "Low-Pass"
 msgstr "Dolnoprzepustowy"
 
-#: data/ui/compressor.glade:664
+#: data/ui/compressor.glade:665
 msgid "Uniform"
 msgstr "Równomierny"
 
-#: data/ui/compressor.glade:678 data/ui/deesser.glade:230
-#: data/ui/equalizer.glade:224 data/ui/equalizer_band.glade:79
-#: data/ui/multiband_compressor.glade:324 data/ui/multiband_gate.glade:348
-#: data/ui/stereo_tools.glade:485 data/ui/webrtc.glade:376
+#: data/ui/compressor.glade:679 data/ui/deesser.glade:227
+#: data/ui/equalizer.glade:225 data/ui/equalizer_band.glade:79
+#: data/ui/multiband_compressor.glade:322 data/ui/multiband_gate.glade:346
+#: data/ui/stereo_tools.glade:486 data/ui/webrtc.glade:377
 msgid "Mode"
 msgstr "Tryb"
 
-#: data/ui/compressor.glade:692
+#: data/ui/compressor.glade:693
 #, fuzzy
 msgid "Middle"
 msgstr "Środek"
 
-#: data/ui/compressor.glade:693
+#: data/ui/compressor.glade:694
 msgid "Side"
 msgstr "Strona"
 
-#: data/ui/compressor.glade:694 data/ui/delay.glade:157
-#: data/ui/equalizer.glade:474 data/ui/stereo_tools.glade:548
+#: data/ui/compressor.glade:695 data/ui/delay.glade:158
+#: data/ui/equalizer.glade:475 data/ui/stereo_tools.glade:549
 msgid "Left"
 msgstr "Lewy"
 
-#: data/ui/compressor.glade:695 data/ui/delay.glade:189
-#: data/ui/equalizer.glade:515 data/ui/stereo_tools.glade:620
+#: data/ui/compressor.glade:696 data/ui/delay.glade:190
+#: data/ui/equalizer.glade:516 data/ui/stereo_tools.glade:621
 msgid "Right"
 msgstr "Prawy"
 
-#: data/ui/compressor.glade:709
+#: data/ui/compressor.glade:710
 msgid "Source"
 msgstr "Źródło"
 
-#: data/ui/compressor.glade:725 data/ui/compressor.glade:1167
+#: data/ui/compressor.glade:726 data/ui/compressor.glade:1170
 msgid "Sidechain"
 msgstr "Łańcuch boczny"
 
-#: data/ui/compressor.glade:821
+#: data/ui/compressor.glade:824
 msgid "Relative Release Threshold"
 msgstr ""
 
-#: data/ui/compressor.glade:832
+#: data/ui/compressor.glade:835
 #, fuzzy
 msgid "Boost Threshold"
 msgstr "Próg"
 
-#: data/ui/compressor.glade:843
+#: data/ui/compressor.glade:846
 #, fuzzy
 msgid "High-pass Frequency"
 msgstr "Tłumienie wysokich tonów"
 
-#: data/ui/compressor.glade:854
+#: data/ui/compressor.glade:857
 #, fuzzy
 msgid "Low-pass Frequency"
 msgstr "Przelicz częstotliwości"
 
-#: data/ui/compressor.glade:865
+#: data/ui/compressor.glade:868
 #, fuzzy
 msgid "High-pass Filter Mode"
 msgstr "Filtr górnoprzepustowy"
 
-#: data/ui/compressor.glade:876
+#: data/ui/compressor.glade:879
 msgid "Low-pass Filter Mode"
 msgstr ""
 
-#: data/ui/compressor.glade:889 data/ui/compressor.glade:906
+#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
 #: data/ui/equalizer_band.glade:60
 msgid "Off"
 msgstr ""
 
-#: data/ui/compressor.glade:890 data/ui/compressor.glade:907
+#: data/ui/compressor.glade:893 data/ui/compressor.glade:910
 #, fuzzy
 msgid "12 dB/oct"
 msgstr "12dB/okt dolnoprzepustowy"
 
-#: data/ui/compressor.glade:891 data/ui/compressor.glade:908
+#: data/ui/compressor.glade:894 data/ui/compressor.glade:911
 #, fuzzy
 msgid "24 dB/oct"
 msgstr "24dB/okt dolnoprzepustowy"
 
-#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
+#: data/ui/compressor.glade:895 data/ui/compressor.glade:912
 #, fuzzy
 msgid "36 dB/oct"
 msgstr "36dB/okt dolnoprzepustowy"
 
-#: data/ui/compressor.glade:932
+#: data/ui/compressor.glade:935
 #, fuzzy
 msgid "Advanced"
 msgstr "Ustawienia zaawansowane"
 
-#: data/ui/compressor.glade:1243
+#: data/ui/compressor.glade:1244
 msgid "Curve"
 msgstr ""
 
-#: data/ui/convolver.glade:91
+#: data/ui/convolver.glade:92
 msgid "Convolver"
 msgstr ""
 
-#: data/ui/convolver.glade:125
+#: data/ui/convolver.glade:126
 #, fuzzy
 msgid "Import Impulse"
 msgstr "Importuj profile"
 
-#: data/ui/convolver.glade:129
+#: data/ui/convolver.glade:130
 msgid "Import Impulse Response File"
 msgstr ""
 
-#: data/ui/convolver.glade:247
+#: data/ui/convolver.glade:248
 msgid "L"
 msgstr "L"
 
-#: data/ui/convolver.glade:261
+#: data/ui/convolver.glade:262
 msgid "R"
 msgstr "P"
 
-#: data/ui/convolver.glade:324
+#: data/ui/convolver.glade:325
 #, fuzzy
 msgid "Duration"
 msgstr "Kalibracja"
 
-#: data/ui/convolver.glade:335
+#: data/ui/convolver.glade:336
 #, fuzzy
 msgid "Samples"
 msgstr "Resampler"
 
-#: data/ui/convolver.glade:367 src/convolver_ui.cpp:283
+#: data/ui/convolver.glade:368 src/convolver_ui.cpp:283
 #, fuzzy
 msgid "Impulse Response"
 msgstr "Płaska odpowiedź"
 
-#: data/ui/convolver.glade:389
+#: data/ui/convolver.glade:390
 msgid "Select the impulse Response File"
 msgstr ""
 
-#: data/ui/convolver.glade:409 src/spectrum_settings_ui.cpp:176
+#: data/ui/convolver.glade:410 src/spectrum_settings_ui.cpp:176
 msgid "Spectrum"
 msgstr "Widmo"
 
-#: data/ui/convolver.glade:450
+#: data/ui/convolver.glade:451
 #, fuzzy
 msgid "Stereo Width"
 msgstr "Powiązanie stereo"
 
-#: data/ui/crossfeed.glade:63
+#: data/ui/crossfeed.glade:62
 msgid "Jmeier"
 msgstr "Jmeier"
 
-#: data/ui/crossfeed.glade:76 data/ui/filter.glade:183 data/ui/reverb.glade:259
+#: data/ui/crossfeed.glade:75 data/ui/filter.glade:184 data/ui/reverb.glade:260
 msgid "Default"
 msgstr "Domyślne"
 
-#: data/ui/crossfeed.glade:89
+#: data/ui/crossfeed.glade:88
 msgid "Cmoy"
 msgstr "Cmoy"
 
-#: data/ui/crossfeed.glade:120
+#: data/ui/crossfeed.glade:119
 msgid "Cutoff"
 msgstr "Odcięcie"
 
 # Wejście?
-#: data/ui/crossfeed.glade:153
+#: data/ui/crossfeed.glade:152
 msgid "Feed"
 msgstr "Feed"
 
@@ -752,119 +750,136 @@ msgstr "Feed"
 msgid "Crossfeed"
 msgstr "Crossfeed"
 
-#: data/ui/crystalizer.glade:115
+#: data/ui/crystalizer.glade:92
 #, fuzzy
 msgid "Crystalizer"
 msgstr "Resetuj korektor"
 
-#: data/ui/crystalizer.glade:187
+#: data/ui/crystalizer.glade:137
 #, fuzzy
 msgid "Aggressive Mode"
 msgstr "Kompresor"
 
-#: data/ui/crystalizer.glade:447
+#: data/ui/crystalizer.glade:395
 msgid "Loudness Range"
 msgstr ""
 
-#: data/ui/crystalizer.glade:466
+#: data/ui/crystalizer.glade:414
 msgid "Before"
 msgstr ""
 
-#: data/ui/crystalizer.glade:479
+#: data/ui/crystalizer.glade:427
 msgid "After"
 msgstr ""
 
 #: data/ui/crystalizer_band.glade:27 data/ui/equalizer_band.glade:313
-#: data/ui/stereo_tools.glade:574 data/ui/stereo_tools.glade:633
+#: data/ui/stereo_tools.glade:575 data/ui/stereo_tools.glade:634
 msgid "Mute"
 msgstr "Wycisz"
 
-#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:483
+#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:481
 #: data/ui/multiband_compressor.glade:855
-#: data/ui/multiband_compressor.glade:1233
-#: data/ui/multiband_compressor.glade:1611 data/ui/multiband_gate.glade:507
-#: data/ui/multiband_gate.glade:912 data/ui/multiband_gate.glade:1322
-#: data/ui/multiband_gate.glade:1732
+#: data/ui/multiband_compressor.glade:1235
+#: data/ui/multiband_compressor.glade:1615 data/ui/multiband_gate.glade:505
+#: data/ui/multiband_gate.glade:913 data/ui/multiband_gate.glade:1326
+#: data/ui/multiband_gate.glade:1739
 msgid "Bypass"
 msgstr ""
 
-#: data/ui/deesser.glade:128
+#: data/ui/deesser.glade:127
 msgid "Deesser"
 msgstr "De-Esser"
 
-#: data/ui/deesser.glade:216 data/ui/gate.glade:195
+#: data/ui/deesser.glade:213 data/ui/gate.glade:198
 msgid "Detection"
 msgstr "Wykrycie"
 
-#: data/ui/deesser.glade:258
+#: data/ui/deesser.glade:255
 msgid "Wide"
 msgstr "Szeroki"
 
-#: data/ui/deesser.glade:259 data/ui/deesser.glade:288
+#: data/ui/deesser.glade:256
 msgid "Split"
 msgstr "Podzielony"
 
-#: data/ui/deesser.glade:407
-msgid "Level"
+#: data/ui/deesser.glade:285
+#, fuzzy
+msgid "F1 Split"
+msgstr "Podzielony"
+
+#: data/ui/deesser.glade:318
+#, fuzzy
+msgid "F1 Gain"
+msgstr "Wzmocnienie"
+
+#: data/ui/deesser.glade:352
+#, fuzzy
+msgid "F2 Peak"
+msgstr "Szczyt"
+
+#: data/ui/deesser.glade:406
+#, fuzzy
+msgid "F2 Level"
 msgstr "Poziom"
 
-#: data/ui/deesser.glade:420
-msgid "Peak Q"
+#: data/ui/deesser.glade:419
+#, fuzzy
+msgid "F2 Peak Q"
 msgstr "Szczyt Q"
 
-#: data/ui/deesser.glade:452
+#: data/ui/deesser.glade:451
 msgid "Laxity"
 msgstr "Swoboda"
 
-#: data/ui/deesser.glade:778 data/ui/multiband_gate.glade:767
-#: data/ui/multiband_gate.glade:1197 data/ui/multiband_gate.glade:1607
-#: data/ui/multiband_gate.glade:2017
+#: data/ui/deesser.glade:779 data/ui/multiband_gate.glade:767
+#: data/ui/multiband_gate.glade:1201 data/ui/multiband_gate.glade:1614
+#: data/ui/multiband_gate.glade:2027
 msgid "Reduction"
 msgstr "Redukcja"
 
-#: data/ui/deesser.glade:791
+#: data/ui/deesser.glade:792
 msgid "Detected"
 msgstr "Wykryto"
 
-#: data/ui/delay.glade:91
+#: data/ui/delay.glade:92
 #, fuzzy
 msgid "Delay"
 msgstr "Przedopóźnienie"
 
-#: data/ui/equalizer.glade:44
+#: data/ui/equalizer.glade:45
 msgid "Equalizer"
 msgstr "Korektor"
 
-#: data/ui/equalizer.glade:153
+#: data/ui/equalizer.glade:154
 #, fuzzy
 msgid "Split Channels"
 msgstr "Kanały"
 
-#: data/ui/equalizer.glade:179
+#: data/ui/equalizer.glade:180
 msgid "IIR"
 msgstr ""
 
-#: data/ui/equalizer.glade:180
+#: data/ui/equalizer.glade:181
 msgid "FIR"
 msgstr ""
 
-#: data/ui/equalizer.glade:181
+#: data/ui/equalizer.glade:182
 msgid "FFT"
 msgstr ""
 
-#: data/ui/equalizer.glade:211
+#: data/ui/equalizer.glade:212
 msgid "Bands"
 msgstr "Pasma"
 
-#: data/ui/equalizer.glade:233
+#: data/ui/equalizer.glade:234
 msgid "Flat Response"
 msgstr "Płaska odpowiedź"
 
-#: data/ui/equalizer.glade:248
+#: data/ui/equalizer.glade:249
 msgid "Calculate Frequencies"
 msgstr "Przelicz częstotliwości"
 
-#: data/ui/equalizer.glade:262
+#: data/ui/equalizer.glade:263
 #, fuzzy
 msgid "Import APO Presets"
 msgstr "Importuj profile"
@@ -895,7 +910,7 @@ msgstr "Dolna Wartość"
 msgid "Notch"
 msgstr ""
 
-#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:314
+#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:315
 msgid "Resonance"
 msgstr "Rezonans"
 
@@ -939,12 +954,12 @@ msgstr "Jakość"
 msgid "Width"
 msgstr "Szerokość"
 
-#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:496
+#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:494
 #: data/ui/multiband_compressor.glade:868
-#: data/ui/multiband_compressor.glade:1246
-#: data/ui/multiband_compressor.glade:1624 data/ui/multiband_gate.glade:520
-#: data/ui/multiband_gate.glade:925 data/ui/multiband_gate.glade:1335
-#: data/ui/multiband_gate.glade:1745
+#: data/ui/multiband_compressor.glade:1248
+#: data/ui/multiband_compressor.glade:1628 data/ui/multiband_gate.glade:518
+#: data/ui/multiband_gate.glade:926 data/ui/multiband_gate.glade:1339
+#: data/ui/multiband_gate.glade:1752
 msgid "Solo"
 msgstr ""
 
@@ -952,79 +967,79 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: data/ui/exciter.glade:117
+#: data/ui/exciter.glade:118
 msgid "Exciter"
 msgstr "Exciter"
 
-#: data/ui/exciter.glade:384 data/ui/maximizer.glade:165
+#: data/ui/exciter.glade:384 data/ui/maximizer.glade:166
 msgid "Ceiling"
 msgstr "Sufit"
 
-#: data/ui/filter.glade:98
+#: data/ui/filter.glade:99
 msgid "Filter"
 msgstr "Filtr"
 
-#: data/ui/filter.glade:147
+#: data/ui/filter.glade:148
 msgid "Muted"
 msgstr "Wyciszony"
 
-#: data/ui/filter.glade:159 data/ui/reverb.glade:233
+#: data/ui/filter.glade:160 data/ui/reverb.glade:234
 msgid "Disco"
 msgstr "Disco"
 
-#: data/ui/filter.glade:171
+#: data/ui/filter.glade:172
 msgid "Distant Headphones"
 msgstr "Odległe słuchawki"
 
-#: data/ui/filter.glade:246
+#: data/ui/filter.glade:247
 msgid "12dB/oct Lowpass"
 msgstr "12dB/okt dolnoprzepustowy"
 
-#: data/ui/filter.glade:247
+#: data/ui/filter.glade:248
 msgid "24dB/oct Lowpass"
 msgstr "24dB/okt dolnoprzepustowy"
 
-#: data/ui/filter.glade:248
+#: data/ui/filter.glade:249
 msgid "36dB/oct Lowpass"
 msgstr "36dB/okt dolnoprzepustowy"
 
-#: data/ui/filter.glade:249
+#: data/ui/filter.glade:250
 msgid "12dB/oct Highpass"
 msgstr "12dB/okt górnoprzepustowy"
 
-#: data/ui/filter.glade:250
+#: data/ui/filter.glade:251
 msgid "24dB/oct Highpass"
 msgstr "24dB/okt górnoprzepustowy"
 
-#: data/ui/filter.glade:251
+#: data/ui/filter.glade:252
 msgid "36dB/oct Highpass"
 msgstr "36dB/okt górnoprzepustowy"
 
-#: data/ui/filter.glade:252
+#: data/ui/filter.glade:253
 msgid "6dB/oct Bandpass"
 msgstr "6dB/okt środkowoprzepustowy"
 
-#: data/ui/filter.glade:253
+#: data/ui/filter.glade:254
 msgid "12dB/oct Bandpass"
 msgstr "12dB/okt środkowoprzepustowy"
 
-#: data/ui/filter.glade:254
+#: data/ui/filter.glade:255
 msgid "18dB/oct Bandpass"
 msgstr "18dB/okt środkowoprzepustowy"
 
-#: data/ui/filter.glade:255
+#: data/ui/filter.glade:256
 msgid "6dB/oct Bandreject"
 msgstr "6dB/okt Środkowozaporowy"
 
-#: data/ui/filter.glade:256
+#: data/ui/filter.glade:257
 msgid "12dB/oct Bandreject"
 msgstr "12dB/okt środkowozaporowy"
 
-#: data/ui/filter.glade:257
+#: data/ui/filter.glade:258
 msgid "18dB/oct Bandreject"
 msgstr "18dB/okt środkowozaporowy"
 
-#: data/ui/filter.glade:349
+#: data/ui/filter.glade:350
 msgid "Inertia"
 msgstr "Inercja"
 
@@ -1069,50 +1084,51 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: data/ui/gate.glade:98
+#: data/ui/gate.glade:99
 msgid "Gate"
 msgstr "Bramka"
 
-#: data/ui/gate.glade:209
+#: data/ui/gate.glade:240
+#, fuzzy
+msgid "Maximum Gain Reduction"
+msgstr "Redukcja wzmocnienia"
+
+#: data/ui/gate.glade:289
 msgid "Stereo Link"
 msgstr "Powiązanie stereo"
 
-#: data/ui/gate.glade:222 data/ui/maximizer.glade:293
-msgid "Gain Reduction"
-msgstr "Redukcja wzmocnienia"
-
-#: data/ui/gate.glade:273
+#: data/ui/gate.glade:304
 msgid "Average"
 msgstr "Średnia"
 
-#: data/ui/gate.glade:274
+#: data/ui/gate.glade:305
 msgid "Maximum"
 msgstr "Maksimum"
 
-#: data/ui/gate.glade:525
+#: data/ui/gate.glade:578
 #, fuzzy
 msgid "Input Level"
 msgstr "Urządzenie wejściowe"
 
-#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:811
-#: data/ui/multiband_gate.glade:1220 data/ui/multiband_gate.glade:1630
-#: data/ui/multiband_gate.glade:2040
+#: data/ui/gate.glade:797 data/ui/multiband_gate.glade:812
+#: data/ui/multiband_gate.glade:1224 data/ui/multiband_gate.glade:1637
+#: data/ui/multiband_gate.glade:2050
 msgid "Gating"
 msgstr ""
 
-#: data/ui/limiter.glade:97 data/ui/webrtc.glade:421
+#: data/ui/limiter.glade:98 data/ui/webrtc.glade:422
 msgid "Limiter"
 msgstr "Limiter"
 
-#: data/ui/limiter.glade:176
+#: data/ui/limiter.glade:175
 msgid "Automatic Smoothing Control"
 msgstr ""
 
-#: data/ui/limiter.glade:190
+#: data/ui/limiter.glade:189
 msgid "Automatic Leveling"
 msgstr ""
 
-#: data/ui/limiter.glade:222
+#: data/ui/limiter.glade:221
 msgid "Input Gain"
 msgstr "Wzmocnienie wej."
 
@@ -1120,146 +1136,150 @@ msgstr "Wzmocnienie wej."
 msgid "Limit"
 msgstr "Limit"
 
-#: data/ui/limiter.glade:358
+#: data/ui/limiter.glade:359
 msgid "Oversampling"
 msgstr "Nadpróbkowanie"
 
-#: data/ui/limiter.glade:411
+#: data/ui/limiter.glade:413
 #, fuzzy
 msgid "Output Gain"
 msgstr "Wzmocnienie wej."
 
-#: data/ui/limiter.glade:429
+#: data/ui/limiter.glade:431
 msgid "ASC"
 msgstr "ASC"
 
 # Tłumienie?
-#: data/ui/limiter.glade:584
+#: data/ui/limiter.glade:586
 msgid "Attenuation"
 msgstr "Tłumienie"
 
-#: data/ui/loudness.glade:91
+#: data/ui/loudness.glade:92
 msgid "Loudness Compensator"
 msgstr ""
 
-#: data/ui/loudness.glade:147
-msgid "Standard"
-msgstr ""
-
-#: data/ui/loudness.glade:161
-msgid "Flat"
-msgstr ""
-
-#: data/ui/loudness.glade:162
-msgid "ISO226-2003"
-msgstr ""
-
-#: data/ui/loudness.glade:163
-msgid "Fletcher-Munson"
-msgstr ""
-
-#: data/ui/loudness.glade:164
-msgid "Robinson-Dadson"
-msgstr ""
-
-#: data/ui/loudness.glade:174
-msgid "Reference Signal"
-msgstr ""
-
-#: data/ui/loudness.glade:199
+#: data/ui/loudness.glade:155
 #, fuzzy
 msgid "FFT Size"
 msgstr "Rozmiar ramki"
 
-#: data/ui/maximizer.glade:96
+#: data/ui/loudness.glade:205
+msgid "Standard"
+msgstr ""
+
+#: data/ui/loudness.glade:220
+msgid "Flat"
+msgstr ""
+
+#: data/ui/loudness.glade:221
+msgid "ISO226-2003"
+msgstr ""
+
+#: data/ui/loudness.glade:222
+msgid "Fletcher-Munson"
+msgstr ""
+
+#: data/ui/loudness.glade:223
+msgid "Robinson-Dadson"
+msgstr ""
+
+#: data/ui/loudness.glade:259
+msgid "Reference Signal"
+msgstr ""
+
+#: data/ui/maximizer.glade:97
 msgid "Maximizer"
 msgstr "Maximizer"
 
-#: data/ui/multiband_compressor.glade:140
+#: data/ui/maximizer.glade:296
+msgid "Gain Reduction"
+msgstr "Redukcja wzmocnienia"
+
+#: data/ui/multiband_compressor.glade:141
 #, fuzzy
 msgid "Multiband Compressor"
 msgstr "Kompresor"
 
-#: data/ui/multiband_compressor.glade:338 data/ui/multiband_gate.glade:362
+#: data/ui/multiband_compressor.glade:336 data/ui/multiband_gate.glade:360
 msgid "LR4"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:339 data/ui/multiband_gate.glade:363
+#: data/ui/multiband_compressor.glade:337 data/ui/multiband_gate.glade:361
 msgid "LR8"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:353 data/ui/multiband_gate.glade:377
+#: data/ui/multiband_compressor.glade:351 data/ui/multiband_gate.glade:375
 #, fuzzy
 msgid "Split 1/2"
 msgstr "Podzielony"
 
-#: data/ui/multiband_compressor.glade:366 data/ui/multiband_gate.glade:390
+#: data/ui/multiband_compressor.glade:364 data/ui/multiband_gate.glade:388
 #, fuzzy
 msgid "Split 2/3"
 msgstr "Podzielony"
 
-#: data/ui/multiband_compressor.glade:379 data/ui/multiband_gate.glade:403
+#: data/ui/multiband_compressor.glade:377 data/ui/multiband_gate.glade:401
 #, fuzzy
 msgid "Split 3/4"
 msgstr "Podzielony"
 
 #: data/ui/multiband_compressor.glade:754
-#: data/ui/multiband_compressor.glade:1131
-#: data/ui/multiband_compressor.glade:1509
-#: data/ui/multiband_compressor.glade:1887
+#: data/ui/multiband_compressor.glade:1133
+#: data/ui/multiband_compressor.glade:1513
+#: data/ui/multiband_compressor.glade:1893
 #, fuzzy
 msgid "Compression"
 msgstr "Kompresor"
 
-#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:894
+#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:895
 #, fuzzy
 msgid "Sub Band"
 msgstr "Pasma"
 
-#: data/ui/multiband_compressor.glade:1214 data/ui/multiband_gate.glade:1303
+#: data/ui/multiband_compressor.glade:1216 data/ui/multiband_gate.glade:1307
 #, fuzzy
 msgid "Low Band"
 msgstr "Dolnoprzepustowy"
 
-#: data/ui/multiband_compressor.glade:1592 data/ui/multiband_gate.glade:1713
+#: data/ui/multiband_compressor.glade:1596 data/ui/multiband_gate.glade:1720
 #, fuzzy
 msgid "Mid Band"
 msgstr "Pasma"
 
-#: data/ui/multiband_compressor.glade:1970 data/ui/multiband_gate.glade:2123
+#: data/ui/multiband_compressor.glade:1976 data/ui/multiband_gate.glade:2133
 #, fuzzy
 msgid "High Band"
 msgstr "Górnoprzepustowy"
 
-#: data/ui/multiband_gate.glade:140
+#: data/ui/multiband_gate.glade:141
 msgid "Multiband Gate"
 msgstr ""
 
-#: data/ui/pitch.glade:103
+#: data/ui/pitch.glade:104
 msgid "Pitch"
 msgstr "Wysokość"
 
-#: data/ui/pitch.glade:178
+#: data/ui/pitch.glade:179
 msgid "Cents"
 msgstr "Centy"
 
-#: data/ui/pitch.glade:209
+#: data/ui/pitch.glade:210
 msgid "Semitones"
 msgstr "Półtony"
 
-#: data/ui/pitch.glade:240
+#: data/ui/pitch.glade:241
 msgid "Octaves"
 msgstr "Oktawy"
 
-#: data/ui/pitch.glade:271
+#: data/ui/pitch.glade:272
 msgid "Crispness"
 msgstr "Czystość"
 
-#: data/ui/pitch.glade:311
+#: data/ui/pitch.glade:312
 msgid "Faster"
 msgstr "Szybszy"
 
-#: data/ui/pitch.glade:325
+#: data/ui/pitch.glade:326
 msgid "Preserve Formant"
 msgstr "Zachowaj formant"
 
@@ -1361,83 +1381,83 @@ msgstr ""
 msgid "Pipeline Output"
 msgstr ""
 
-#: data/ui/reverb.glade:131
+#: data/ui/reverb.glade:132
 msgid "Reverberation"
 msgstr "Pogłos"
 
-#: data/ui/reverb.glade:181
+#: data/ui/reverb.glade:182
 msgid "Ambience"
 msgstr "Otoczenie"
 
-#: data/ui/reverb.glade:194
+#: data/ui/reverb.glade:195
 msgid "Empty Walls"
 msgstr "Gołe ściany"
 
-#: data/ui/reverb.glade:207
+#: data/ui/reverb.glade:208
 msgid "Room"
 msgstr "Pokój"
 
-#: data/ui/reverb.glade:220
+#: data/ui/reverb.glade:221
 msgid "Large Empty Hall"
 msgstr "Duża pusta sala"
 
-#: data/ui/reverb.glade:246
+#: data/ui/reverb.glade:247
 msgid "Large Occupied Hall"
 msgstr "Duża pełna sala"
 
-#: data/ui/reverb.glade:361
+#: data/ui/reverb.glade:362
 msgid "Pre Delay"
 msgstr "Przedopóźnienie"
 
-#: data/ui/reverb.glade:374
+#: data/ui/reverb.glade:375
 msgid "Decay Time"
 msgstr "Czas zaniku"
 
-#: data/ui/reverb.glade:439
+#: data/ui/reverb.glade:441
 msgid "Dry"
 msgstr "Suchy"
 
-#: data/ui/reverb.glade:471
+#: data/ui/reverb.glade:474
 msgid "Bass Cut"
 msgstr "Odcięcie basu"
 
-#: data/ui/reverb.glade:522
+#: data/ui/reverb.glade:525
 msgid "Treble Cut"
 msgstr "Odcięcie sopranu"
 
-#: data/ui/reverb.glade:565
+#: data/ui/reverb.glade:568
 msgid "Diffusion"
 msgstr "Rozproszenie"
 
-#: data/ui/reverb.glade:577
+#: data/ui/reverb.glade:580
 msgid "Room Size"
 msgstr "Rozmiar pomieszczenia"
 
-#: data/ui/reverb.glade:590
+#: data/ui/reverb.glade:593
 msgid "Small"
 msgstr "Mały"
 
-#: data/ui/reverb.glade:591
+#: data/ui/reverb.glade:594
 msgid "Medium"
 msgstr "Średni"
 
-#: data/ui/reverb.glade:592
+#: data/ui/reverb.glade:595
 msgid "Large"
 msgstr "Duży"
 
-#: data/ui/reverb.glade:593
+#: data/ui/reverb.glade:596
 msgid "Tunnel"
 msgstr "Tunel"
 
-#: data/ui/reverb.glade:594
+#: data/ui/reverb.glade:597
 msgid "Large/smooth"
 msgstr "Duży/gładki"
 
-#: data/ui/reverb.glade:595
+#: data/ui/reverb.glade:598
 msgid "Experimental"
 msgstr "Experymentalne"
 
-#: data/ui/reverb.glade:608
+#: data/ui/reverb.glade:611
 msgid "High Frequency Damping"
 msgstr "Tłumienie wysokich tonów"
 
@@ -1515,25 +1535,25 @@ msgstr "Wysokość"
 msgid "Points"
 msgstr "Punkty"
 
-#: data/ui/stereo_tools.glade:109
+#: data/ui/stereo_tools.glade:110
 #, fuzzy
 msgid "Stereo Tools"
 msgstr "Powiązanie stereo"
 
-#: data/ui/stereo_tools.glade:231
+#: data/ui/stereo_tools.glade:230
 msgid "Softclip"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:255 data/ui/stereo_tools.glade:671
+#: data/ui/stereo_tools.glade:254 data/ui/stereo_tools.glade:672
 msgid "Balance"
 msgstr "Balans"
 
-#: data/ui/stereo_tools.glade:287
+#: data/ui/stereo_tools.glade:286
 #, fuzzy
 msgid "S/C Level"
 msgstr "Poziom"
 
-#: data/ui/stereo_tools.glade:345
+#: data/ui/stereo_tools.glade:344
 #, fuzzy
 msgid "Side Level"
 msgstr "Poziom"
@@ -1543,150 +1563,150 @@ msgstr "Poziom"
 msgid "Side Balance"
 msgstr "Balans"
 
-#: data/ui/stereo_tools.glade:428
+#: data/ui/stereo_tools.glade:429
 #, fuzzy
 msgid "Middle Level"
 msgstr "Środek"
 
-#: data/ui/stereo_tools.glade:441
+#: data/ui/stereo_tools.glade:442
 #, fuzzy
 msgid "Middle Panorama"
 msgstr "Panorama"
 
-#: data/ui/stereo_tools.glade:499
+#: data/ui/stereo_tools.glade:500
 msgid "LR > LR (Stereo Default)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:500
+#: data/ui/stereo_tools.glade:501
 msgid "LR > MS (Stereo to Mid-Side)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:501
+#: data/ui/stereo_tools.glade:502
 msgid "MS > LR (Mid-Side to Stereo)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:502
+#: data/ui/stereo_tools.glade:503
 msgid "LR > LL (Mono Left Channel)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:503
+#: data/ui/stereo_tools.glade:504
 msgid "LR > RR (Mono Right Channel)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:504
+#: data/ui/stereo_tools.glade:505
 msgid "LR > L+R (Mono Sum L+R)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:505
+#: data/ui/stereo_tools.glade:506
 msgid "LR > RL (Stereo Flip Channels)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:522
+#: data/ui/stereo_tools.glade:523
 #, fuzzy
 msgid "Stereo Matrix"
 msgstr "Powiązanie stereo"
 
-#: data/ui/stereo_tools.glade:561 data/ui/stereo_tools.glade:602
+#: data/ui/stereo_tools.glade:562 data/ui/stereo_tools.glade:603
 msgid "Invert Phase"
 msgstr "Odwróć fazę"
 
-#: data/ui/stereo_tools.glade:703
+#: data/ui/stereo_tools.glade:704
 #, fuzzy
 msgid "Delay L/R"
 msgstr "Opóźnienie"
 
-#: data/ui/stereo_tools.glade:737
+#: data/ui/stereo_tools.glade:738
 #, fuzzy
 msgid "Stereo Base"
 msgstr "Wzmacniacz stereo"
 
-#: data/ui/stereo_tools.glade:770
+#: data/ui/stereo_tools.glade:771
 #, fuzzy
 msgid "Stereo Phase"
 msgstr "Wzmacniacz stereo"
 
-#: data/ui/webrtc.glade:97
+#: data/ui/webrtc.glade:98
 msgid "WebRTC"
 msgstr ""
 
-#: data/ui/webrtc.glade:163 data/ui/webrtc.glade:283 data/ui/webrtc.glade:353
-#: data/ui/webrtc.glade:523
+#: data/ui/webrtc.glade:164 data/ui/webrtc.glade:284 data/ui/webrtc.glade:354
+#: data/ui/webrtc.glade:524
 msgid "Enable"
 msgstr "Włącz"
 
-#: data/ui/webrtc.glade:184
+#: data/ui/webrtc.glade:185
 msgid "Extended Filter"
 msgstr "Rozszerzony Filtr"
 
-#: data/ui/webrtc.glade:197
+#: data/ui/webrtc.glade:198
 msgid "Delay Agnostic"
 msgstr "Niezależny od opóźnienia"
 
-#: data/ui/webrtc.glade:209
+#: data/ui/webrtc.glade:210
 msgid "High Pass Filter"
 msgstr "Filtr górnoprzepustowy"
 
-#: data/ui/webrtc.glade:238 data/ui/webrtc.glade:306
+#: data/ui/webrtc.glade:239 data/ui/webrtc.glade:307
 msgid "Suppresion Level"
 msgstr "Poziom tłumienia"
 
-#: data/ui/webrtc.glade:251 data/ui/webrtc.glade:319 data/ui/webrtc.glade:575
+#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
 msgid "Low"
 msgstr "Nisko"
 
-#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
+#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
 msgid "Moderate"
 msgstr "Średni"
 
-#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
+#: data/ui/webrtc.glade:254 data/ui/webrtc.glade:322 data/ui/webrtc.glade:578
 msgid "High"
 msgstr "Wysoki"
 
-#: data/ui/webrtc.glade:270
+#: data/ui/webrtc.glade:271
 msgid "Echo Canceller"
 msgstr "Usuwanie echa"
 
-#: data/ui/webrtc.glade:322
+#: data/ui/webrtc.glade:323
 msgid "Very High"
 msgstr "Bardzo wysokie"
 
-#: data/ui/webrtc.glade:339
+#: data/ui/webrtc.glade:340
 msgid "Noise Suppressor"
 msgstr "Tłumienie szumu"
 
-#: data/ui/webrtc.glade:389
+#: data/ui/webrtc.glade:390
 msgid "Adaptive Digital"
 msgstr "Cyfrowy adaptacyjny"
 
-#: data/ui/webrtc.glade:390
+#: data/ui/webrtc.glade:391
 msgid "Fixed Digital"
 msgstr "Cyfrowy ustalony"
 
-#: data/ui/webrtc.glade:407
+#: data/ui/webrtc.glade:408
 msgid "Gain Controller"
 msgstr "Kontroler wzmocnienia"
 
-#: data/ui/webrtc.glade:445
+#: data/ui/webrtc.glade:446
 msgid "Target Level"
 msgstr "Poziom docelowy"
 
-#: data/ui/webrtc.glade:475
+#: data/ui/webrtc.glade:476
 msgid "Maximum Gain"
 msgstr "Maksymalne wzmocnienie"
 
-#: data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:549
 msgid "Detection Likelihood"
 msgstr "Szansa wykrycia"
 
-#: data/ui/webrtc.glade:561
+#: data/ui/webrtc.glade:562
 msgid "Frame Size"
 msgstr "Rozmiar ramki"
 
-#: data/ui/webrtc.glade:574
+#: data/ui/webrtc.glade:575
 msgid "Very Low"
 msgstr "Bardzo niskie"
 
-#: data/ui/webrtc.glade:611
+#: data/ui/webrtc.glade:612
 msgid "Voice Detector"
 msgstr "Wykrywanie głosu"
 
@@ -1785,3 +1805,7 @@ msgstr "Ogólne"
 #: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
+
+#, fuzzy
+#~ msgid "Gain Detection"
+#~ msgstr "Redukcja wzmocnienia"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PulseEffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-22 15:29+0200\n"
+"POT-Creation-Date: 2020-08-24 16:51+0200\n"
 "PO-Revision-Date: 2019-09-10 12:56-0300\n"
 "Last-Translator: Patrik Nilsson <translation_AT_hembas.se>\n"
 "Language-Team: Portuguese <>\n"
@@ -89,8 +89,8 @@ msgid "Input Limiter"
 msgstr "Limitador de Entrada"
 
 #: data/com.github.wwmm.pulseeffects.appdata.xml.in:52
-#: data/ui/compressor.glade:111 data/ui/compressor.glade:494
-#: data/ui/webrtc.glade:509
+#: data/ui/compressor.glade:112 data/ui/compressor.glade:494
+#: data/ui/webrtc.glade:510
 msgid "Compressor"
 msgstr "Compressor"
 
@@ -122,12 +122,12 @@ msgstr "Aplicativos"
 msgid "Format"
 msgstr "Formato"
 
-#: data/ui/app_info.glade:75 data/ui/convolver.glade:283
+#: data/ui/app_info.glade:75 data/ui/convolver.glade:284
 msgid "Rate"
 msgstr "Taxa"
 
 #: data/ui/app_info.glade:102 data/ui/pulse_info.glade:238
-#: data/ui/stereo_tools.glade:653
+#: data/ui/stereo_tools.glade:654
 msgid "Channels"
 msgstr "Canais"
 
@@ -166,7 +166,7 @@ msgstr "Sinais de Teste"
 msgid "Global Bypass"
 msgstr "Ignorar"
 
-#: data/ui/application.glade:170 data/ui/equalizer.glade:277
+#: data/ui/application.glade:170 data/ui/equalizer.glade:278
 #: data/ui/general_settings.glade:107
 msgid "Settings"
 msgstr "Configurações"
@@ -175,170 +175,169 @@ msgstr "Configurações"
 msgid "Help"
 msgstr "Ajuda"
 
-#: data/ui/application.glade:215 data/ui/crossfeed.glade:49
-#: data/ui/equalizer.glade:333 data/ui/filter.glade:230
-#: data/ui/reverb.glade:310 src/presets_menu_ui.cpp:113
+#: data/ui/application.glade:215 data/ui/crossfeed.glade:48
+#: data/ui/equalizer.glade:334 data/ui/filter.glade:231
+#: data/ui/reverb.glade:311 src/presets_menu_ui.cpp:113
 #: src/presets_menu_ui.cpp:258 src/presets_menu_ui.cpp:275
 msgid "Presets"
 msgstr "Predefinições"
 
-#: data/ui/autogain.glade:91
+#: data/ui/autogain.glade:92
 msgid "Auto Gain"
 msgstr "Ganho Automático"
 
-#: data/ui/autogain.glade:171
+#: data/ui/autogain.glade:172
 msgid "Reset History"
 msgstr "Redefinir Histórico"
 
-#: data/ui/autogain.glade:183
+#: data/ui/autogain.glade:184
 msgid "Detect Silence"
 msgstr "Detectar Silêncio"
 
-#: data/ui/autogain.glade:195
+#: data/ui/autogain.glade:196
 #, fuzzy
 msgid "Use Geometric Mean"
 msgstr "Usar Gradiente"
 
-#: data/ui/autogain.glade:233
+#: data/ui/autogain.glade:234
 msgid "Target"
 msgstr "Alvo"
 
-#: data/ui/autogain.glade:283 data/ui/autogain.glade:627
+#: data/ui/autogain.glade:286 data/ui/autogain.glade:631
 msgid "Momentary"
 msgstr "Momentâneo"
 
-#: data/ui/autogain.glade:298 data/ui/autogain.glade:640
+#: data/ui/autogain.glade:301 data/ui/autogain.glade:644
 msgid "Short Term"
 msgstr "Curto Prazo"
 
-#: data/ui/autogain.glade:313 data/ui/autogain.glade:653
+#: data/ui/autogain.glade:316 data/ui/autogain.glade:657
 msgid "Integrated"
 msgstr "Integrada"
 
-#: data/ui/autogain.glade:388
+#: data/ui/autogain.glade:394
 msgid "Weights"
 msgstr "Pesos"
 
-#: data/ui/autogain.glade:428 data/ui/autogain.glade:917
-#: data/ui/bass_enhancer.glade:504 data/ui/compressor.glade:974
-#: data/ui/convolver.glade:504 data/ui/crossfeed.glade:200
-#: data/ui/crystalizer.glade:255 data/ui/deesser.glade:593
-#: data/ui/delay.glade:236 data/ui/equalizer.glade:543
-#: data/ui/exciter.glade:510 data/ui/filter.glade:396 data/ui/gate.glade:558
-#: data/ui/limiter.glade:483 data/ui/loudness.glade:259
-#: data/ui/loudness.glade:338 data/ui/maximizer.glade:265
-#: data/ui/multiband_compressor.glade:2000 data/ui/multiband_gate.glade:2153
-#: data/ui/pitch.glade:362 data/ui/presets_menu.glade:255
-#: data/ui/reverb.glade:658 data/ui/stereo_tools.glade:323
-#: data/ui/stereo_tools.glade:829 data/ui/webrtc.glade:650
+#: data/ui/autogain.glade:434 data/ui/autogain.glade:921
+#: data/ui/bass_enhancer.glade:506 data/ui/compressor.glade:977
+#: data/ui/convolver.glade:505 data/ui/crossfeed.glade:199
+#: data/ui/crystalizer.glade:205 data/ui/deesser.glade:594
+#: data/ui/delay.glade:237 data/ui/equalizer.glade:544
+#: data/ui/exciter.glade:510 data/ui/filter.glade:397 data/ui/gate.glade:611
+#: data/ui/limiter.glade:485 data/ui/loudness.glade:299
+#: data/ui/loudness.glade:380 data/ui/maximizer.glade:268
+#: data/ui/multiband_compressor.glade:2006 data/ui/multiband_gate.glade:2163
+#: data/ui/pitch.glade:363 data/ui/presets_menu.glade:255
+#: data/ui/reverb.glade:661 data/ui/stereo_tools.glade:322
+#: data/ui/stereo_tools.glade:830 data/ui/webrtc.glade:651
 msgid "Input"
 msgstr "Entrada"
 
-#: data/ui/autogain.glade:443 data/ui/autogain.glade:862
-#: data/ui/bass_enhancer.glade:536 data/ui/compressor.glade:988
-#: data/ui/convolver.glade:519 data/ui/crossfeed.glade:214
-#: data/ui/crystalizer.glade:270 data/ui/deesser.glade:607
-#: data/ui/delay.glade:250 data/ui/equalizer.glade:557
-#: data/ui/exciter.glade:542 data/ui/filter.glade:411 data/ui/gate.glade:572
-#: data/ui/limiter.glade:626 data/ui/loudness.glade:292
-#: data/ui/loudness.glade:352 data/ui/maximizer.glade:279
+#: data/ui/autogain.glade:449 data/ui/autogain.glade:866
+#: data/ui/bass_enhancer.glade:537 data/ui/compressor.glade:991
+#: data/ui/convolver.glade:520 data/ui/crossfeed.glade:213
+#: data/ui/crystalizer.glade:220 data/ui/deesser.glade:608
+#: data/ui/delay.glade:251 data/ui/equalizer.glade:558
+#: data/ui/exciter.glade:541 data/ui/filter.glade:412 data/ui/gate.glade:625
+#: data/ui/limiter.glade:628 data/ui/loudness.glade:333
+#: data/ui/loudness.glade:394 data/ui/maximizer.glade:282
 #: data/ui/multiband_compressor.glade:794
-#: data/ui/multiband_compressor.glade:1171
-#: data/ui/multiband_compressor.glade:1549
-#: data/ui/multiband_compressor.glade:1927
-#: data/ui/multiband_compressor.glade:2015 data/ui/multiband_gate.glade:851
-#: data/ui/multiband_gate.glade:1260 data/ui/multiband_gate.glade:1670
-#: data/ui/multiband_gate.glade:2080 data/ui/multiband_gate.glade:2168
-#: data/ui/pitch.glade:376 data/ui/presets_menu.glade:146
-#: data/ui/reverb.glade:673 data/ui/stereo_tools.glade:800
-#: data/ui/stereo_tools.glade:843 data/ui/webrtc.glade:664
+#: data/ui/multiband_compressor.glade:1173
+#: data/ui/multiband_compressor.glade:1553
+#: data/ui/multiband_compressor.glade:1933
+#: data/ui/multiband_compressor.glade:2021 data/ui/multiband_gate.glade:852
+#: data/ui/multiband_gate.glade:1264 data/ui/multiband_gate.glade:1677
+#: data/ui/multiband_gate.glade:2090 data/ui/multiband_gate.glade:2178
+#: data/ui/pitch.glade:377 data/ui/presets_menu.glade:146
+#: data/ui/reverb.glade:676 data/ui/stereo_tools.glade:801
+#: data/ui/stereo_tools.glade:844 data/ui/webrtc.glade:665
 msgid "Output"
 msgstr "Saída"
 
-#: data/ui/autogain.glade:744
+#: data/ui/autogain.glade:748
 msgid "Relative"
 msgstr "Relativo"
 
-#: data/ui/autogain.glade:757 data/ui/compressor.glade:1154
-#: data/ui/deesser.glade:321
+#: data/ui/autogain.glade:761 data/ui/compressor.glade:1157
 msgid "Gain"
 msgstr "Ganho"
 
-#: data/ui/autogain.glade:823
+#: data/ui/autogain.glade:827
 msgid "Loudness"
 msgstr "Sonoridade"
 
-#: data/ui/autogain.glade:876
+#: data/ui/autogain.glade:880
 msgid "Range"
 msgstr "Alcance"
 
-#: data/ui/autogain.glade:945 data/ui/bass_enhancer.glade:655
-#: data/ui/compressor.glade:1299 data/ui/convolver.glade:703
-#: data/ui/crossfeed.glade:395 data/ui/crystalizer.glade:566
-#: data/ui/deesser.glade:898 data/ui/delay.glade:434
-#: data/ui/equalizer.glade:743 data/ui/equalizer_band.glade:182
-#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:661
-#: data/ui/filter.glade:595 data/ui/general_settings.glade:116
-#: data/ui/gate.glade:809 data/ui/limiter.glade:733 data/ui/loudness.glade:573
-#: data/ui/maximizer.glade:516 data/ui/multiband_compressor.glade:2199
-#: data/ui/multiband_gate.glade:2352 data/ui/pitch.glade:560
-#: data/ui/reverb.glade:857 data/ui/stereo_tools.glade:1029
-#: data/ui/webrtc.glade:814
+#: data/ui/autogain.glade:949 data/ui/bass_enhancer.glade:650
+#: data/ui/compressor.glade:1300 data/ui/convolver.glade:702
+#: data/ui/crossfeed.glade:394 data/ui/crystalizer.glade:514
+#: data/ui/deesser.glade:899 data/ui/delay.glade:433
+#: data/ui/equalizer.glade:744 data/ui/equalizer_band.glade:182
+#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:654
+#: data/ui/filter.glade:594 data/ui/general_settings.glade:116
+#: data/ui/gate.glade:862 data/ui/limiter.glade:735 data/ui/loudness.glade:615
+#: data/ui/maximizer.glade:519 data/ui/multiband_compressor.glade:2203
+#: data/ui/multiband_gate.glade:2360 data/ui/pitch.glade:559
+#: data/ui/reverb.glade:858 data/ui/stereo_tools.glade:1028
+#: data/ui/webrtc.glade:815
 msgid "Reset"
 msgstr "Resetar"
 
-#: data/ui/autogain.glade:969
+#: data/ui/autogain.glade:973
 msgid "Based on"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:117
+#: data/ui/bass_enhancer.glade:118
 msgid "Bass Enhancer"
 msgstr "Reforçador de Graves"
 
-#: data/ui/bass_enhancer.glade:169 data/ui/compressor.glade:506
-#: data/ui/deesser.glade:188 data/ui/exciter.glade:171
+#: data/ui/bass_enhancer.glade:170 data/ui/compressor.glade:506
+#: data/ui/deesser.glade:185 data/ui/exciter.glade:170
 msgid "Listen"
 msgstr "Escutar"
 
-#: data/ui/bass_enhancer.glade:210 data/ui/exciter.glade:213
+#: data/ui/bass_enhancer.glade:211 data/ui/exciter.glade:212
 msgid "3rd"
 msgstr "3°"
 
-#: data/ui/bass_enhancer.glade:222 data/ui/exciter.glade:225
+#: data/ui/bass_enhancer.glade:223 data/ui/exciter.glade:224
 msgid "2nd"
 msgstr "2°"
 
-#: data/ui/bass_enhancer.glade:234 data/ui/exciter.glade:237
+#: data/ui/bass_enhancer.glade:235 data/ui/exciter.glade:236
 msgid "Blend Harmonics"
 msgstr "Mistura de Harmônicos"
 
-#: data/ui/bass_enhancer.glade:266 data/ui/exciter.glade:271
-#: data/ui/reverb.glade:407
+#: data/ui/bass_enhancer.glade:267 data/ui/exciter.glade:270
+#: data/ui/reverb.glade:408
 msgid "Amount"
 msgstr "Quantidade"
 
-#: data/ui/bass_enhancer.glade:278 data/ui/bass_enhancer.glade:411
-#: data/ui/exciter.glade:284 data/ui/exciter.glade:417
+#: data/ui/bass_enhancer.glade:279 data/ui/bass_enhancer.glade:413
+#: data/ui/exciter.glade:283 data/ui/exciter.glade:417
 msgid "Harmonics"
 msgstr "Harmônico"
 
-#: data/ui/bass_enhancer.glade:290 data/ui/exciter.glade:297
+#: data/ui/bass_enhancer.glade:291 data/ui/exciter.glade:296
 msgid "Scope"
 msgstr "Escopo"
 
-#: data/ui/bass_enhancer.glade:379
+#: data/ui/bass_enhancer.glade:381
 msgid "Floor"
 msgstr "Piso"
 
-#: data/ui/bass_enhancer.glade:679 data/ui/compressor.glade:1323
-#: data/ui/crossfeed.glade:419 data/ui/deesser.glade:922
-#: data/ui/delay.glade:458 data/ui/equalizer.glade:767
-#: data/ui/exciter.glade:685 data/ui/filter.glade:619 data/ui/gate.glade:833
-#: data/ui/limiter.glade:757 data/ui/loudness.glade:542
-#: data/ui/maximizer.glade:540 data/ui/multiband_compressor.glade:2223
-#: data/ui/multiband_gate.glade:2376 data/ui/pitch.glade:584
-#: data/ui/reverb.glade:881 data/ui/stereo_tools.glade:1053
-#: data/ui/webrtc.glade:838
+#: data/ui/bass_enhancer.glade:674 data/ui/compressor.glade:1324
+#: data/ui/crossfeed.glade:418 data/ui/deesser.glade:923
+#: data/ui/delay.glade:457 data/ui/equalizer.glade:768
+#: data/ui/exciter.glade:678 data/ui/filter.glade:618 data/ui/gate.glade:886
+#: data/ui/limiter.glade:759 data/ui/loudness.glade:584
+#: data/ui/maximizer.glade:543 data/ui/multiband_compressor.glade:2227
+#: data/ui/multiband_gate.glade:2384 data/ui/pitch.glade:583
+#: data/ui/reverb.glade:882 data/ui/stereo_tools.glade:1052
+#: data/ui/webrtc.glade:839
 msgid "Provided by"
 msgstr ""
 
@@ -373,138 +372,138 @@ msgstr "Efeitos de Saída"
 msgid "Show Blocklisted Apps in Main Tab"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:32 data/ui/equalizer_band.glade:152
-#: data/ui/filter.glade:280
+#: data/ui/calibration_signals.glade:30 data/ui/equalizer_band.glade:152
+#: data/ui/filter.glade:281
 msgid "Frequency"
 msgstr "Frequência"
 
-#: data/ui/calibration_signals.glade:64
+#: data/ui/calibration_signals.glade:62
 msgid "Volume"
 msgstr "Volume"
 
-#: data/ui/calibration_signals.glade:108
+#: data/ui/calibration_signals.glade:106
 msgid "Sine"
 msgstr "Seno"
 
-#: data/ui/calibration_signals.glade:109
+#: data/ui/calibration_signals.glade:107
 msgid "Square"
 msgstr "Quadrada"
 
-#: data/ui/calibration_signals.glade:110
+#: data/ui/calibration_signals.glade:108
 msgid "Saw"
 msgstr "Serra"
 
-#: data/ui/calibration_signals.glade:111
+#: data/ui/calibration_signals.glade:109
 msgid "Triangle"
 msgstr "Triângulo"
 
-#: data/ui/calibration_signals.glade:112
+#: data/ui/calibration_signals.glade:110
 msgid "Silence"
 msgstr "Silencio"
 
-#: data/ui/calibration_signals.glade:113
+#: data/ui/calibration_signals.glade:111
 msgid "White Noise"
 msgstr "Ruído Branco"
 
-#: data/ui/calibration_signals.glade:114
+#: data/ui/calibration_signals.glade:112
 msgid "Pink Noise"
 msgstr "Ruído Rosa"
 
-#: data/ui/calibration_signals.glade:115
+#: data/ui/calibration_signals.glade:113
 msgid "Sine Table"
 msgstr "Tabela de Seno"
 
-#: data/ui/calibration_signals.glade:116
+#: data/ui/calibration_signals.glade:114
 msgid "Ticks"
 msgstr "Tique-Taque"
 
-#: data/ui/calibration_signals.glade:117
+#: data/ui/calibration_signals.glade:115
 msgid "Gaussian Noise"
 msgstr "Ruído Gaussiano"
 
-#: data/ui/calibration_signals.glade:118
+#: data/ui/calibration_signals.glade:116
 msgid "Red Noise"
 msgstr "Ruído Vermelho"
 
-#: data/ui/calibration_signals.glade:119
+#: data/ui/calibration_signals.glade:117
 msgid "Blue Noise"
 msgstr "Ruído Azul"
 
-#: data/ui/calibration_signals.glade:120
+#: data/ui/calibration_signals.glade:118
 msgid "Violet Noise"
 msgstr "Ruído Violeta"
 
-#: data/ui/calibration_mic.glade:29
+#: data/ui/calibration_mic.glade:28
 msgid "Window"
 msgstr "Janela"
 
-#: data/ui/calibration_mic.glade:70
+#: data/ui/calibration_mic.glade:69
 msgid "Measure Noise"
 msgstr "Medir Ruído"
 
-#: data/ui/calibration_mic.glade:99
+#: data/ui/calibration_mic.glade:98
 msgid "Subtract Noise"
 msgstr "Subtrair Ruído"
 
-#: data/ui/compressor.glade:292 data/ui/deesser.glade:483
-#: data/ui/gate.glade:370 data/ui/maximizer.glade:152
-#: data/ui/multiband_compressor.glade:609
+#: data/ui/compressor.glade:290 data/ui/deesser.glade:482
+#: data/ui/gate.glade:413 data/ui/maximizer.glade:153
+#: data/ui/multiband_compressor.glade:607
 #: data/ui/multiband_compressor.glade:983
-#: data/ui/multiband_compressor.glade:1361
-#: data/ui/multiband_compressor.glade:1739 data/ui/multiband_gate.glade:633
-#: data/ui/multiband_gate.glade:1040 data/ui/multiband_gate.glade:1450
-#: data/ui/multiband_gate.glade:1860
+#: data/ui/multiband_compressor.glade:1363
+#: data/ui/multiband_compressor.glade:1743 data/ui/multiband_gate.glade:631
+#: data/ui/multiband_gate.glade:1041 data/ui/multiband_gate.glade:1454
+#: data/ui/multiband_gate.glade:1867
 msgid "Threshold"
 msgstr "Limiar"
 
-#: data/ui/compressor.glade:325 data/ui/deesser.glade:516
-#: data/ui/gate.glade:403 data/ui/multiband_compressor.glade:642
-#: data/ui/multiband_compressor.glade:1017
-#: data/ui/multiband_compressor.glade:1395
-#: data/ui/multiband_compressor.glade:1773 data/ui/multiband_gate.glade:666
-#: data/ui/multiband_gate.glade:1074 data/ui/multiband_gate.glade:1484
-#: data/ui/multiband_gate.glade:1894
+#: data/ui/compressor.glade:324 data/ui/deesser.glade:516
+#: data/ui/gate.glade:449 data/ui/multiband_compressor.glade:641
+#: data/ui/multiband_compressor.glade:1018
+#: data/ui/multiband_compressor.glade:1398
+#: data/ui/multiband_compressor.glade:1778 data/ui/multiband_gate.glade:665
+#: data/ui/multiband_gate.glade:1076 data/ui/multiband_gate.glade:1489
+#: data/ui/multiband_gate.glade:1902
 msgid "Ratio"
 msgstr "Razão"
 
-#: data/ui/compressor.glade:357 data/ui/gate.glade:435
-#: data/ui/multiband_compressor.glade:674
-#: data/ui/multiband_compressor.glade:1050
-#: data/ui/multiband_compressor.glade:1428
-#: data/ui/multiband_compressor.glade:1806 data/ui/multiband_gate.glade:698
-#: data/ui/multiband_gate.glade:1107 data/ui/multiband_gate.glade:1517
-#: data/ui/multiband_gate.glade:1927
+#: data/ui/compressor.glade:356 data/ui/gate.glade:483
+#: data/ui/multiband_compressor.glade:673
+#: data/ui/multiband_compressor.glade:1051
+#: data/ui/multiband_compressor.glade:1431
+#: data/ui/multiband_compressor.glade:1811 data/ui/multiband_gate.glade:697
+#: data/ui/multiband_gate.glade:1109 data/ui/multiband_gate.glade:1522
+#: data/ui/multiband_gate.glade:1935
 msgid "Knee"
 msgstr "Joelho"
 
-#: data/ui/compressor.glade:391 data/ui/deesser.glade:547
-#: data/ui/gate.glade:469 data/ui/multiband_compressor.glade:708
-#: data/ui/multiband_compressor.glade:1085
-#: data/ui/multiband_compressor.glade:1463
-#: data/ui/multiband_compressor.glade:1841 data/ui/multiband_gate.glade:732
-#: data/ui/multiband_gate.glade:1142 data/ui/multiband_gate.glade:1552
-#: data/ui/multiband_gate.glade:1962
+#: data/ui/compressor.glade:390 data/ui/deesser.glade:547
+#: data/ui/gate.glade:519 data/ui/multiband_compressor.glade:707
+#: data/ui/multiband_compressor.glade:1086
+#: data/ui/multiband_compressor.glade:1466
+#: data/ui/multiband_compressor.glade:1846 data/ui/multiband_gate.glade:731
+#: data/ui/multiband_gate.glade:1144 data/ui/multiband_gate.glade:1557
+#: data/ui/multiband_gate.glade:1970
 msgid "Makeup"
 msgstr "Ganho de Saída"
 
-#: data/ui/compressor.glade:425 data/ui/gate.glade:336
-#: data/ui/limiter.glade:310 data/ui/maximizer.glade:178
-#: data/ui/multiband_compressor.glade:575
+#: data/ui/compressor.glade:425 data/ui/gate.glade:377
+#: data/ui/limiter.glade:311 data/ui/maximizer.glade:179
+#: data/ui/multiband_compressor.glade:573
 #: data/ui/multiband_compressor.glade:948
-#: data/ui/multiband_compressor.glade:1326
-#: data/ui/multiband_compressor.glade:1704 data/ui/multiband_gate.glade:599
-#: data/ui/multiband_gate.glade:1005 data/ui/multiband_gate.glade:1415
-#: data/ui/multiband_gate.glade:1825
+#: data/ui/multiband_compressor.glade:1328
+#: data/ui/multiband_compressor.glade:1708 data/ui/multiband_gate.glade:597
+#: data/ui/multiband_gate.glade:1006 data/ui/multiband_gate.glade:1419
+#: data/ui/multiband_gate.glade:1832
 msgid "Release"
 msgstr "Liberação"
 
-#: data/ui/compressor.glade:438 data/ui/gate.glade:302
-#: data/ui/multiband_compressor.glade:541
+#: data/ui/compressor.glade:438 data/ui/gate.glade:341
+#: data/ui/multiband_compressor.glade:539
 #: data/ui/multiband_compressor.glade:913
-#: data/ui/multiband_compressor.glade:1291
-#: data/ui/multiband_compressor.glade:1669 data/ui/multiband_gate.glade:565
-#: data/ui/multiband_gate.glade:970 data/ui/multiband_gate.glade:1380
-#: data/ui/multiband_gate.glade:1790
+#: data/ui/multiband_compressor.glade:1293
+#: data/ui/multiband_compressor.glade:1673 data/ui/multiband_gate.glade:563
+#: data/ui/multiband_gate.glade:971 data/ui/multiband_gate.glade:1384
+#: data/ui/multiband_gate.glade:1797
 msgid "Attack"
 msgstr "Ataque"
 
@@ -520,210 +519,209 @@ msgstr "Para Cima"
 msgid "Compression Mode"
 msgstr "Modo de Compressão"
 
-#: data/ui/compressor.glade:551
+#: data/ui/compressor.glade:552
 msgid "Pre-amplification"
 msgstr "Pré-amplificação"
 
-#: data/ui/compressor.glade:585
+#: data/ui/compressor.glade:586
 msgid "Reactivity"
 msgstr "Reatividade"
 
-#: data/ui/compressor.glade:619 data/ui/limiter.glade:323
+#: data/ui/compressor.glade:620 data/ui/limiter.glade:324
 msgid "Lookahead"
 msgstr "Lookahead"
 
-#: data/ui/compressor.glade:632
+#: data/ui/compressor.glade:633
 msgid "Feed-forward"
 msgstr "Feed-forward"
 
-#: data/ui/compressor.glade:633
+#: data/ui/compressor.glade:634
 msgid "Feed-back"
 msgstr "Feed-back"
 
-#: data/ui/compressor.glade:647 data/ui/equalizer_band.glade:48
+#: data/ui/compressor.glade:648 data/ui/equalizer_band.glade:48
 msgid "Type"
 msgstr "Tipo"
 
-#: data/ui/compressor.glade:661 data/ui/deesser.glade:244
-#: data/ui/deesser.glade:354 data/ui/gate.glade:257
-#: data/ui/multiband_compressor.glade:514
+#: data/ui/compressor.glade:662 data/ui/deesser.glade:241
+#: data/ui/gate.glade:213 data/ui/multiband_compressor.glade:512
 #: data/ui/multiband_compressor.glade:886
-#: data/ui/multiband_compressor.glade:1264
-#: data/ui/multiband_compressor.glade:1642 data/ui/multiband_gate.glade:538
-#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1353
-#: data/ui/multiband_gate.glade:1763
+#: data/ui/multiband_compressor.glade:1266
+#: data/ui/multiband_compressor.glade:1646 data/ui/multiband_gate.glade:536
+#: data/ui/multiband_gate.glade:944 data/ui/multiband_gate.glade:1357
+#: data/ui/multiband_gate.glade:1770
 msgid "Peak"
 msgstr "Pico"
 
-#: data/ui/compressor.glade:662 data/ui/deesser.glade:243
-#: data/ui/gate.glade:256 data/ui/multiband_compressor.glade:513
+#: data/ui/compressor.glade:663 data/ui/deesser.glade:240
+#: data/ui/gate.glade:212 data/ui/multiband_compressor.glade:511
 #: data/ui/multiband_compressor.glade:885
-#: data/ui/multiband_compressor.glade:1263
-#: data/ui/multiband_compressor.glade:1641 data/ui/multiband_gate.glade:537
-#: data/ui/multiband_gate.glade:942 data/ui/multiband_gate.glade:1352
-#: data/ui/multiband_gate.glade:1762
+#: data/ui/multiband_compressor.glade:1265
+#: data/ui/multiband_compressor.glade:1645 data/ui/multiband_gate.glade:535
+#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1356
+#: data/ui/multiband_gate.glade:1769
 msgid "RMS"
 msgstr "RMS"
 
-#: data/ui/compressor.glade:663
+#: data/ui/compressor.glade:664
 msgid "Low-Pass"
 msgstr "Passa-Baixa"
 
-#: data/ui/compressor.glade:664
+#: data/ui/compressor.glade:665
 msgid "Uniform"
 msgstr "Uniforme"
 
-#: data/ui/compressor.glade:678 data/ui/deesser.glade:230
-#: data/ui/equalizer.glade:224 data/ui/equalizer_band.glade:79
-#: data/ui/multiband_compressor.glade:324 data/ui/multiband_gate.glade:348
-#: data/ui/stereo_tools.glade:485 data/ui/webrtc.glade:376
+#: data/ui/compressor.glade:679 data/ui/deesser.glade:227
+#: data/ui/equalizer.glade:225 data/ui/equalizer_band.glade:79
+#: data/ui/multiband_compressor.glade:322 data/ui/multiband_gate.glade:346
+#: data/ui/stereo_tools.glade:486 data/ui/webrtc.glade:377
 msgid "Mode"
 msgstr "Modo"
 
-#: data/ui/compressor.glade:692
+#: data/ui/compressor.glade:693
 msgid "Middle"
 msgstr "Meio"
 
-#: data/ui/compressor.glade:693
+#: data/ui/compressor.glade:694
 msgid "Side"
 msgstr "Lado"
 
-#: data/ui/compressor.glade:694 data/ui/delay.glade:157
-#: data/ui/equalizer.glade:474 data/ui/stereo_tools.glade:548
+#: data/ui/compressor.glade:695 data/ui/delay.glade:158
+#: data/ui/equalizer.glade:475 data/ui/stereo_tools.glade:549
 msgid "Left"
 msgstr "Esquerda"
 
-#: data/ui/compressor.glade:695 data/ui/delay.glade:189
-#: data/ui/equalizer.glade:515 data/ui/stereo_tools.glade:620
+#: data/ui/compressor.glade:696 data/ui/delay.glade:190
+#: data/ui/equalizer.glade:516 data/ui/stereo_tools.glade:621
 msgid "Right"
 msgstr "Direita"
 
-#: data/ui/compressor.glade:709
+#: data/ui/compressor.glade:710
 msgid "Source"
 msgstr "Fonte"
 
-#: data/ui/compressor.glade:725 data/ui/compressor.glade:1167
+#: data/ui/compressor.glade:726 data/ui/compressor.glade:1170
 msgid "Sidechain"
 msgstr "Cadeia Lateral"
 
-#: data/ui/compressor.glade:821
+#: data/ui/compressor.glade:824
 msgid "Relative Release Threshold"
 msgstr ""
 
-#: data/ui/compressor.glade:832
+#: data/ui/compressor.glade:835
 #, fuzzy
 msgid "Boost Threshold"
 msgstr "Limiar"
 
-#: data/ui/compressor.glade:843
+#: data/ui/compressor.glade:846
 #, fuzzy
 msgid "High-pass Frequency"
 msgstr "Frequências Mais Altas"
 
-#: data/ui/compressor.glade:854
+#: data/ui/compressor.glade:857
 #, fuzzy
 msgid "Low-pass Frequency"
 msgstr "Frequências Mais Baixas"
 
-#: data/ui/compressor.glade:865
+#: data/ui/compressor.glade:868
 #, fuzzy
 msgid "High-pass Filter Mode"
 msgstr "Filtro Passa-Alta"
 
-#: data/ui/compressor.glade:876
+#: data/ui/compressor.glade:879
 msgid "Low-pass Filter Mode"
 msgstr ""
 
-#: data/ui/compressor.glade:889 data/ui/compressor.glade:906
+#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
 #: data/ui/equalizer_band.glade:60
 msgid "Off"
 msgstr "Desligado"
 
-#: data/ui/compressor.glade:890 data/ui/compressor.glade:907
+#: data/ui/compressor.glade:893 data/ui/compressor.glade:910
 #, fuzzy
 msgid "12 dB/oct"
 msgstr "12dB/oct Passa-Baixa"
 
-#: data/ui/compressor.glade:891 data/ui/compressor.glade:908
+#: data/ui/compressor.glade:894 data/ui/compressor.glade:911
 #, fuzzy
 msgid "24 dB/oct"
 msgstr "24dB/oct Passa-Baixa"
 
-#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
+#: data/ui/compressor.glade:895 data/ui/compressor.glade:912
 #, fuzzy
 msgid "36 dB/oct"
 msgstr "36dB/oct Passa-Baixa"
 
-#: data/ui/compressor.glade:932
+#: data/ui/compressor.glade:935
 #, fuzzy
 msgid "Advanced"
 msgstr "Configurações Avançadas"
 
-#: data/ui/compressor.glade:1243
+#: data/ui/compressor.glade:1244
 msgid "Curve"
 msgstr "Curva"
 
-#: data/ui/convolver.glade:91
+#: data/ui/convolver.glade:92
 msgid "Convolver"
 msgstr "Convolver"
 
-#: data/ui/convolver.glade:125
+#: data/ui/convolver.glade:126
 msgid "Import Impulse"
 msgstr "Importar Impulso"
 
-#: data/ui/convolver.glade:129
+#: data/ui/convolver.glade:130
 msgid "Import Impulse Response File"
 msgstr "Arquivo da Resposta de Impulso"
 
-#: data/ui/convolver.glade:247
+#: data/ui/convolver.glade:248
 msgid "L"
 msgstr "L"
 
-#: data/ui/convolver.glade:261
+#: data/ui/convolver.glade:262
 msgid "R"
 msgstr "R"
 
-#: data/ui/convolver.glade:324
+#: data/ui/convolver.glade:325
 msgid "Duration"
 msgstr "Duração"
 
-#: data/ui/convolver.glade:335
+#: data/ui/convolver.glade:336
 msgid "Samples"
 msgstr "Amostras"
 
-#: data/ui/convolver.glade:367 src/convolver_ui.cpp:283
+#: data/ui/convolver.glade:368 src/convolver_ui.cpp:283
 msgid "Impulse Response"
 msgstr "Resposta de Impulso"
 
-#: data/ui/convolver.glade:389
+#: data/ui/convolver.glade:390
 msgid "Select the impulse Response File"
 msgstr "Selecione o Arquivo com a Resposta de Impulso"
 
-#: data/ui/convolver.glade:409 src/spectrum_settings_ui.cpp:176
+#: data/ui/convolver.glade:410 src/spectrum_settings_ui.cpp:176
 msgid "Spectrum"
 msgstr "Espectro"
 
-#: data/ui/convolver.glade:450
+#: data/ui/convolver.glade:451
 msgid "Stereo Width"
 msgstr "Largura do Stereo"
 
-#: data/ui/crossfeed.glade:63
+#: data/ui/crossfeed.glade:62
 msgid "Jmeier"
 msgstr "Jmeier"
 
-#: data/ui/crossfeed.glade:76 data/ui/filter.glade:183 data/ui/reverb.glade:259
+#: data/ui/crossfeed.glade:75 data/ui/filter.glade:184 data/ui/reverb.glade:260
 msgid "Default"
 msgstr "Padrão"
 
-#: data/ui/crossfeed.glade:89
+#: data/ui/crossfeed.glade:88
 msgid "Cmoy"
 msgstr "Cmoy"
 
-#: data/ui/crossfeed.glade:120
+#: data/ui/crossfeed.glade:119
 msgid "Cutoff"
 msgstr "Corte"
 
-#: data/ui/crossfeed.glade:153
+#: data/ui/crossfeed.glade:152
 msgid "Feed"
 msgstr "Alimentação"
 
@@ -731,115 +729,132 @@ msgstr "Alimentação"
 msgid "Crossfeed"
 msgstr "Crossfeed"
 
-#: data/ui/crystalizer.glade:115
+#: data/ui/crystalizer.glade:92
 msgid "Crystalizer"
 msgstr "Cristalizador"
 
-#: data/ui/crystalizer.glade:187
+#: data/ui/crystalizer.glade:137
 msgid "Aggressive Mode"
 msgstr "Modo Agressivo"
 
-#: data/ui/crystalizer.glade:447
+#: data/ui/crystalizer.glade:395
 msgid "Loudness Range"
 msgstr "Faixa de Sonoridade"
 
-#: data/ui/crystalizer.glade:466
+#: data/ui/crystalizer.glade:414
 msgid "Before"
 msgstr "Antes"
 
-#: data/ui/crystalizer.glade:479
+#: data/ui/crystalizer.glade:427
 msgid "After"
 msgstr "Depois"
 
 #: data/ui/crystalizer_band.glade:27 data/ui/equalizer_band.glade:313
-#: data/ui/stereo_tools.glade:574 data/ui/stereo_tools.glade:633
+#: data/ui/stereo_tools.glade:575 data/ui/stereo_tools.glade:634
 msgid "Mute"
 msgstr "Mudo"
 
-#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:483
+#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:481
 #: data/ui/multiband_compressor.glade:855
-#: data/ui/multiband_compressor.glade:1233
-#: data/ui/multiband_compressor.glade:1611 data/ui/multiband_gate.glade:507
-#: data/ui/multiband_gate.glade:912 data/ui/multiband_gate.glade:1322
-#: data/ui/multiband_gate.glade:1732
+#: data/ui/multiband_compressor.glade:1235
+#: data/ui/multiband_compressor.glade:1615 data/ui/multiband_gate.glade:505
+#: data/ui/multiband_gate.glade:913 data/ui/multiband_gate.glade:1326
+#: data/ui/multiband_gate.glade:1739
 msgid "Bypass"
 msgstr "Ignorar"
 
-#: data/ui/deesser.glade:128
+#: data/ui/deesser.glade:127
 msgid "Deesser"
 msgstr "Deesser"
 
-#: data/ui/deesser.glade:216 data/ui/gate.glade:195
+#: data/ui/deesser.glade:213 data/ui/gate.glade:198
 msgid "Detection"
 msgstr "Detecção"
 
-#: data/ui/deesser.glade:258
+#: data/ui/deesser.glade:255
 msgid "Wide"
 msgstr "Amplo"
 
-#: data/ui/deesser.glade:259 data/ui/deesser.glade:288
+#: data/ui/deesser.glade:256
 msgid "Split"
 msgstr "Separado"
 
-#: data/ui/deesser.glade:407
-msgid "Level"
+#: data/ui/deesser.glade:285
+#, fuzzy
+msgid "F1 Split"
+msgstr "Separado"
+
+#: data/ui/deesser.glade:318
+#, fuzzy
+msgid "F1 Gain"
+msgstr "Ganho"
+
+#: data/ui/deesser.glade:352
+#, fuzzy
+msgid "F2 Peak"
+msgstr "Pico"
+
+#: data/ui/deesser.glade:406
+#, fuzzy
+msgid "F2 Level"
 msgstr "Nível"
 
-#: data/ui/deesser.glade:420
-msgid "Peak Q"
+#: data/ui/deesser.glade:419
+#, fuzzy
+msgid "F2 Peak Q"
 msgstr "Pico Q"
 
-#: data/ui/deesser.glade:452
+#: data/ui/deesser.glade:451
 msgid "Laxity"
 msgstr "Frouxidão"
 
-#: data/ui/deesser.glade:778 data/ui/multiband_gate.glade:767
-#: data/ui/multiband_gate.glade:1197 data/ui/multiband_gate.glade:1607
-#: data/ui/multiband_gate.glade:2017
+#: data/ui/deesser.glade:779 data/ui/multiband_gate.glade:767
+#: data/ui/multiband_gate.glade:1201 data/ui/multiband_gate.glade:1614
+#: data/ui/multiband_gate.glade:2027
 msgid "Reduction"
 msgstr "Redução"
 
-#: data/ui/deesser.glade:791
+#: data/ui/deesser.glade:792
 msgid "Detected"
 msgstr "Detectado"
 
-#: data/ui/delay.glade:91
+#: data/ui/delay.glade:92
 msgid "Delay"
 msgstr "Atraso"
 
-#: data/ui/equalizer.glade:44
+#: data/ui/equalizer.glade:45
 msgid "Equalizer"
 msgstr "Equalizador"
 
-#: data/ui/equalizer.glade:153
+#: data/ui/equalizer.glade:154
 msgid "Split Channels"
 msgstr "Canais Separados"
 
-#: data/ui/equalizer.glade:179
+#: data/ui/equalizer.glade:180
 msgid "IIR"
 msgstr "IIR"
 
-#: data/ui/equalizer.glade:180
+#: data/ui/equalizer.glade:181
 msgid "FIR"
 msgstr "FIR"
 
-#: data/ui/equalizer.glade:181
+#: data/ui/equalizer.glade:182
 msgid "FFT"
 msgstr "FFT"
 
-#: data/ui/equalizer.glade:211
+#: data/ui/equalizer.glade:212
 msgid "Bands"
 msgstr "Bandas"
 
-#: data/ui/equalizer.glade:233
+#: data/ui/equalizer.glade:234
 msgid "Flat Response"
 msgstr "Resposta Plana"
 
-#: data/ui/equalizer.glade:248
+#: data/ui/equalizer.glade:249
 msgid "Calculate Frequencies"
 msgstr "Calcular Frequências"
 
-#: data/ui/equalizer.glade:262
+#: data/ui/equalizer.glade:263
 #, fuzzy
 msgid "Import APO Presets"
 msgstr "Importar Predefinições"
@@ -868,7 +883,7 @@ msgstr "Low Shelf"
 msgid "Notch"
 msgstr "Rejeita-faixa"
 
-#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:314
+#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:315
 msgid "Resonance"
 msgstr "Ressonância"
 
@@ -912,12 +927,12 @@ msgstr "Qualidade"
 msgid "Width"
 msgstr "Largura"
 
-#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:496
+#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:494
 #: data/ui/multiband_compressor.glade:868
-#: data/ui/multiband_compressor.glade:1246
-#: data/ui/multiband_compressor.glade:1624 data/ui/multiband_gate.glade:520
-#: data/ui/multiband_gate.glade:925 data/ui/multiband_gate.glade:1335
-#: data/ui/multiband_gate.glade:1745
+#: data/ui/multiband_compressor.glade:1248
+#: data/ui/multiband_compressor.glade:1628 data/ui/multiband_gate.glade:518
+#: data/ui/multiband_gate.glade:926 data/ui/multiband_gate.glade:1339
+#: data/ui/multiband_gate.glade:1752
 msgid "Solo"
 msgstr "Sozinho"
 
@@ -925,79 +940,79 @@ msgstr "Sozinho"
 msgid "Apply"
 msgstr "Aplicar"
 
-#: data/ui/exciter.glade:117
+#: data/ui/exciter.glade:118
 msgid "Exciter"
 msgstr "Excitador"
 
-#: data/ui/exciter.glade:384 data/ui/maximizer.glade:165
+#: data/ui/exciter.glade:384 data/ui/maximizer.glade:166
 msgid "Ceiling"
 msgstr "Teto"
 
-#: data/ui/filter.glade:98
+#: data/ui/filter.glade:99
 msgid "Filter"
 msgstr "Filtro"
 
-#: data/ui/filter.glade:147
+#: data/ui/filter.glade:148
 msgid "Muted"
 msgstr "Mudo"
 
-#: data/ui/filter.glade:159 data/ui/reverb.glade:233
+#: data/ui/filter.glade:160 data/ui/reverb.glade:234
 msgid "Disco"
 msgstr "Discoteca"
 
-#: data/ui/filter.glade:171
+#: data/ui/filter.glade:172
 msgid "Distant Headphones"
 msgstr "Fones de Ouvido Distantes"
 
-#: data/ui/filter.glade:246
+#: data/ui/filter.glade:247
 msgid "12dB/oct Lowpass"
 msgstr "12dB/oct Passa-Baixa"
 
-#: data/ui/filter.glade:247
+#: data/ui/filter.glade:248
 msgid "24dB/oct Lowpass"
 msgstr "24dB/oct Passa-Baixa"
 
-#: data/ui/filter.glade:248
+#: data/ui/filter.glade:249
 msgid "36dB/oct Lowpass"
 msgstr "36dB/oct Passa-Baixa"
 
-#: data/ui/filter.glade:249
+#: data/ui/filter.glade:250
 msgid "12dB/oct Highpass"
 msgstr "12dB/oct Passa-Alta"
 
-#: data/ui/filter.glade:250
+#: data/ui/filter.glade:251
 msgid "24dB/oct Highpass"
 msgstr "24dB/oct Passa-Alta"
 
-#: data/ui/filter.glade:251
+#: data/ui/filter.glade:252
 msgid "36dB/oct Highpass"
 msgstr "36dB/oct Passa-Alta"
 
-#: data/ui/filter.glade:252
+#: data/ui/filter.glade:253
 msgid "6dB/oct Bandpass"
 msgstr "6dB/oct Passa-Banda"
 
-#: data/ui/filter.glade:253
+#: data/ui/filter.glade:254
 msgid "12dB/oct Bandpass"
 msgstr "12dB/oct Passa-Banda"
 
-#: data/ui/filter.glade:254
+#: data/ui/filter.glade:255
 msgid "18dB/oct Bandpass"
 msgstr "18dB/oct Passa-Banda"
 
-#: data/ui/filter.glade:255
+#: data/ui/filter.glade:256
 msgid "6dB/oct Bandreject"
 msgstr "6dB/oct Rejeita-Faixa"
 
-#: data/ui/filter.glade:256
+#: data/ui/filter.glade:257
 msgid "12dB/oct Bandreject"
 msgstr "12dB/oct Rejeita-Faixa"
 
-#: data/ui/filter.glade:257
+#: data/ui/filter.glade:258
 msgid "18dB/oct Bandreject"
 msgstr "18dB/oct Rejeita-Faixa"
 
-#: data/ui/filter.glade:349
+#: data/ui/filter.glade:350
 msgid "Inertia"
 msgstr "Inércia"
 
@@ -1041,50 +1056,51 @@ msgstr "Processar Todas as Entradas"
 msgid "Priority"
 msgstr "Prioridade"
 
-#: data/ui/gate.glade:98
+#: data/ui/gate.glade:99
 msgid "Gate"
 msgstr "Gate"
 
-#: data/ui/gate.glade:209
+#: data/ui/gate.glade:240
+#, fuzzy
+msgid "Maximum Gain Reduction"
+msgstr "Redução de Ganho"
+
+#: data/ui/gate.glade:289
 msgid "Stereo Link"
 msgstr "Elo Stereo"
 
-#: data/ui/gate.glade:222 data/ui/maximizer.glade:293
-msgid "Gain Reduction"
-msgstr "Redução de Ganho"
-
-#: data/ui/gate.glade:273
+#: data/ui/gate.glade:304
 msgid "Average"
 msgstr "Médio"
 
-#: data/ui/gate.glade:274
+#: data/ui/gate.glade:305
 msgid "Maximum"
 msgstr "Máximo"
 
-#: data/ui/gate.glade:525
+#: data/ui/gate.glade:578
 #, fuzzy
 msgid "Input Level"
 msgstr "Dispositivo de Entrada"
 
-#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:811
-#: data/ui/multiband_gate.glade:1220 data/ui/multiband_gate.glade:1630
-#: data/ui/multiband_gate.glade:2040
+#: data/ui/gate.glade:797 data/ui/multiband_gate.glade:812
+#: data/ui/multiband_gate.glade:1224 data/ui/multiband_gate.glade:1637
+#: data/ui/multiband_gate.glade:2050
 msgid "Gating"
 msgstr "Gating"
 
-#: data/ui/limiter.glade:97 data/ui/webrtc.glade:421
+#: data/ui/limiter.glade:98 data/ui/webrtc.glade:422
 msgid "Limiter"
 msgstr "Limitador"
 
-#: data/ui/limiter.glade:176
+#: data/ui/limiter.glade:175
 msgid "Automatic Smoothing Control"
 msgstr ""
 
-#: data/ui/limiter.glade:190
+#: data/ui/limiter.glade:189
 msgid "Automatic Leveling"
 msgstr ""
 
-#: data/ui/limiter.glade:222
+#: data/ui/limiter.glade:221
 msgid "Input Gain"
 msgstr "Ganho de Entrada"
 
@@ -1092,136 +1108,140 @@ msgstr "Ganho de Entrada"
 msgid "Limit"
 msgstr "Limite"
 
-#: data/ui/limiter.glade:358
+#: data/ui/limiter.glade:359
 msgid "Oversampling"
 msgstr "Oversampling"
 
-#: data/ui/limiter.glade:411
+#: data/ui/limiter.glade:413
 #, fuzzy
 msgid "Output Gain"
 msgstr "Ganho de Entrada"
 
-#: data/ui/limiter.glade:429
+#: data/ui/limiter.glade:431
 msgid "ASC"
 msgstr "ASC"
 
-#: data/ui/limiter.glade:584
+#: data/ui/limiter.glade:586
 msgid "Attenuation"
 msgstr "Atenuação"
 
-#: data/ui/loudness.glade:91
+#: data/ui/loudness.glade:92
 msgid "Loudness Compensator"
 msgstr ""
 
-#: data/ui/loudness.glade:147
-msgid "Standard"
-msgstr ""
-
-#: data/ui/loudness.glade:161
-msgid "Flat"
-msgstr "Plano"
-
-#: data/ui/loudness.glade:162
-msgid "ISO226-2003"
-msgstr ""
-
-#: data/ui/loudness.glade:163
-msgid "Fletcher-Munson"
-msgstr ""
-
-#: data/ui/loudness.glade:164
-msgid "Robinson-Dadson"
-msgstr ""
-
-#: data/ui/loudness.glade:174
-msgid "Reference Signal"
-msgstr ""
-
-#: data/ui/loudness.glade:199
+#: data/ui/loudness.glade:155
 #, fuzzy
 msgid "FFT Size"
 msgstr "Tamanho do Quadro"
 
-#: data/ui/maximizer.glade:96
+#: data/ui/loudness.glade:205
+msgid "Standard"
+msgstr ""
+
+#: data/ui/loudness.glade:220
+msgid "Flat"
+msgstr "Plano"
+
+#: data/ui/loudness.glade:221
+msgid "ISO226-2003"
+msgstr ""
+
+#: data/ui/loudness.glade:222
+msgid "Fletcher-Munson"
+msgstr ""
+
+#: data/ui/loudness.glade:223
+msgid "Robinson-Dadson"
+msgstr ""
+
+#: data/ui/loudness.glade:259
+msgid "Reference Signal"
+msgstr ""
+
+#: data/ui/maximizer.glade:97
 msgid "Maximizer"
 msgstr "Maximizador"
 
-#: data/ui/multiband_compressor.glade:140
+#: data/ui/maximizer.glade:296
+msgid "Gain Reduction"
+msgstr "Redução de Ganho"
+
+#: data/ui/multiband_compressor.glade:141
 msgid "Multiband Compressor"
 msgstr "Compressor Multibandas"
 
-#: data/ui/multiband_compressor.glade:338 data/ui/multiband_gate.glade:362
+#: data/ui/multiband_compressor.glade:336 data/ui/multiband_gate.glade:360
 msgid "LR4"
 msgstr "LR4"
 
-#: data/ui/multiband_compressor.glade:339 data/ui/multiband_gate.glade:363
+#: data/ui/multiband_compressor.glade:337 data/ui/multiband_gate.glade:361
 msgid "LR8"
 msgstr "LR8"
 
-#: data/ui/multiband_compressor.glade:353 data/ui/multiband_gate.glade:377
+#: data/ui/multiband_compressor.glade:351 data/ui/multiband_gate.glade:375
 msgid "Split 1/2"
 msgstr "Disivão 1/2"
 
-#: data/ui/multiband_compressor.glade:366 data/ui/multiband_gate.glade:390
+#: data/ui/multiband_compressor.glade:364 data/ui/multiband_gate.glade:388
 msgid "Split 2/3"
 msgstr "Disivão 2/3"
 
-#: data/ui/multiband_compressor.glade:379 data/ui/multiband_gate.glade:403
+#: data/ui/multiband_compressor.glade:377 data/ui/multiband_gate.glade:401
 msgid "Split 3/4"
 msgstr "Disivão 3/4"
 
 #: data/ui/multiband_compressor.glade:754
-#: data/ui/multiband_compressor.glade:1131
-#: data/ui/multiband_compressor.glade:1509
-#: data/ui/multiband_compressor.glade:1887
+#: data/ui/multiband_compressor.glade:1133
+#: data/ui/multiband_compressor.glade:1513
+#: data/ui/multiband_compressor.glade:1893
 msgid "Compression"
 msgstr "Compressão"
 
-#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:894
+#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:895
 msgid "Sub Band"
 msgstr "Banda"
 
-#: data/ui/multiband_compressor.glade:1214 data/ui/multiband_gate.glade:1303
+#: data/ui/multiband_compressor.glade:1216 data/ui/multiband_gate.glade:1307
 msgid "Low Band"
 msgstr "Banda Baixa"
 
-#: data/ui/multiband_compressor.glade:1592 data/ui/multiband_gate.glade:1713
+#: data/ui/multiband_compressor.glade:1596 data/ui/multiband_gate.glade:1720
 msgid "Mid Band"
 msgstr "Banda Média"
 
-#: data/ui/multiband_compressor.glade:1970 data/ui/multiband_gate.glade:2123
+#: data/ui/multiband_compressor.glade:1976 data/ui/multiband_gate.glade:2133
 msgid "High Band"
 msgstr "Banda Alta"
 
-#: data/ui/multiband_gate.glade:140
+#: data/ui/multiband_gate.glade:141
 msgid "Multiband Gate"
 msgstr "Gate Multibandas"
 
-#: data/ui/pitch.glade:103
+#: data/ui/pitch.glade:104
 msgid "Pitch"
 msgstr "Altura"
 
-#: data/ui/pitch.glade:178
+#: data/ui/pitch.glade:179
 msgid "Cents"
 msgstr "Cents"
 
-#: data/ui/pitch.glade:209
+#: data/ui/pitch.glade:210
 msgid "Semitones"
 msgstr "Semitons"
 
-#: data/ui/pitch.glade:240
+#: data/ui/pitch.glade:241
 msgid "Octaves"
 msgstr "Oitavas"
 
-#: data/ui/pitch.glade:271
+#: data/ui/pitch.glade:272
 msgid "Crispness"
 msgstr "Clareza"
 
-#: data/ui/pitch.glade:311
+#: data/ui/pitch.glade:312
 msgid "Faster"
 msgstr "Mais Rápido"
 
-#: data/ui/pitch.glade:325
+#: data/ui/pitch.glade:326
 msgid "Preserve Formant"
 msgstr "Preservar Formante"
 
@@ -1318,83 +1338,83 @@ msgstr "Entrada da Pipeline"
 msgid "Pipeline Output"
 msgstr "Saída da Pipeline"
 
-#: data/ui/reverb.glade:131
+#: data/ui/reverb.glade:132
 msgid "Reverberation"
 msgstr "Reverberação"
 
-#: data/ui/reverb.glade:181
+#: data/ui/reverb.glade:182
 msgid "Ambience"
 msgstr "Ambiente"
 
-#: data/ui/reverb.glade:194
+#: data/ui/reverb.glade:195
 msgid "Empty Walls"
 msgstr "Paredes Vazias"
 
-#: data/ui/reverb.glade:207
+#: data/ui/reverb.glade:208
 msgid "Room"
 msgstr "Quarto"
 
-#: data/ui/reverb.glade:220
+#: data/ui/reverb.glade:221
 msgid "Large Empty Hall"
 msgstr "Grande Salão Vazio"
 
-#: data/ui/reverb.glade:246
+#: data/ui/reverb.glade:247
 msgid "Large Occupied Hall"
 msgstr "Grande Salão Ocupado"
 
-#: data/ui/reverb.glade:361
+#: data/ui/reverb.glade:362
 msgid "Pre Delay"
 msgstr "Pré Atraso"
 
-#: data/ui/reverb.glade:374
+#: data/ui/reverb.glade:375
 msgid "Decay Time"
 msgstr "Tempo de Decaimento"
 
-#: data/ui/reverb.glade:439
+#: data/ui/reverb.glade:441
 msgid "Dry"
 msgstr "Seco"
 
-#: data/ui/reverb.glade:471
+#: data/ui/reverb.glade:474
 msgid "Bass Cut"
 msgstr "Corte de Grave"
 
-#: data/ui/reverb.glade:522
+#: data/ui/reverb.glade:525
 msgid "Treble Cut"
 msgstr "Corte de Agudo"
 
-#: data/ui/reverb.glade:565
+#: data/ui/reverb.glade:568
 msgid "Diffusion"
 msgstr "Difusão"
 
-#: data/ui/reverb.glade:577
+#: data/ui/reverb.glade:580
 msgid "Room Size"
 msgstr "Tamanho do quarto"
 
-#: data/ui/reverb.glade:590
+#: data/ui/reverb.glade:593
 msgid "Small"
 msgstr "Pequeno"
 
-#: data/ui/reverb.glade:591
+#: data/ui/reverb.glade:594
 msgid "Medium"
 msgstr "Médio"
 
-#: data/ui/reverb.glade:592
+#: data/ui/reverb.glade:595
 msgid "Large"
 msgstr "Grande"
 
-#: data/ui/reverb.glade:593
+#: data/ui/reverb.glade:596
 msgid "Tunnel"
 msgstr "Túnel"
 
-#: data/ui/reverb.glade:594
+#: data/ui/reverb.glade:597
 msgid "Large/smooth"
 msgstr "Grande/Suave"
 
-#: data/ui/reverb.glade:595
+#: data/ui/reverb.glade:598
 msgid "Experimental"
 msgstr "Experimental"
 
-#: data/ui/reverb.glade:608
+#: data/ui/reverb.glade:611
 msgid "High Frequency Damping"
 msgstr "Amortecimento de Alta Frequência"
 
@@ -1468,23 +1488,23 @@ msgstr "Altura"
 msgid "Points"
 msgstr "Pontos"
 
-#: data/ui/stereo_tools.glade:109
+#: data/ui/stereo_tools.glade:110
 msgid "Stereo Tools"
 msgstr "Ferramentas Stereo"
 
-#: data/ui/stereo_tools.glade:231
+#: data/ui/stereo_tools.glade:230
 msgid "Softclip"
 msgstr "Clipe Macio"
 
-#: data/ui/stereo_tools.glade:255 data/ui/stereo_tools.glade:671
+#: data/ui/stereo_tools.glade:254 data/ui/stereo_tools.glade:672
 msgid "Balance"
 msgstr "Balanço"
 
-#: data/ui/stereo_tools.glade:287
+#: data/ui/stereo_tools.glade:286
 msgid "S/C Level"
 msgstr "Nível de S/C"
 
-#: data/ui/stereo_tools.glade:345
+#: data/ui/stereo_tools.glade:344
 msgid "Side Level"
 msgstr "Nível Lateral"
 
@@ -1492,144 +1512,144 @@ msgstr "Nível Lateral"
 msgid "Side Balance"
 msgstr "Balanço Lateral"
 
-#: data/ui/stereo_tools.glade:428
+#: data/ui/stereo_tools.glade:429
 msgid "Middle Level"
 msgstr "Nível do Meio"
 
-#: data/ui/stereo_tools.glade:441
+#: data/ui/stereo_tools.glade:442
 msgid "Middle Panorama"
 msgstr "Panorama do Meio"
 
-#: data/ui/stereo_tools.glade:499
+#: data/ui/stereo_tools.glade:500
 msgid "LR > LR (Stereo Default)"
 msgstr "ED > ED (Stereo Padrão)"
 
-#: data/ui/stereo_tools.glade:500
+#: data/ui/stereo_tools.glade:501
 msgid "LR > MS (Stereo to Mid-Side)"
 msgstr "ED > ML (Stereo para Meio-Lado)"
 
-#: data/ui/stereo_tools.glade:501
+#: data/ui/stereo_tools.glade:502
 msgid "MS > LR (Mid-Side to Stereo)"
 msgstr "ML > ED (Meio-Lado para Stereo)"
 
-#: data/ui/stereo_tools.glade:502
+#: data/ui/stereo_tools.glade:503
 msgid "LR > LL (Mono Left Channel)"
 msgstr "ED > EE (Canal Esquerdo Mono)"
 
-#: data/ui/stereo_tools.glade:503
+#: data/ui/stereo_tools.glade:504
 msgid "LR > RR (Mono Right Channel)"
 msgstr "ED > DD (Canal Direito Mono)"
 
-#: data/ui/stereo_tools.glade:504
+#: data/ui/stereo_tools.glade:505
 msgid "LR > L+R (Mono Sum L+R)"
 msgstr "ED > E+D (Soma Mono E+D)"
 
-#: data/ui/stereo_tools.glade:505
+#: data/ui/stereo_tools.glade:506
 msgid "LR > RL (Stereo Flip Channels)"
 msgstr "ED > DL (Alternar Canais Stereo)"
 
-#: data/ui/stereo_tools.glade:522
+#: data/ui/stereo_tools.glade:523
 msgid "Stereo Matrix"
 msgstr "Matriz Stereo"
 
-#: data/ui/stereo_tools.glade:561 data/ui/stereo_tools.glade:602
+#: data/ui/stereo_tools.glade:562 data/ui/stereo_tools.glade:603
 msgid "Invert Phase"
 msgstr "Inverter Fase"
 
-#: data/ui/stereo_tools.glade:703
+#: data/ui/stereo_tools.glade:704
 msgid "Delay L/R"
 msgstr "Atraso E/D"
 
-#: data/ui/stereo_tools.glade:737
+#: data/ui/stereo_tools.glade:738
 msgid "Stereo Base"
 msgstr "Base Stereo"
 
-#: data/ui/stereo_tools.glade:770
+#: data/ui/stereo_tools.glade:771
 msgid "Stereo Phase"
 msgstr "Fase Stereo"
 
-#: data/ui/webrtc.glade:97
+#: data/ui/webrtc.glade:98
 msgid "WebRTC"
 msgstr ""
 
-#: data/ui/webrtc.glade:163 data/ui/webrtc.glade:283 data/ui/webrtc.glade:353
-#: data/ui/webrtc.glade:523
+#: data/ui/webrtc.glade:164 data/ui/webrtc.glade:284 data/ui/webrtc.glade:354
+#: data/ui/webrtc.glade:524
 msgid "Enable"
 msgstr "Habilitar"
 
-#: data/ui/webrtc.glade:184
+#: data/ui/webrtc.glade:185
 msgid "Extended Filter"
 msgstr "Filtro Estendido"
 
-#: data/ui/webrtc.glade:197
+#: data/ui/webrtc.glade:198
 msgid "Delay Agnostic"
 msgstr "Atraso Agnóstico"
 
-#: data/ui/webrtc.glade:209
+#: data/ui/webrtc.glade:210
 msgid "High Pass Filter"
 msgstr "Filtro Passa-Alta"
 
-#: data/ui/webrtc.glade:238 data/ui/webrtc.glade:306
+#: data/ui/webrtc.glade:239 data/ui/webrtc.glade:307
 msgid "Suppresion Level"
 msgstr "Nível de Supressão"
 
-#: data/ui/webrtc.glade:251 data/ui/webrtc.glade:319 data/ui/webrtc.glade:575
+#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
 msgid "Low"
 msgstr "Baixo"
 
-#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
+#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
 msgid "Moderate"
 msgstr "Moderado"
 
-#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
+#: data/ui/webrtc.glade:254 data/ui/webrtc.glade:322 data/ui/webrtc.glade:578
 msgid "High"
 msgstr "Alto"
 
-#: data/ui/webrtc.glade:270
+#: data/ui/webrtc.glade:271
 msgid "Echo Canceller"
 msgstr "Cancelador de Eco"
 
-#: data/ui/webrtc.glade:322
+#: data/ui/webrtc.glade:323
 msgid "Very High"
 msgstr "Muito Alto"
 
-#: data/ui/webrtc.glade:339
+#: data/ui/webrtc.glade:340
 msgid "Noise Suppressor"
 msgstr "Supressor de Ruído"
 
-#: data/ui/webrtc.glade:389
+#: data/ui/webrtc.glade:390
 msgid "Adaptive Digital"
 msgstr "Digital Adaptativo"
 
-#: data/ui/webrtc.glade:390
+#: data/ui/webrtc.glade:391
 msgid "Fixed Digital"
 msgstr "Digital Fixo"
 
-#: data/ui/webrtc.glade:407
+#: data/ui/webrtc.glade:408
 msgid "Gain Controller"
 msgstr "Controlador de Ganho"
 
-#: data/ui/webrtc.glade:445
+#: data/ui/webrtc.glade:446
 msgid "Target Level"
 msgstr "Nível Alvo"
 
-#: data/ui/webrtc.glade:475
+#: data/ui/webrtc.glade:476
 msgid "Maximum Gain"
 msgstr "Ganho Máximo"
 
-#: data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:549
 msgid "Detection Likelihood"
 msgstr "Probabilidade de Detecção"
 
-#: data/ui/webrtc.glade:561
+#: data/ui/webrtc.glade:562
 msgid "Frame Size"
 msgstr "Tamanho do Quadro"
 
-#: data/ui/webrtc.glade:574
+#: data/ui/webrtc.glade:575
 msgid "Very Low"
 msgstr "Muito Baixo"
 
-#: data/ui/webrtc.glade:611
+#: data/ui/webrtc.glade:612
 msgid "Voice Detector"
 msgstr "Detector de Voz"
 
@@ -1724,6 +1744,10 @@ msgstr "Geral"
 #: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
+
+#, fuzzy
+#~ msgid "Gain Detection"
+#~ msgstr "Redução de Ganho"
 
 #~ msgid "Scale"
 #~ msgstr "Escala"

--- a/po/pulseeffects.pot
+++ b/po/pulseeffects.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pulseeffects\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-22 15:29+0200\n"
+"POT-Creation-Date: 2020-08-24 16:51+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -72,8 +72,8 @@ msgid "Input Limiter"
 msgstr ""
 
 #: data/com.github.wwmm.pulseeffects.appdata.xml.in:52
-#: data/ui/compressor.glade:111 data/ui/compressor.glade:494
-#: data/ui/webrtc.glade:509
+#: data/ui/compressor.glade:112 data/ui/compressor.glade:494
+#: data/ui/webrtc.glade:510
 msgid "Compressor"
 msgstr ""
 
@@ -105,12 +105,12 @@ msgstr ""
 msgid "Format"
 msgstr ""
 
-#: data/ui/app_info.glade:75 data/ui/convolver.glade:283
+#: data/ui/app_info.glade:75 data/ui/convolver.glade:284
 msgid "Rate"
 msgstr ""
 
 #: data/ui/app_info.glade:102 data/ui/pulse_info.glade:238
-#: data/ui/stereo_tools.glade:653
+#: data/ui/stereo_tools.glade:654
 msgid "Channels"
 msgstr ""
 
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Global Bypass"
 msgstr ""
 
-#: data/ui/application.glade:170 data/ui/equalizer.glade:277
+#: data/ui/application.glade:170 data/ui/equalizer.glade:278
 #: data/ui/general_settings.glade:107
 msgid "Settings"
 msgstr ""
@@ -156,169 +156,168 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
-#: data/ui/application.glade:215 data/ui/crossfeed.glade:49
-#: data/ui/equalizer.glade:333 data/ui/filter.glade:230
-#: data/ui/reverb.glade:310 src/presets_menu_ui.cpp:113
+#: data/ui/application.glade:215 data/ui/crossfeed.glade:48
+#: data/ui/equalizer.glade:334 data/ui/filter.glade:231
+#: data/ui/reverb.glade:311 src/presets_menu_ui.cpp:113
 #: src/presets_menu_ui.cpp:258 src/presets_menu_ui.cpp:275
 msgid "Presets"
 msgstr ""
 
-#: data/ui/autogain.glade:91
+#: data/ui/autogain.glade:92
 msgid "Auto Gain"
 msgstr ""
 
-#: data/ui/autogain.glade:171
+#: data/ui/autogain.glade:172
 msgid "Reset History"
 msgstr ""
 
-#: data/ui/autogain.glade:183
+#: data/ui/autogain.glade:184
 msgid "Detect Silence"
 msgstr ""
 
-#: data/ui/autogain.glade:195
+#: data/ui/autogain.glade:196
 msgid "Use Geometric Mean"
 msgstr ""
 
-#: data/ui/autogain.glade:233
+#: data/ui/autogain.glade:234
 msgid "Target"
 msgstr ""
 
-#: data/ui/autogain.glade:283 data/ui/autogain.glade:627
+#: data/ui/autogain.glade:286 data/ui/autogain.glade:631
 msgid "Momentary"
 msgstr ""
 
-#: data/ui/autogain.glade:298 data/ui/autogain.glade:640
+#: data/ui/autogain.glade:301 data/ui/autogain.glade:644
 msgid "Short Term"
 msgstr ""
 
-#: data/ui/autogain.glade:313 data/ui/autogain.glade:653
+#: data/ui/autogain.glade:316 data/ui/autogain.glade:657
 msgid "Integrated"
 msgstr ""
 
-#: data/ui/autogain.glade:388
+#: data/ui/autogain.glade:394
 msgid "Weights"
 msgstr ""
 
-#: data/ui/autogain.glade:428 data/ui/autogain.glade:917
-#: data/ui/bass_enhancer.glade:504 data/ui/compressor.glade:974
-#: data/ui/convolver.glade:504 data/ui/crossfeed.glade:200
-#: data/ui/crystalizer.glade:255 data/ui/deesser.glade:593
-#: data/ui/delay.glade:236 data/ui/equalizer.glade:543
-#: data/ui/exciter.glade:510 data/ui/filter.glade:396 data/ui/gate.glade:558
-#: data/ui/limiter.glade:483 data/ui/loudness.glade:259
-#: data/ui/loudness.glade:338 data/ui/maximizer.glade:265
-#: data/ui/multiband_compressor.glade:2000 data/ui/multiband_gate.glade:2153
-#: data/ui/pitch.glade:362 data/ui/presets_menu.glade:255
-#: data/ui/reverb.glade:658 data/ui/stereo_tools.glade:323
-#: data/ui/stereo_tools.glade:829 data/ui/webrtc.glade:650
+#: data/ui/autogain.glade:434 data/ui/autogain.glade:921
+#: data/ui/bass_enhancer.glade:506 data/ui/compressor.glade:977
+#: data/ui/convolver.glade:505 data/ui/crossfeed.glade:199
+#: data/ui/crystalizer.glade:205 data/ui/deesser.glade:594
+#: data/ui/delay.glade:237 data/ui/equalizer.glade:544
+#: data/ui/exciter.glade:510 data/ui/filter.glade:397 data/ui/gate.glade:611
+#: data/ui/limiter.glade:485 data/ui/loudness.glade:299
+#: data/ui/loudness.glade:380 data/ui/maximizer.glade:268
+#: data/ui/multiband_compressor.glade:2006 data/ui/multiband_gate.glade:2163
+#: data/ui/pitch.glade:363 data/ui/presets_menu.glade:255
+#: data/ui/reverb.glade:661 data/ui/stereo_tools.glade:322
+#: data/ui/stereo_tools.glade:830 data/ui/webrtc.glade:651
 msgid "Input"
 msgstr ""
 
-#: data/ui/autogain.glade:443 data/ui/autogain.glade:862
-#: data/ui/bass_enhancer.glade:536 data/ui/compressor.glade:988
-#: data/ui/convolver.glade:519 data/ui/crossfeed.glade:214
-#: data/ui/crystalizer.glade:270 data/ui/deesser.glade:607
-#: data/ui/delay.glade:250 data/ui/equalizer.glade:557
-#: data/ui/exciter.glade:542 data/ui/filter.glade:411 data/ui/gate.glade:572
-#: data/ui/limiter.glade:626 data/ui/loudness.glade:292
-#: data/ui/loudness.glade:352 data/ui/maximizer.glade:279
+#: data/ui/autogain.glade:449 data/ui/autogain.glade:866
+#: data/ui/bass_enhancer.glade:537 data/ui/compressor.glade:991
+#: data/ui/convolver.glade:520 data/ui/crossfeed.glade:213
+#: data/ui/crystalizer.glade:220 data/ui/deesser.glade:608
+#: data/ui/delay.glade:251 data/ui/equalizer.glade:558
+#: data/ui/exciter.glade:541 data/ui/filter.glade:412 data/ui/gate.glade:625
+#: data/ui/limiter.glade:628 data/ui/loudness.glade:333
+#: data/ui/loudness.glade:394 data/ui/maximizer.glade:282
 #: data/ui/multiband_compressor.glade:794
-#: data/ui/multiband_compressor.glade:1171
-#: data/ui/multiband_compressor.glade:1549
-#: data/ui/multiband_compressor.glade:1927
-#: data/ui/multiband_compressor.glade:2015 data/ui/multiband_gate.glade:851
-#: data/ui/multiband_gate.glade:1260 data/ui/multiband_gate.glade:1670
-#: data/ui/multiband_gate.glade:2080 data/ui/multiband_gate.glade:2168
-#: data/ui/pitch.glade:376 data/ui/presets_menu.glade:146
-#: data/ui/reverb.glade:673 data/ui/stereo_tools.glade:800
-#: data/ui/stereo_tools.glade:843 data/ui/webrtc.glade:664
+#: data/ui/multiband_compressor.glade:1173
+#: data/ui/multiband_compressor.glade:1553
+#: data/ui/multiband_compressor.glade:1933
+#: data/ui/multiband_compressor.glade:2021 data/ui/multiband_gate.glade:852
+#: data/ui/multiband_gate.glade:1264 data/ui/multiband_gate.glade:1677
+#: data/ui/multiband_gate.glade:2090 data/ui/multiband_gate.glade:2178
+#: data/ui/pitch.glade:377 data/ui/presets_menu.glade:146
+#: data/ui/reverb.glade:676 data/ui/stereo_tools.glade:801
+#: data/ui/stereo_tools.glade:844 data/ui/webrtc.glade:665
 msgid "Output"
 msgstr ""
 
-#: data/ui/autogain.glade:744
+#: data/ui/autogain.glade:748
 msgid "Relative"
 msgstr ""
 
-#: data/ui/autogain.glade:757 data/ui/compressor.glade:1154
-#: data/ui/deesser.glade:321
+#: data/ui/autogain.glade:761 data/ui/compressor.glade:1157
 msgid "Gain"
 msgstr ""
 
-#: data/ui/autogain.glade:823
+#: data/ui/autogain.glade:827
 msgid "Loudness"
 msgstr ""
 
-#: data/ui/autogain.glade:876
+#: data/ui/autogain.glade:880
 msgid "Range"
 msgstr ""
 
-#: data/ui/autogain.glade:945 data/ui/bass_enhancer.glade:655
-#: data/ui/compressor.glade:1299 data/ui/convolver.glade:703
-#: data/ui/crossfeed.glade:395 data/ui/crystalizer.glade:566
-#: data/ui/deesser.glade:898 data/ui/delay.glade:434
-#: data/ui/equalizer.glade:743 data/ui/equalizer_band.glade:182
-#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:661
-#: data/ui/filter.glade:595 data/ui/general_settings.glade:116
-#: data/ui/gate.glade:809 data/ui/limiter.glade:733 data/ui/loudness.glade:573
-#: data/ui/maximizer.glade:516 data/ui/multiband_compressor.glade:2199
-#: data/ui/multiband_gate.glade:2352 data/ui/pitch.glade:560
-#: data/ui/reverb.glade:857 data/ui/stereo_tools.glade:1029
-#: data/ui/webrtc.glade:814
+#: data/ui/autogain.glade:949 data/ui/bass_enhancer.glade:650
+#: data/ui/compressor.glade:1300 data/ui/convolver.glade:702
+#: data/ui/crossfeed.glade:394 data/ui/crystalizer.glade:514
+#: data/ui/deesser.glade:899 data/ui/delay.glade:433
+#: data/ui/equalizer.glade:744 data/ui/equalizer_band.glade:182
+#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:654
+#: data/ui/filter.glade:594 data/ui/general_settings.glade:116
+#: data/ui/gate.glade:862 data/ui/limiter.glade:735 data/ui/loudness.glade:615
+#: data/ui/maximizer.glade:519 data/ui/multiband_compressor.glade:2203
+#: data/ui/multiband_gate.glade:2360 data/ui/pitch.glade:559
+#: data/ui/reverb.glade:858 data/ui/stereo_tools.glade:1028
+#: data/ui/webrtc.glade:815
 msgid "Reset"
 msgstr ""
 
-#: data/ui/autogain.glade:969
+#: data/ui/autogain.glade:973
 msgid "Based on"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:117
+#: data/ui/bass_enhancer.glade:118
 msgid "Bass Enhancer"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:169 data/ui/compressor.glade:506
-#: data/ui/deesser.glade:188 data/ui/exciter.glade:171
+#: data/ui/bass_enhancer.glade:170 data/ui/compressor.glade:506
+#: data/ui/deesser.glade:185 data/ui/exciter.glade:170
 msgid "Listen"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:210 data/ui/exciter.glade:213
+#: data/ui/bass_enhancer.glade:211 data/ui/exciter.glade:212
 msgid "3rd"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:222 data/ui/exciter.glade:225
+#: data/ui/bass_enhancer.glade:223 data/ui/exciter.glade:224
 msgid "2nd"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:234 data/ui/exciter.glade:237
+#: data/ui/bass_enhancer.glade:235 data/ui/exciter.glade:236
 msgid "Blend Harmonics"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:266 data/ui/exciter.glade:271
-#: data/ui/reverb.glade:407
+#: data/ui/bass_enhancer.glade:267 data/ui/exciter.glade:270
+#: data/ui/reverb.glade:408
 msgid "Amount"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:278 data/ui/bass_enhancer.glade:411
-#: data/ui/exciter.glade:284 data/ui/exciter.glade:417
+#: data/ui/bass_enhancer.glade:279 data/ui/bass_enhancer.glade:413
+#: data/ui/exciter.glade:283 data/ui/exciter.glade:417
 msgid "Harmonics"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:290 data/ui/exciter.glade:297
+#: data/ui/bass_enhancer.glade:291 data/ui/exciter.glade:296
 msgid "Scope"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:379
+#: data/ui/bass_enhancer.glade:381
 msgid "Floor"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:679 data/ui/compressor.glade:1323
-#: data/ui/crossfeed.glade:419 data/ui/deesser.glade:922
-#: data/ui/delay.glade:458 data/ui/equalizer.glade:767
-#: data/ui/exciter.glade:685 data/ui/filter.glade:619 data/ui/gate.glade:833
-#: data/ui/limiter.glade:757 data/ui/loudness.glade:542
-#: data/ui/maximizer.glade:540 data/ui/multiband_compressor.glade:2223
-#: data/ui/multiband_gate.glade:2376 data/ui/pitch.glade:584
-#: data/ui/reverb.glade:881 data/ui/stereo_tools.glade:1053
-#: data/ui/webrtc.glade:838
+#: data/ui/bass_enhancer.glade:674 data/ui/compressor.glade:1324
+#: data/ui/crossfeed.glade:418 data/ui/deesser.glade:923
+#: data/ui/delay.glade:457 data/ui/equalizer.glade:768
+#: data/ui/exciter.glade:678 data/ui/filter.glade:618 data/ui/gate.glade:886
+#: data/ui/limiter.glade:759 data/ui/loudness.glade:584
+#: data/ui/maximizer.glade:543 data/ui/multiband_compressor.glade:2227
+#: data/ui/multiband_gate.glade:2384 data/ui/pitch.glade:583
+#: data/ui/reverb.glade:882 data/ui/stereo_tools.glade:1052
+#: data/ui/webrtc.glade:839
 msgid "Provided by"
 msgstr ""
 
@@ -353,138 +352,138 @@ msgstr ""
 msgid "Show Blocklisted Apps in Main Tab"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:32 data/ui/equalizer_band.glade:152
-#: data/ui/filter.glade:280
+#: data/ui/calibration_signals.glade:30 data/ui/equalizer_band.glade:152
+#: data/ui/filter.glade:281
 msgid "Frequency"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:64
+#: data/ui/calibration_signals.glade:62
 msgid "Volume"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:108
+#: data/ui/calibration_signals.glade:106
 msgid "Sine"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:109
+#: data/ui/calibration_signals.glade:107
 msgid "Square"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:110
+#: data/ui/calibration_signals.glade:108
 msgid "Saw"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:111
+#: data/ui/calibration_signals.glade:109
 msgid "Triangle"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:112
+#: data/ui/calibration_signals.glade:110
 msgid "Silence"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:113
+#: data/ui/calibration_signals.glade:111
 msgid "White Noise"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:114
+#: data/ui/calibration_signals.glade:112
 msgid "Pink Noise"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:115
+#: data/ui/calibration_signals.glade:113
 msgid "Sine Table"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:116
+#: data/ui/calibration_signals.glade:114
 msgid "Ticks"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:117
+#: data/ui/calibration_signals.glade:115
 msgid "Gaussian Noise"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:118
+#: data/ui/calibration_signals.glade:116
 msgid "Red Noise"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:119
+#: data/ui/calibration_signals.glade:117
 msgid "Blue Noise"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:120
+#: data/ui/calibration_signals.glade:118
 msgid "Violet Noise"
 msgstr ""
 
-#: data/ui/calibration_mic.glade:29
+#: data/ui/calibration_mic.glade:28
 msgid "Window"
 msgstr ""
 
-#: data/ui/calibration_mic.glade:70
+#: data/ui/calibration_mic.glade:69
 msgid "Measure Noise"
 msgstr ""
 
-#: data/ui/calibration_mic.glade:99
+#: data/ui/calibration_mic.glade:98
 msgid "Subtract Noise"
 msgstr ""
 
-#: data/ui/compressor.glade:292 data/ui/deesser.glade:483
-#: data/ui/gate.glade:370 data/ui/maximizer.glade:152
-#: data/ui/multiband_compressor.glade:609
+#: data/ui/compressor.glade:290 data/ui/deesser.glade:482
+#: data/ui/gate.glade:413 data/ui/maximizer.glade:153
+#: data/ui/multiband_compressor.glade:607
 #: data/ui/multiband_compressor.glade:983
-#: data/ui/multiband_compressor.glade:1361
-#: data/ui/multiband_compressor.glade:1739 data/ui/multiband_gate.glade:633
-#: data/ui/multiband_gate.glade:1040 data/ui/multiband_gate.glade:1450
-#: data/ui/multiband_gate.glade:1860
+#: data/ui/multiband_compressor.glade:1363
+#: data/ui/multiband_compressor.glade:1743 data/ui/multiband_gate.glade:631
+#: data/ui/multiband_gate.glade:1041 data/ui/multiband_gate.glade:1454
+#: data/ui/multiband_gate.glade:1867
 msgid "Threshold"
 msgstr ""
 
-#: data/ui/compressor.glade:325 data/ui/deesser.glade:516
-#: data/ui/gate.glade:403 data/ui/multiband_compressor.glade:642
-#: data/ui/multiband_compressor.glade:1017
-#: data/ui/multiband_compressor.glade:1395
-#: data/ui/multiband_compressor.glade:1773 data/ui/multiband_gate.glade:666
-#: data/ui/multiband_gate.glade:1074 data/ui/multiband_gate.glade:1484
-#: data/ui/multiband_gate.glade:1894
+#: data/ui/compressor.glade:324 data/ui/deesser.glade:516
+#: data/ui/gate.glade:449 data/ui/multiband_compressor.glade:641
+#: data/ui/multiband_compressor.glade:1018
+#: data/ui/multiband_compressor.glade:1398
+#: data/ui/multiband_compressor.glade:1778 data/ui/multiband_gate.glade:665
+#: data/ui/multiband_gate.glade:1076 data/ui/multiband_gate.glade:1489
+#: data/ui/multiband_gate.glade:1902
 msgid "Ratio"
 msgstr ""
 
-#: data/ui/compressor.glade:357 data/ui/gate.glade:435
-#: data/ui/multiband_compressor.glade:674
-#: data/ui/multiband_compressor.glade:1050
-#: data/ui/multiband_compressor.glade:1428
-#: data/ui/multiband_compressor.glade:1806 data/ui/multiband_gate.glade:698
-#: data/ui/multiband_gate.glade:1107 data/ui/multiband_gate.glade:1517
-#: data/ui/multiband_gate.glade:1927
+#: data/ui/compressor.glade:356 data/ui/gate.glade:483
+#: data/ui/multiband_compressor.glade:673
+#: data/ui/multiband_compressor.glade:1051
+#: data/ui/multiband_compressor.glade:1431
+#: data/ui/multiband_compressor.glade:1811 data/ui/multiband_gate.glade:697
+#: data/ui/multiband_gate.glade:1109 data/ui/multiband_gate.glade:1522
+#: data/ui/multiband_gate.glade:1935
 msgid "Knee"
 msgstr ""
 
-#: data/ui/compressor.glade:391 data/ui/deesser.glade:547
-#: data/ui/gate.glade:469 data/ui/multiband_compressor.glade:708
-#: data/ui/multiband_compressor.glade:1085
-#: data/ui/multiband_compressor.glade:1463
-#: data/ui/multiband_compressor.glade:1841 data/ui/multiband_gate.glade:732
-#: data/ui/multiband_gate.glade:1142 data/ui/multiband_gate.glade:1552
-#: data/ui/multiband_gate.glade:1962
+#: data/ui/compressor.glade:390 data/ui/deesser.glade:547
+#: data/ui/gate.glade:519 data/ui/multiband_compressor.glade:707
+#: data/ui/multiband_compressor.glade:1086
+#: data/ui/multiband_compressor.glade:1466
+#: data/ui/multiband_compressor.glade:1846 data/ui/multiband_gate.glade:731
+#: data/ui/multiband_gate.glade:1144 data/ui/multiband_gate.glade:1557
+#: data/ui/multiband_gate.glade:1970
 msgid "Makeup"
 msgstr ""
 
-#: data/ui/compressor.glade:425 data/ui/gate.glade:336
-#: data/ui/limiter.glade:310 data/ui/maximizer.glade:178
-#: data/ui/multiband_compressor.glade:575
+#: data/ui/compressor.glade:425 data/ui/gate.glade:377
+#: data/ui/limiter.glade:311 data/ui/maximizer.glade:179
+#: data/ui/multiband_compressor.glade:573
 #: data/ui/multiband_compressor.glade:948
-#: data/ui/multiband_compressor.glade:1326
-#: data/ui/multiband_compressor.glade:1704 data/ui/multiband_gate.glade:599
-#: data/ui/multiband_gate.glade:1005 data/ui/multiband_gate.glade:1415
-#: data/ui/multiband_gate.glade:1825
+#: data/ui/multiband_compressor.glade:1328
+#: data/ui/multiband_compressor.glade:1708 data/ui/multiband_gate.glade:597
+#: data/ui/multiband_gate.glade:1006 data/ui/multiband_gate.glade:1419
+#: data/ui/multiband_gate.glade:1832
 msgid "Release"
 msgstr ""
 
-#: data/ui/compressor.glade:438 data/ui/gate.glade:302
-#: data/ui/multiband_compressor.glade:541
+#: data/ui/compressor.glade:438 data/ui/gate.glade:341
+#: data/ui/multiband_compressor.glade:539
 #: data/ui/multiband_compressor.glade:913
-#: data/ui/multiband_compressor.glade:1291
-#: data/ui/multiband_compressor.glade:1669 data/ui/multiband_gate.glade:565
-#: data/ui/multiband_gate.glade:970 data/ui/multiband_gate.glade:1380
-#: data/ui/multiband_gate.glade:1790
+#: data/ui/multiband_compressor.glade:1293
+#: data/ui/multiband_compressor.glade:1673 data/ui/multiband_gate.glade:563
+#: data/ui/multiband_gate.glade:971 data/ui/multiband_gate.glade:1384
+#: data/ui/multiband_gate.glade:1797
 msgid "Attack"
 msgstr ""
 
@@ -500,202 +499,201 @@ msgstr ""
 msgid "Compression Mode"
 msgstr ""
 
-#: data/ui/compressor.glade:551
+#: data/ui/compressor.glade:552
 msgid "Pre-amplification"
 msgstr ""
 
-#: data/ui/compressor.glade:585
+#: data/ui/compressor.glade:586
 msgid "Reactivity"
 msgstr ""
 
-#: data/ui/compressor.glade:619 data/ui/limiter.glade:323
+#: data/ui/compressor.glade:620 data/ui/limiter.glade:324
 msgid "Lookahead"
 msgstr ""
 
-#: data/ui/compressor.glade:632
+#: data/ui/compressor.glade:633
 msgid "Feed-forward"
 msgstr ""
 
-#: data/ui/compressor.glade:633
+#: data/ui/compressor.glade:634
 msgid "Feed-back"
 msgstr ""
 
-#: data/ui/compressor.glade:647 data/ui/equalizer_band.glade:48
+#: data/ui/compressor.glade:648 data/ui/equalizer_band.glade:48
 msgid "Type"
 msgstr ""
 
-#: data/ui/compressor.glade:661 data/ui/deesser.glade:244
-#: data/ui/deesser.glade:354 data/ui/gate.glade:257
-#: data/ui/multiband_compressor.glade:514
+#: data/ui/compressor.glade:662 data/ui/deesser.glade:241
+#: data/ui/gate.glade:213 data/ui/multiband_compressor.glade:512
 #: data/ui/multiband_compressor.glade:886
-#: data/ui/multiband_compressor.glade:1264
-#: data/ui/multiband_compressor.glade:1642 data/ui/multiband_gate.glade:538
-#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1353
-#: data/ui/multiband_gate.glade:1763
+#: data/ui/multiband_compressor.glade:1266
+#: data/ui/multiband_compressor.glade:1646 data/ui/multiband_gate.glade:536
+#: data/ui/multiband_gate.glade:944 data/ui/multiband_gate.glade:1357
+#: data/ui/multiband_gate.glade:1770
 msgid "Peak"
 msgstr ""
 
-#: data/ui/compressor.glade:662 data/ui/deesser.glade:243
-#: data/ui/gate.glade:256 data/ui/multiband_compressor.glade:513
+#: data/ui/compressor.glade:663 data/ui/deesser.glade:240
+#: data/ui/gate.glade:212 data/ui/multiband_compressor.glade:511
 #: data/ui/multiband_compressor.glade:885
-#: data/ui/multiband_compressor.glade:1263
-#: data/ui/multiband_compressor.glade:1641 data/ui/multiband_gate.glade:537
-#: data/ui/multiband_gate.glade:942 data/ui/multiband_gate.glade:1352
-#: data/ui/multiband_gate.glade:1762
+#: data/ui/multiband_compressor.glade:1265
+#: data/ui/multiband_compressor.glade:1645 data/ui/multiband_gate.glade:535
+#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1356
+#: data/ui/multiband_gate.glade:1769
 msgid "RMS"
 msgstr ""
 
-#: data/ui/compressor.glade:663
+#: data/ui/compressor.glade:664
 msgid "Low-Pass"
 msgstr ""
 
-#: data/ui/compressor.glade:664
+#: data/ui/compressor.glade:665
 msgid "Uniform"
 msgstr ""
 
-#: data/ui/compressor.glade:678 data/ui/deesser.glade:230
-#: data/ui/equalizer.glade:224 data/ui/equalizer_band.glade:79
-#: data/ui/multiband_compressor.glade:324 data/ui/multiband_gate.glade:348
-#: data/ui/stereo_tools.glade:485 data/ui/webrtc.glade:376
+#: data/ui/compressor.glade:679 data/ui/deesser.glade:227
+#: data/ui/equalizer.glade:225 data/ui/equalizer_band.glade:79
+#: data/ui/multiband_compressor.glade:322 data/ui/multiband_gate.glade:346
+#: data/ui/stereo_tools.glade:486 data/ui/webrtc.glade:377
 msgid "Mode"
 msgstr ""
 
-#: data/ui/compressor.glade:692
+#: data/ui/compressor.glade:693
 msgid "Middle"
 msgstr ""
 
-#: data/ui/compressor.glade:693
+#: data/ui/compressor.glade:694
 msgid "Side"
 msgstr ""
 
-#: data/ui/compressor.glade:694 data/ui/delay.glade:157
-#: data/ui/equalizer.glade:474 data/ui/stereo_tools.glade:548
+#: data/ui/compressor.glade:695 data/ui/delay.glade:158
+#: data/ui/equalizer.glade:475 data/ui/stereo_tools.glade:549
 msgid "Left"
 msgstr ""
 
-#: data/ui/compressor.glade:695 data/ui/delay.glade:189
-#: data/ui/equalizer.glade:515 data/ui/stereo_tools.glade:620
+#: data/ui/compressor.glade:696 data/ui/delay.glade:190
+#: data/ui/equalizer.glade:516 data/ui/stereo_tools.glade:621
 msgid "Right"
 msgstr ""
 
-#: data/ui/compressor.glade:709
+#: data/ui/compressor.glade:710
 msgid "Source"
 msgstr ""
 
-#: data/ui/compressor.glade:725 data/ui/compressor.glade:1167
+#: data/ui/compressor.glade:726 data/ui/compressor.glade:1170
 msgid "Sidechain"
 msgstr ""
 
-#: data/ui/compressor.glade:821
+#: data/ui/compressor.glade:824
 msgid "Relative Release Threshold"
 msgstr ""
 
-#: data/ui/compressor.glade:832
+#: data/ui/compressor.glade:835
 msgid "Boost Threshold"
 msgstr ""
 
-#: data/ui/compressor.glade:843
+#: data/ui/compressor.glade:846
 msgid "High-pass Frequency"
 msgstr ""
 
-#: data/ui/compressor.glade:854
+#: data/ui/compressor.glade:857
 msgid "Low-pass Frequency"
 msgstr ""
 
-#: data/ui/compressor.glade:865
+#: data/ui/compressor.glade:868
 msgid "High-pass Filter Mode"
 msgstr ""
 
-#: data/ui/compressor.glade:876
+#: data/ui/compressor.glade:879
 msgid "Low-pass Filter Mode"
 msgstr ""
 
-#: data/ui/compressor.glade:889 data/ui/compressor.glade:906
+#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
 #: data/ui/equalizer_band.glade:60
 msgid "Off"
 msgstr ""
 
-#: data/ui/compressor.glade:890 data/ui/compressor.glade:907
+#: data/ui/compressor.glade:893 data/ui/compressor.glade:910
 msgid "12 dB/oct"
 msgstr ""
 
-#: data/ui/compressor.glade:891 data/ui/compressor.glade:908
+#: data/ui/compressor.glade:894 data/ui/compressor.glade:911
 msgid "24 dB/oct"
 msgstr ""
 
-#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
+#: data/ui/compressor.glade:895 data/ui/compressor.glade:912
 msgid "36 dB/oct"
 msgstr ""
 
-#: data/ui/compressor.glade:932
+#: data/ui/compressor.glade:935
 msgid "Advanced"
 msgstr ""
 
-#: data/ui/compressor.glade:1243
+#: data/ui/compressor.glade:1244
 msgid "Curve"
 msgstr ""
 
-#: data/ui/convolver.glade:91
+#: data/ui/convolver.glade:92
 msgid "Convolver"
 msgstr ""
 
-#: data/ui/convolver.glade:125
+#: data/ui/convolver.glade:126
 msgid "Import Impulse"
 msgstr ""
 
-#: data/ui/convolver.glade:129
+#: data/ui/convolver.glade:130
 msgid "Import Impulse Response File"
 msgstr ""
 
-#: data/ui/convolver.glade:247
+#: data/ui/convolver.glade:248
 msgid "L"
 msgstr ""
 
-#: data/ui/convolver.glade:261
+#: data/ui/convolver.glade:262
 msgid "R"
 msgstr ""
 
-#: data/ui/convolver.glade:324
+#: data/ui/convolver.glade:325
 msgid "Duration"
 msgstr ""
 
-#: data/ui/convolver.glade:335
+#: data/ui/convolver.glade:336
 msgid "Samples"
 msgstr ""
 
-#: data/ui/convolver.glade:367 src/convolver_ui.cpp:283
+#: data/ui/convolver.glade:368 src/convolver_ui.cpp:283
 msgid "Impulse Response"
 msgstr ""
 
-#: data/ui/convolver.glade:389
+#: data/ui/convolver.glade:390
 msgid "Select the impulse Response File"
 msgstr ""
 
-#: data/ui/convolver.glade:409 src/spectrum_settings_ui.cpp:176
+#: data/ui/convolver.glade:410 src/spectrum_settings_ui.cpp:176
 msgid "Spectrum"
 msgstr ""
 
-#: data/ui/convolver.glade:450
+#: data/ui/convolver.glade:451
 msgid "Stereo Width"
 msgstr ""
 
-#: data/ui/crossfeed.glade:63
+#: data/ui/crossfeed.glade:62
 msgid "Jmeier"
 msgstr ""
 
-#: data/ui/crossfeed.glade:76 data/ui/filter.glade:183 data/ui/reverb.glade:259
+#: data/ui/crossfeed.glade:75 data/ui/filter.glade:184 data/ui/reverb.glade:260
 msgid "Default"
 msgstr ""
 
-#: data/ui/crossfeed.glade:89
+#: data/ui/crossfeed.glade:88
 msgid "Cmoy"
 msgstr ""
 
-#: data/ui/crossfeed.glade:120
+#: data/ui/crossfeed.glade:119
 msgid "Cutoff"
 msgstr ""
 
-#: data/ui/crossfeed.glade:153
+#: data/ui/crossfeed.glade:152
 msgid "Feed"
 msgstr ""
 
@@ -703,115 +701,127 @@ msgstr ""
 msgid "Crossfeed"
 msgstr ""
 
-#: data/ui/crystalizer.glade:115
+#: data/ui/crystalizer.glade:92
 msgid "Crystalizer"
 msgstr ""
 
-#: data/ui/crystalizer.glade:187
+#: data/ui/crystalizer.glade:137
 msgid "Aggressive Mode"
 msgstr ""
 
-#: data/ui/crystalizer.glade:447
+#: data/ui/crystalizer.glade:395
 msgid "Loudness Range"
 msgstr ""
 
-#: data/ui/crystalizer.glade:466
+#: data/ui/crystalizer.glade:414
 msgid "Before"
 msgstr ""
 
-#: data/ui/crystalizer.glade:479
+#: data/ui/crystalizer.glade:427
 msgid "After"
 msgstr ""
 
 #: data/ui/crystalizer_band.glade:27 data/ui/equalizer_band.glade:313
-#: data/ui/stereo_tools.glade:574 data/ui/stereo_tools.glade:633
+#: data/ui/stereo_tools.glade:575 data/ui/stereo_tools.glade:634
 msgid "Mute"
 msgstr ""
 
-#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:483
+#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:481
 #: data/ui/multiband_compressor.glade:855
-#: data/ui/multiband_compressor.glade:1233
-#: data/ui/multiband_compressor.glade:1611 data/ui/multiband_gate.glade:507
-#: data/ui/multiband_gate.glade:912 data/ui/multiband_gate.glade:1322
-#: data/ui/multiband_gate.glade:1732
+#: data/ui/multiband_compressor.glade:1235
+#: data/ui/multiband_compressor.glade:1615 data/ui/multiband_gate.glade:505
+#: data/ui/multiband_gate.glade:913 data/ui/multiband_gate.glade:1326
+#: data/ui/multiband_gate.glade:1739
 msgid "Bypass"
 msgstr ""
 
-#: data/ui/deesser.glade:128
+#: data/ui/deesser.glade:127
 msgid "Deesser"
 msgstr ""
 
-#: data/ui/deesser.glade:216 data/ui/gate.glade:195
+#: data/ui/deesser.glade:213 data/ui/gate.glade:198
 msgid "Detection"
 msgstr ""
 
-#: data/ui/deesser.glade:258
+#: data/ui/deesser.glade:255
 msgid "Wide"
 msgstr ""
 
-#: data/ui/deesser.glade:259 data/ui/deesser.glade:288
+#: data/ui/deesser.glade:256
 msgid "Split"
 msgstr ""
 
-#: data/ui/deesser.glade:407
-msgid "Level"
+#: data/ui/deesser.glade:285
+msgid "F1 Split"
 msgstr ""
 
-#: data/ui/deesser.glade:420
-msgid "Peak Q"
+#: data/ui/deesser.glade:318
+msgid "F1 Gain"
 msgstr ""
 
-#: data/ui/deesser.glade:452
+#: data/ui/deesser.glade:352
+msgid "F2 Peak"
+msgstr ""
+
+#: data/ui/deesser.glade:406
+msgid "F2 Level"
+msgstr ""
+
+#: data/ui/deesser.glade:419
+msgid "F2 Peak Q"
+msgstr ""
+
+#: data/ui/deesser.glade:451
 msgid "Laxity"
 msgstr ""
 
-#: data/ui/deesser.glade:778 data/ui/multiband_gate.glade:767
-#: data/ui/multiband_gate.glade:1197 data/ui/multiband_gate.glade:1607
-#: data/ui/multiband_gate.glade:2017
+#: data/ui/deesser.glade:779 data/ui/multiband_gate.glade:767
+#: data/ui/multiband_gate.glade:1201 data/ui/multiband_gate.glade:1614
+#: data/ui/multiband_gate.glade:2027
 msgid "Reduction"
 msgstr ""
 
-#: data/ui/deesser.glade:791
+#: data/ui/deesser.glade:792
 msgid "Detected"
 msgstr ""
 
-#: data/ui/delay.glade:91
+#: data/ui/delay.glade:92
 msgid "Delay"
 msgstr ""
 
-#: data/ui/equalizer.glade:44
+#: data/ui/equalizer.glade:45
 msgid "Equalizer"
 msgstr ""
 
-#: data/ui/equalizer.glade:153
+#: data/ui/equalizer.glade:154
 msgid "Split Channels"
 msgstr ""
 
-#: data/ui/equalizer.glade:179
+#: data/ui/equalizer.glade:180
 msgid "IIR"
 msgstr ""
 
-#: data/ui/equalizer.glade:180
+#: data/ui/equalizer.glade:181
 msgid "FIR"
 msgstr ""
 
-#: data/ui/equalizer.glade:181
+#: data/ui/equalizer.glade:182
 msgid "FFT"
 msgstr ""
 
-#: data/ui/equalizer.glade:211
+#: data/ui/equalizer.glade:212
 msgid "Bands"
 msgstr ""
 
-#: data/ui/equalizer.glade:233
+#: data/ui/equalizer.glade:234
 msgid "Flat Response"
 msgstr ""
 
-#: data/ui/equalizer.glade:248
+#: data/ui/equalizer.glade:249
 msgid "Calculate Frequencies"
 msgstr ""
 
-#: data/ui/equalizer.glade:262
+#: data/ui/equalizer.glade:263
 msgid "Import APO Presets"
 msgstr ""
 
@@ -839,7 +849,7 @@ msgstr ""
 msgid "Notch"
 msgstr ""
 
-#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:314
+#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:315
 msgid "Resonance"
 msgstr ""
 
@@ -883,12 +893,12 @@ msgstr ""
 msgid "Width"
 msgstr ""
 
-#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:496
+#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:494
 #: data/ui/multiband_compressor.glade:868
-#: data/ui/multiband_compressor.glade:1246
-#: data/ui/multiband_compressor.glade:1624 data/ui/multiband_gate.glade:520
-#: data/ui/multiband_gate.glade:925 data/ui/multiband_gate.glade:1335
-#: data/ui/multiband_gate.glade:1745
+#: data/ui/multiband_compressor.glade:1248
+#: data/ui/multiband_compressor.glade:1628 data/ui/multiband_gate.glade:518
+#: data/ui/multiband_gate.glade:926 data/ui/multiband_gate.glade:1339
+#: data/ui/multiband_gate.glade:1752
 msgid "Solo"
 msgstr ""
 
@@ -896,79 +906,79 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: data/ui/exciter.glade:117
+#: data/ui/exciter.glade:118
 msgid "Exciter"
 msgstr ""
 
-#: data/ui/exciter.glade:384 data/ui/maximizer.glade:165
+#: data/ui/exciter.glade:384 data/ui/maximizer.glade:166
 msgid "Ceiling"
 msgstr ""
 
-#: data/ui/filter.glade:98
+#: data/ui/filter.glade:99
 msgid "Filter"
 msgstr ""
 
-#: data/ui/filter.glade:147
+#: data/ui/filter.glade:148
 msgid "Muted"
 msgstr ""
 
-#: data/ui/filter.glade:159 data/ui/reverb.glade:233
+#: data/ui/filter.glade:160 data/ui/reverb.glade:234
 msgid "Disco"
 msgstr ""
 
-#: data/ui/filter.glade:171
+#: data/ui/filter.glade:172
 msgid "Distant Headphones"
 msgstr ""
 
-#: data/ui/filter.glade:246
+#: data/ui/filter.glade:247
 msgid "12dB/oct Lowpass"
 msgstr ""
 
-#: data/ui/filter.glade:247
+#: data/ui/filter.glade:248
 msgid "24dB/oct Lowpass"
 msgstr ""
 
-#: data/ui/filter.glade:248
+#: data/ui/filter.glade:249
 msgid "36dB/oct Lowpass"
 msgstr ""
 
-#: data/ui/filter.glade:249
+#: data/ui/filter.glade:250
 msgid "12dB/oct Highpass"
 msgstr ""
 
-#: data/ui/filter.glade:250
+#: data/ui/filter.glade:251
 msgid "24dB/oct Highpass"
 msgstr ""
 
-#: data/ui/filter.glade:251
+#: data/ui/filter.glade:252
 msgid "36dB/oct Highpass"
 msgstr ""
 
-#: data/ui/filter.glade:252
+#: data/ui/filter.glade:253
 msgid "6dB/oct Bandpass"
 msgstr ""
 
-#: data/ui/filter.glade:253
+#: data/ui/filter.glade:254
 msgid "12dB/oct Bandpass"
 msgstr ""
 
-#: data/ui/filter.glade:254
+#: data/ui/filter.glade:255
 msgid "18dB/oct Bandpass"
 msgstr ""
 
-#: data/ui/filter.glade:255
+#: data/ui/filter.glade:256
 msgid "6dB/oct Bandreject"
 msgstr ""
 
-#: data/ui/filter.glade:256
+#: data/ui/filter.glade:257
 msgid "12dB/oct Bandreject"
 msgstr ""
 
-#: data/ui/filter.glade:257
+#: data/ui/filter.glade:258
 msgid "18dB/oct Bandreject"
 msgstr ""
 
-#: data/ui/filter.glade:349
+#: data/ui/filter.glade:350
 msgid "Inertia"
 msgstr ""
 
@@ -1012,49 +1022,49 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: data/ui/gate.glade:98
+#: data/ui/gate.glade:99
 msgid "Gate"
 msgstr ""
 
-#: data/ui/gate.glade:209
+#: data/ui/gate.glade:240
+msgid "Maximum Gain Reduction"
+msgstr ""
+
+#: data/ui/gate.glade:289
 msgid "Stereo Link"
 msgstr ""
 
-#: data/ui/gate.glade:222 data/ui/maximizer.glade:293
-msgid "Gain Reduction"
-msgstr ""
-
-#: data/ui/gate.glade:273
+#: data/ui/gate.glade:304
 msgid "Average"
 msgstr ""
 
-#: data/ui/gate.glade:274
+#: data/ui/gate.glade:305
 msgid "Maximum"
 msgstr ""
 
-#: data/ui/gate.glade:525
+#: data/ui/gate.glade:578
 msgid "Input Level"
 msgstr ""
 
-#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:811
-#: data/ui/multiband_gate.glade:1220 data/ui/multiband_gate.glade:1630
-#: data/ui/multiband_gate.glade:2040
+#: data/ui/gate.glade:797 data/ui/multiband_gate.glade:812
+#: data/ui/multiband_gate.glade:1224 data/ui/multiband_gate.glade:1637
+#: data/ui/multiband_gate.glade:2050
 msgid "Gating"
 msgstr ""
 
-#: data/ui/limiter.glade:97 data/ui/webrtc.glade:421
+#: data/ui/limiter.glade:98 data/ui/webrtc.glade:422
 msgid "Limiter"
 msgstr ""
 
-#: data/ui/limiter.glade:176
+#: data/ui/limiter.glade:175
 msgid "Automatic Smoothing Control"
 msgstr ""
 
-#: data/ui/limiter.glade:190
+#: data/ui/limiter.glade:189
 msgid "Automatic Leveling"
 msgstr ""
 
-#: data/ui/limiter.glade:222
+#: data/ui/limiter.glade:221
 msgid "Input Gain"
 msgstr ""
 
@@ -1062,134 +1072,138 @@ msgstr ""
 msgid "Limit"
 msgstr ""
 
-#: data/ui/limiter.glade:358
+#: data/ui/limiter.glade:359
 msgid "Oversampling"
 msgstr ""
 
-#: data/ui/limiter.glade:411
+#: data/ui/limiter.glade:413
 msgid "Output Gain"
 msgstr ""
 
-#: data/ui/limiter.glade:429
+#: data/ui/limiter.glade:431
 msgid "ASC"
 msgstr ""
 
-#: data/ui/limiter.glade:584
+#: data/ui/limiter.glade:586
 msgid "Attenuation"
 msgstr ""
 
-#: data/ui/loudness.glade:91
+#: data/ui/loudness.glade:92
 msgid "Loudness Compensator"
 msgstr ""
 
-#: data/ui/loudness.glade:147
-msgid "Standard"
-msgstr ""
-
-#: data/ui/loudness.glade:161
-msgid "Flat"
-msgstr ""
-
-#: data/ui/loudness.glade:162
-msgid "ISO226-2003"
-msgstr ""
-
-#: data/ui/loudness.glade:163
-msgid "Fletcher-Munson"
-msgstr ""
-
-#: data/ui/loudness.glade:164
-msgid "Robinson-Dadson"
-msgstr ""
-
-#: data/ui/loudness.glade:174
-msgid "Reference Signal"
-msgstr ""
-
-#: data/ui/loudness.glade:199
+#: data/ui/loudness.glade:155
 msgid "FFT Size"
 msgstr ""
 
-#: data/ui/maximizer.glade:96
+#: data/ui/loudness.glade:205
+msgid "Standard"
+msgstr ""
+
+#: data/ui/loudness.glade:220
+msgid "Flat"
+msgstr ""
+
+#: data/ui/loudness.glade:221
+msgid "ISO226-2003"
+msgstr ""
+
+#: data/ui/loudness.glade:222
+msgid "Fletcher-Munson"
+msgstr ""
+
+#: data/ui/loudness.glade:223
+msgid "Robinson-Dadson"
+msgstr ""
+
+#: data/ui/loudness.glade:259
+msgid "Reference Signal"
+msgstr ""
+
+#: data/ui/maximizer.glade:97
 msgid "Maximizer"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:140
+#: data/ui/maximizer.glade:296
+msgid "Gain Reduction"
+msgstr ""
+
+#: data/ui/multiband_compressor.glade:141
 msgid "Multiband Compressor"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:338 data/ui/multiband_gate.glade:362
+#: data/ui/multiband_compressor.glade:336 data/ui/multiband_gate.glade:360
 msgid "LR4"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:339 data/ui/multiband_gate.glade:363
+#: data/ui/multiband_compressor.glade:337 data/ui/multiband_gate.glade:361
 msgid "LR8"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:353 data/ui/multiband_gate.glade:377
+#: data/ui/multiband_compressor.glade:351 data/ui/multiband_gate.glade:375
 msgid "Split 1/2"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:366 data/ui/multiband_gate.glade:390
+#: data/ui/multiband_compressor.glade:364 data/ui/multiband_gate.glade:388
 msgid "Split 2/3"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:379 data/ui/multiband_gate.glade:403
+#: data/ui/multiband_compressor.glade:377 data/ui/multiband_gate.glade:401
 msgid "Split 3/4"
 msgstr ""
 
 #: data/ui/multiband_compressor.glade:754
-#: data/ui/multiband_compressor.glade:1131
-#: data/ui/multiband_compressor.glade:1509
-#: data/ui/multiband_compressor.glade:1887
+#: data/ui/multiband_compressor.glade:1133
+#: data/ui/multiband_compressor.glade:1513
+#: data/ui/multiband_compressor.glade:1893
 msgid "Compression"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:894
+#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:895
 msgid "Sub Band"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:1214 data/ui/multiband_gate.glade:1303
+#: data/ui/multiband_compressor.glade:1216 data/ui/multiband_gate.glade:1307
 msgid "Low Band"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:1592 data/ui/multiband_gate.glade:1713
+#: data/ui/multiband_compressor.glade:1596 data/ui/multiband_gate.glade:1720
 msgid "Mid Band"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:1970 data/ui/multiband_gate.glade:2123
+#: data/ui/multiband_compressor.glade:1976 data/ui/multiband_gate.glade:2133
 msgid "High Band"
 msgstr ""
 
-#: data/ui/multiband_gate.glade:140
+#: data/ui/multiband_gate.glade:141
 msgid "Multiband Gate"
 msgstr ""
 
-#: data/ui/pitch.glade:103
+#: data/ui/pitch.glade:104
 msgid "Pitch"
 msgstr ""
 
-#: data/ui/pitch.glade:178
+#: data/ui/pitch.glade:179
 msgid "Cents"
 msgstr ""
 
-#: data/ui/pitch.glade:209
+#: data/ui/pitch.glade:210
 msgid "Semitones"
 msgstr ""
 
-#: data/ui/pitch.glade:240
+#: data/ui/pitch.glade:241
 msgid "Octaves"
 msgstr ""
 
-#: data/ui/pitch.glade:271
+#: data/ui/pitch.glade:272
 msgid "Crispness"
 msgstr ""
 
-#: data/ui/pitch.glade:311
+#: data/ui/pitch.glade:312
 msgid "Faster"
 msgstr ""
 
-#: data/ui/pitch.glade:325
+#: data/ui/pitch.glade:326
 msgid "Preserve Formant"
 msgstr ""
 
@@ -1284,83 +1298,83 @@ msgstr ""
 msgid "Pipeline Output"
 msgstr ""
 
-#: data/ui/reverb.glade:131
+#: data/ui/reverb.glade:132
 msgid "Reverberation"
 msgstr ""
 
-#: data/ui/reverb.glade:181
+#: data/ui/reverb.glade:182
 msgid "Ambience"
 msgstr ""
 
-#: data/ui/reverb.glade:194
+#: data/ui/reverb.glade:195
 msgid "Empty Walls"
 msgstr ""
 
-#: data/ui/reverb.glade:207
+#: data/ui/reverb.glade:208
 msgid "Room"
 msgstr ""
 
-#: data/ui/reverb.glade:220
+#: data/ui/reverb.glade:221
 msgid "Large Empty Hall"
 msgstr ""
 
-#: data/ui/reverb.glade:246
+#: data/ui/reverb.glade:247
 msgid "Large Occupied Hall"
 msgstr ""
 
-#: data/ui/reverb.glade:361
+#: data/ui/reverb.glade:362
 msgid "Pre Delay"
 msgstr ""
 
-#: data/ui/reverb.glade:374
+#: data/ui/reverb.glade:375
 msgid "Decay Time"
 msgstr ""
 
-#: data/ui/reverb.glade:439
+#: data/ui/reverb.glade:441
 msgid "Dry"
 msgstr ""
 
-#: data/ui/reverb.glade:471
+#: data/ui/reverb.glade:474
 msgid "Bass Cut"
 msgstr ""
 
-#: data/ui/reverb.glade:522
+#: data/ui/reverb.glade:525
 msgid "Treble Cut"
 msgstr ""
 
-#: data/ui/reverb.glade:565
+#: data/ui/reverb.glade:568
 msgid "Diffusion"
 msgstr ""
 
-#: data/ui/reverb.glade:577
+#: data/ui/reverb.glade:580
 msgid "Room Size"
 msgstr ""
 
-#: data/ui/reverb.glade:590
+#: data/ui/reverb.glade:593
 msgid "Small"
 msgstr ""
 
-#: data/ui/reverb.glade:591
+#: data/ui/reverb.glade:594
 msgid "Medium"
 msgstr ""
 
-#: data/ui/reverb.glade:592
+#: data/ui/reverb.glade:595
 msgid "Large"
 msgstr ""
 
-#: data/ui/reverb.glade:593
+#: data/ui/reverb.glade:596
 msgid "Tunnel"
 msgstr ""
 
-#: data/ui/reverb.glade:594
+#: data/ui/reverb.glade:597
 msgid "Large/smooth"
 msgstr ""
 
-#: data/ui/reverb.glade:595
+#: data/ui/reverb.glade:598
 msgid "Experimental"
 msgstr ""
 
-#: data/ui/reverb.glade:608
+#: data/ui/reverb.glade:611
 msgid "High Frequency Damping"
 msgstr ""
 
@@ -1432,23 +1446,23 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:109
+#: data/ui/stereo_tools.glade:110
 msgid "Stereo Tools"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:231
+#: data/ui/stereo_tools.glade:230
 msgid "Softclip"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:255 data/ui/stereo_tools.glade:671
+#: data/ui/stereo_tools.glade:254 data/ui/stereo_tools.glade:672
 msgid "Balance"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:287
+#: data/ui/stereo_tools.glade:286
 msgid "S/C Level"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:345
+#: data/ui/stereo_tools.glade:344
 msgid "Side Level"
 msgstr ""
 
@@ -1456,144 +1470,144 @@ msgstr ""
 msgid "Side Balance"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:428
+#: data/ui/stereo_tools.glade:429
 msgid "Middle Level"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:441
+#: data/ui/stereo_tools.glade:442
 msgid "Middle Panorama"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:499
+#: data/ui/stereo_tools.glade:500
 msgid "LR > LR (Stereo Default)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:500
+#: data/ui/stereo_tools.glade:501
 msgid "LR > MS (Stereo to Mid-Side)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:501
+#: data/ui/stereo_tools.glade:502
 msgid "MS > LR (Mid-Side to Stereo)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:502
+#: data/ui/stereo_tools.glade:503
 msgid "LR > LL (Mono Left Channel)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:503
+#: data/ui/stereo_tools.glade:504
 msgid "LR > RR (Mono Right Channel)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:504
+#: data/ui/stereo_tools.glade:505
 msgid "LR > L+R (Mono Sum L+R)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:505
+#: data/ui/stereo_tools.glade:506
 msgid "LR > RL (Stereo Flip Channels)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:522
+#: data/ui/stereo_tools.glade:523
 msgid "Stereo Matrix"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:561 data/ui/stereo_tools.glade:602
+#: data/ui/stereo_tools.glade:562 data/ui/stereo_tools.glade:603
 msgid "Invert Phase"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:703
+#: data/ui/stereo_tools.glade:704
 msgid "Delay L/R"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:737
+#: data/ui/stereo_tools.glade:738
 msgid "Stereo Base"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:770
+#: data/ui/stereo_tools.glade:771
 msgid "Stereo Phase"
 msgstr ""
 
-#: data/ui/webrtc.glade:97
+#: data/ui/webrtc.glade:98
 msgid "WebRTC"
 msgstr ""
 
-#: data/ui/webrtc.glade:163 data/ui/webrtc.glade:283 data/ui/webrtc.glade:353
-#: data/ui/webrtc.glade:523
+#: data/ui/webrtc.glade:164 data/ui/webrtc.glade:284 data/ui/webrtc.glade:354
+#: data/ui/webrtc.glade:524
 msgid "Enable"
 msgstr ""
 
-#: data/ui/webrtc.glade:184
+#: data/ui/webrtc.glade:185
 msgid "Extended Filter"
 msgstr ""
 
-#: data/ui/webrtc.glade:197
+#: data/ui/webrtc.glade:198
 msgid "Delay Agnostic"
 msgstr ""
 
-#: data/ui/webrtc.glade:209
+#: data/ui/webrtc.glade:210
 msgid "High Pass Filter"
 msgstr ""
 
-#: data/ui/webrtc.glade:238 data/ui/webrtc.glade:306
+#: data/ui/webrtc.glade:239 data/ui/webrtc.glade:307
 msgid "Suppresion Level"
 msgstr ""
 
-#: data/ui/webrtc.glade:251 data/ui/webrtc.glade:319 data/ui/webrtc.glade:575
+#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
 msgid "Low"
 msgstr ""
 
-#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
+#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
 msgid "Moderate"
 msgstr ""
 
-#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
+#: data/ui/webrtc.glade:254 data/ui/webrtc.glade:322 data/ui/webrtc.glade:578
 msgid "High"
 msgstr ""
 
-#: data/ui/webrtc.glade:270
+#: data/ui/webrtc.glade:271
 msgid "Echo Canceller"
 msgstr ""
 
-#: data/ui/webrtc.glade:322
+#: data/ui/webrtc.glade:323
 msgid "Very High"
 msgstr ""
 
-#: data/ui/webrtc.glade:339
+#: data/ui/webrtc.glade:340
 msgid "Noise Suppressor"
 msgstr ""
 
-#: data/ui/webrtc.glade:389
+#: data/ui/webrtc.glade:390
 msgid "Adaptive Digital"
 msgstr ""
 
-#: data/ui/webrtc.glade:390
+#: data/ui/webrtc.glade:391
 msgid "Fixed Digital"
 msgstr ""
 
-#: data/ui/webrtc.glade:407
+#: data/ui/webrtc.glade:408
 msgid "Gain Controller"
 msgstr ""
 
-#: data/ui/webrtc.glade:445
+#: data/ui/webrtc.glade:446
 msgid "Target Level"
 msgstr ""
 
-#: data/ui/webrtc.glade:475
+#: data/ui/webrtc.glade:476
 msgid "Maximum Gain"
 msgstr ""
 
-#: data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:549
 msgid "Detection Likelihood"
 msgstr ""
 
-#: data/ui/webrtc.glade:561
+#: data/ui/webrtc.glade:562
 msgid "Frame Size"
 msgstr ""
 
-#: data/ui/webrtc.glade:574
+#: data/ui/webrtc.glade:575
 msgid "Very Low"
 msgstr ""
 
-#: data/ui/webrtc.glade:611
+#: data/ui/webrtc.glade:612
 msgid "Voice Detector"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-22 15:29+0200\n"
+"POT-Creation-Date: 2020-08-24 16:51+0200\n"
 "PO-Revision-Date: 2018-07-18 22:14+0300\n"
 "Last-Translator: Mikhail Novosyolov <mikhailnov@dumalogiya.ru>\n"
 "Language-Team: \n"
@@ -88,8 +88,8 @@ msgid "Input Limiter"
 msgstr "Ограничитель ввода"
 
 #: data/com.github.wwmm.pulseeffects.appdata.xml.in:52
-#: data/ui/compressor.glade:111 data/ui/compressor.glade:494
-#: data/ui/webrtc.glade:509
+#: data/ui/compressor.glade:112 data/ui/compressor.glade:494
+#: data/ui/webrtc.glade:510
 msgid "Compressor"
 msgstr "Компрессор"
 
@@ -121,12 +121,12 @@ msgstr "Приложения"
 msgid "Format"
 msgstr "Формат"
 
-#: data/ui/app_info.glade:75 data/ui/convolver.glade:283
+#: data/ui/app_info.glade:75 data/ui/convolver.glade:284
 msgid "Rate"
 msgstr "Частота"
 
 #: data/ui/app_info.glade:102 data/ui/pulse_info.glade:238
-#: data/ui/stereo_tools.glade:653
+#: data/ui/stereo_tools.glade:654
 msgid "Channels"
 msgstr "Каналы"
 
@@ -165,7 +165,7 @@ msgstr "Проверочный сигнал"
 msgid "Global Bypass"
 msgstr "Обход"
 
-#: data/ui/application.glade:170 data/ui/equalizer.glade:277
+#: data/ui/application.glade:170 data/ui/equalizer.glade:278
 #: data/ui/general_settings.glade:107
 msgid "Settings"
 msgstr "Настройки"
@@ -174,40 +174,40 @@ msgstr "Настройки"
 msgid "Help"
 msgstr "Справка"
 
-#: data/ui/application.glade:215 data/ui/crossfeed.glade:49
-#: data/ui/equalizer.glade:333 data/ui/filter.glade:230
-#: data/ui/reverb.glade:310 src/presets_menu_ui.cpp:113
+#: data/ui/application.glade:215 data/ui/crossfeed.glade:48
+#: data/ui/equalizer.glade:334 data/ui/filter.glade:231
+#: data/ui/reverb.glade:311 src/presets_menu_ui.cpp:113
 #: src/presets_menu_ui.cpp:258 src/presets_menu_ui.cpp:275
 msgid "Presets"
 msgstr "Предустановки"
 
-#: data/ui/autogain.glade:91
+#: data/ui/autogain.glade:92
 msgid "Auto Gain"
 msgstr "Контроль громкости по EBU R 128"
 
 # #, fuzzy
-#: data/ui/autogain.glade:171
+#: data/ui/autogain.glade:172
 msgid "Reset History"
 msgstr "Сбросить историю"
 
-#: data/ui/autogain.glade:183
+#: data/ui/autogain.glade:184
 msgid "Detect Silence"
 msgstr "Определять тишину"
 
-#: data/ui/autogain.glade:195
+#: data/ui/autogain.glade:196
 #, fuzzy
 msgid "Use Geometric Mean"
 msgstr "Использовать градиент"
 
-#: data/ui/autogain.glade:233
+#: data/ui/autogain.glade:234
 msgid "Target"
 msgstr "Целевой уровень громкости"
 
-#: data/ui/autogain.glade:283 data/ui/autogain.glade:627
+#: data/ui/autogain.glade:286 data/ui/autogain.glade:631
 msgid "Momentary"
 msgstr "Моментальные измерения"
 
-#: data/ui/autogain.glade:298 data/ui/autogain.glade:640
+#: data/ui/autogain.glade:301 data/ui/autogain.glade:644
 msgid "Short Term"
 msgstr "Короткие измерения"
 
@@ -216,11 +216,11 @@ msgstr "Короткие измерения"
 # В документе выше переводчик перевел 'Integrated' как 'Интегрированные',
 # хотя сам же написал, что это "измерения от начала до конца"
 # Яндекс.Переводчик перевел лучше — "Комплексные измерения"
-#: data/ui/autogain.glade:313 data/ui/autogain.glade:653
+#: data/ui/autogain.glade:316 data/ui/autogain.glade:657
 msgid "Integrated"
 msgstr "Комплексные измерения"
 
-#: data/ui/autogain.glade:388
+#: data/ui/autogain.glade:394
 msgid "Weights"
 msgstr "Вес в расчете громкости"
 
@@ -234,129 +234,128 @@ msgstr "Вес в расчете громкости"
 # msgid "Influence of integrated measurements"
 # msgstr "Влияние комплексных измерений"
 # ###############################################
-#: data/ui/autogain.glade:428 data/ui/autogain.glade:917
-#: data/ui/bass_enhancer.glade:504 data/ui/compressor.glade:974
-#: data/ui/convolver.glade:504 data/ui/crossfeed.glade:200
-#: data/ui/crystalizer.glade:255 data/ui/deesser.glade:593
-#: data/ui/delay.glade:236 data/ui/equalizer.glade:543
-#: data/ui/exciter.glade:510 data/ui/filter.glade:396 data/ui/gate.glade:558
-#: data/ui/limiter.glade:483 data/ui/loudness.glade:259
-#: data/ui/loudness.glade:338 data/ui/maximizer.glade:265
-#: data/ui/multiband_compressor.glade:2000 data/ui/multiband_gate.glade:2153
-#: data/ui/pitch.glade:362 data/ui/presets_menu.glade:255
-#: data/ui/reverb.glade:658 data/ui/stereo_tools.glade:323
-#: data/ui/stereo_tools.glade:829 data/ui/webrtc.glade:650
+#: data/ui/autogain.glade:434 data/ui/autogain.glade:921
+#: data/ui/bass_enhancer.glade:506 data/ui/compressor.glade:977
+#: data/ui/convolver.glade:505 data/ui/crossfeed.glade:199
+#: data/ui/crystalizer.glade:205 data/ui/deesser.glade:594
+#: data/ui/delay.glade:237 data/ui/equalizer.glade:544
+#: data/ui/exciter.glade:510 data/ui/filter.glade:397 data/ui/gate.glade:611
+#: data/ui/limiter.glade:485 data/ui/loudness.glade:299
+#: data/ui/loudness.glade:380 data/ui/maximizer.glade:268
+#: data/ui/multiband_compressor.glade:2006 data/ui/multiband_gate.glade:2163
+#: data/ui/pitch.glade:363 data/ui/presets_menu.glade:255
+#: data/ui/reverb.glade:661 data/ui/stereo_tools.glade:322
+#: data/ui/stereo_tools.glade:830 data/ui/webrtc.glade:651
 msgid "Input"
 msgstr "Вход"
 
-#: data/ui/autogain.glade:443 data/ui/autogain.glade:862
-#: data/ui/bass_enhancer.glade:536 data/ui/compressor.glade:988
-#: data/ui/convolver.glade:519 data/ui/crossfeed.glade:214
-#: data/ui/crystalizer.glade:270 data/ui/deesser.glade:607
-#: data/ui/delay.glade:250 data/ui/equalizer.glade:557
-#: data/ui/exciter.glade:542 data/ui/filter.glade:411 data/ui/gate.glade:572
-#: data/ui/limiter.glade:626 data/ui/loudness.glade:292
-#: data/ui/loudness.glade:352 data/ui/maximizer.glade:279
+#: data/ui/autogain.glade:449 data/ui/autogain.glade:866
+#: data/ui/bass_enhancer.glade:537 data/ui/compressor.glade:991
+#: data/ui/convolver.glade:520 data/ui/crossfeed.glade:213
+#: data/ui/crystalizer.glade:220 data/ui/deesser.glade:608
+#: data/ui/delay.glade:251 data/ui/equalizer.glade:558
+#: data/ui/exciter.glade:541 data/ui/filter.glade:412 data/ui/gate.glade:625
+#: data/ui/limiter.glade:628 data/ui/loudness.glade:333
+#: data/ui/loudness.glade:394 data/ui/maximizer.glade:282
 #: data/ui/multiband_compressor.glade:794
-#: data/ui/multiband_compressor.glade:1171
-#: data/ui/multiband_compressor.glade:1549
-#: data/ui/multiband_compressor.glade:1927
-#: data/ui/multiband_compressor.glade:2015 data/ui/multiband_gate.glade:851
-#: data/ui/multiband_gate.glade:1260 data/ui/multiband_gate.glade:1670
-#: data/ui/multiband_gate.glade:2080 data/ui/multiband_gate.glade:2168
-#: data/ui/pitch.glade:376 data/ui/presets_menu.glade:146
-#: data/ui/reverb.glade:673 data/ui/stereo_tools.glade:800
-#: data/ui/stereo_tools.glade:843 data/ui/webrtc.glade:664
+#: data/ui/multiband_compressor.glade:1173
+#: data/ui/multiband_compressor.glade:1553
+#: data/ui/multiband_compressor.glade:1933
+#: data/ui/multiband_compressor.glade:2021 data/ui/multiband_gate.glade:852
+#: data/ui/multiband_gate.glade:1264 data/ui/multiband_gate.glade:1677
+#: data/ui/multiband_gate.glade:2090 data/ui/multiband_gate.glade:2178
+#: data/ui/pitch.glade:377 data/ui/presets_menu.glade:146
+#: data/ui/reverb.glade:676 data/ui/stereo_tools.glade:801
+#: data/ui/stereo_tools.glade:844 data/ui/webrtc.glade:665
 msgid "Output"
 msgstr "Выход"
 
-#: data/ui/autogain.glade:744
+#: data/ui/autogain.glade:748
 msgid "Relative"
 msgstr "Относительное значение"
 
-#: data/ui/autogain.glade:757 data/ui/compressor.glade:1154
-#: data/ui/deesser.glade:321
+#: data/ui/autogain.glade:761 data/ui/compressor.glade:1157
 msgid "Gain"
 msgstr "Усиление"
 
-#: data/ui/autogain.glade:823
+#: data/ui/autogain.glade:827
 msgid "Loudness"
 msgstr "Громкость"
 
 # ??? Не уверен в переводе
-#: data/ui/autogain.glade:876
+#: data/ui/autogain.glade:880
 msgid "Range"
 msgstr "Диапазон"
 
-#: data/ui/autogain.glade:945 data/ui/bass_enhancer.glade:655
-#: data/ui/compressor.glade:1299 data/ui/convolver.glade:703
-#: data/ui/crossfeed.glade:395 data/ui/crystalizer.glade:566
-#: data/ui/deesser.glade:898 data/ui/delay.glade:434
-#: data/ui/equalizer.glade:743 data/ui/equalizer_band.glade:182
-#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:661
-#: data/ui/filter.glade:595 data/ui/general_settings.glade:116
-#: data/ui/gate.glade:809 data/ui/limiter.glade:733 data/ui/loudness.glade:573
-#: data/ui/maximizer.glade:516 data/ui/multiband_compressor.glade:2199
-#: data/ui/multiband_gate.glade:2352 data/ui/pitch.glade:560
-#: data/ui/reverb.glade:857 data/ui/stereo_tools.glade:1029
-#: data/ui/webrtc.glade:814
+#: data/ui/autogain.glade:949 data/ui/bass_enhancer.glade:650
+#: data/ui/compressor.glade:1300 data/ui/convolver.glade:702
+#: data/ui/crossfeed.glade:394 data/ui/crystalizer.glade:514
+#: data/ui/deesser.glade:899 data/ui/delay.glade:433
+#: data/ui/equalizer.glade:744 data/ui/equalizer_band.glade:182
+#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:654
+#: data/ui/filter.glade:594 data/ui/general_settings.glade:116
+#: data/ui/gate.glade:862 data/ui/limiter.glade:735 data/ui/loudness.glade:615
+#: data/ui/maximizer.glade:519 data/ui/multiband_compressor.glade:2203
+#: data/ui/multiband_gate.glade:2360 data/ui/pitch.glade:559
+#: data/ui/reverb.glade:858 data/ui/stereo_tools.glade:1028
+#: data/ui/webrtc.glade:815
 msgid "Reset"
 msgstr "Сбросить"
 
-#: data/ui/autogain.glade:969
+#: data/ui/autogain.glade:973
 msgid "Based on"
 msgstr ""
 
 # Энхансер (он же Эксайтер) — это прибор, который генерирует высшие гармоники низких частот, благодаря чему повышается локализация низких частот и их «читаемость».
 # «Бас-Энхансер» или «Глубокий бас»
-#: data/ui/bass_enhancer.glade:117
+#: data/ui/bass_enhancer.glade:118
 msgid "Bass Enhancer"
 msgstr "Усиление басов (бас-энхансер)"
 
-#: data/ui/bass_enhancer.glade:169 data/ui/compressor.glade:506
-#: data/ui/deesser.glade:188 data/ui/exciter.glade:171
+#: data/ui/bass_enhancer.glade:170 data/ui/compressor.glade:506
+#: data/ui/deesser.glade:185 data/ui/exciter.glade:170
 msgid "Listen"
 msgstr "Прослушать"
 
-#: data/ui/bass_enhancer.glade:210 data/ui/exciter.glade:213
+#: data/ui/bass_enhancer.glade:211 data/ui/exciter.glade:212
 msgid "3rd"
 msgstr "3-ий"
 
-#: data/ui/bass_enhancer.glade:222 data/ui/exciter.glade:225
+#: data/ui/bass_enhancer.glade:223 data/ui/exciter.glade:224
 msgid "2nd"
 msgstr "2-ой"
 
-#: data/ui/bass_enhancer.glade:234 data/ui/exciter.glade:237
+#: data/ui/bass_enhancer.glade:235 data/ui/exciter.glade:236
 msgid "Blend Harmonics"
 msgstr "Смешение гармоник"
 
-#: data/ui/bass_enhancer.glade:266 data/ui/exciter.glade:271
-#: data/ui/reverb.glade:407
+#: data/ui/bass_enhancer.glade:267 data/ui/exciter.glade:270
+#: data/ui/reverb.glade:408
 msgid "Amount"
 msgstr "Величина"
 
-#: data/ui/bass_enhancer.glade:278 data/ui/bass_enhancer.glade:411
-#: data/ui/exciter.glade:284 data/ui/exciter.glade:417
+#: data/ui/bass_enhancer.glade:279 data/ui/bass_enhancer.glade:413
+#: data/ui/exciter.glade:283 data/ui/exciter.glade:417
 msgid "Harmonics"
 msgstr "Гармоники"
 
-#: data/ui/bass_enhancer.glade:290 data/ui/exciter.glade:297
+#: data/ui/bass_enhancer.glade:291 data/ui/exciter.glade:296
 msgid "Scope"
 msgstr "Диапазон частот"
 
-#: data/ui/bass_enhancer.glade:379
+#: data/ui/bass_enhancer.glade:381
 msgid "Floor"
 msgstr "Нижний порог"
 
-#: data/ui/bass_enhancer.glade:679 data/ui/compressor.glade:1323
-#: data/ui/crossfeed.glade:419 data/ui/deesser.glade:922
-#: data/ui/delay.glade:458 data/ui/equalizer.glade:767
-#: data/ui/exciter.glade:685 data/ui/filter.glade:619 data/ui/gate.glade:833
-#: data/ui/limiter.glade:757 data/ui/loudness.glade:542
-#: data/ui/maximizer.glade:540 data/ui/multiband_compressor.glade:2223
-#: data/ui/multiband_gate.glade:2376 data/ui/pitch.glade:584
-#: data/ui/reverb.glade:881 data/ui/stereo_tools.glade:1053
-#: data/ui/webrtc.glade:838
+#: data/ui/bass_enhancer.glade:674 data/ui/compressor.glade:1324
+#: data/ui/crossfeed.glade:418 data/ui/deesser.glade:923
+#: data/ui/delay.glade:457 data/ui/equalizer.glade:768
+#: data/ui/exciter.glade:678 data/ui/filter.glade:618 data/ui/gate.glade:886
+#: data/ui/limiter.glade:759 data/ui/loudness.glade:584
+#: data/ui/maximizer.glade:543 data/ui/multiband_compressor.glade:2227
+#: data/ui/multiband_gate.glade:2384 data/ui/pitch.glade:583
+#: data/ui/reverb.glade:882 data/ui/stereo_tools.glade:1052
+#: data/ui/webrtc.glade:839
 msgid "Provided by"
 msgstr ""
 
@@ -391,138 +390,138 @@ msgstr "Эффекты для вывода звука"
 msgid "Show Blocklisted Apps in Main Tab"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:32 data/ui/equalizer_band.glade:152
-#: data/ui/filter.glade:280
+#: data/ui/calibration_signals.glade:30 data/ui/equalizer_band.glade:152
+#: data/ui/filter.glade:281
 msgid "Frequency"
 msgstr "Частота"
 
-#: data/ui/calibration_signals.glade:64
+#: data/ui/calibration_signals.glade:62
 msgid "Volume"
 msgstr "Громкость"
 
-#: data/ui/calibration_signals.glade:108
+#: data/ui/calibration_signals.glade:106
 msgid "Sine"
 msgstr "Синусоида"
 
-#: data/ui/calibration_signals.glade:109
+#: data/ui/calibration_signals.glade:107
 msgid "Square"
 msgstr "Квадратный"
 
-#: data/ui/calibration_signals.glade:110
+#: data/ui/calibration_signals.glade:108
 msgid "Saw"
 msgstr "Пилообразный"
 
-#: data/ui/calibration_signals.glade:111
+#: data/ui/calibration_signals.glade:109
 msgid "Triangle"
 msgstr "Треугольный"
 
-#: data/ui/calibration_signals.glade:112
+#: data/ui/calibration_signals.glade:110
 msgid "Silence"
 msgstr "Тишина"
 
-#: data/ui/calibration_signals.glade:113
+#: data/ui/calibration_signals.glade:111
 msgid "White Noise"
 msgstr "Белый шум"
 
-#: data/ui/calibration_signals.glade:114
+#: data/ui/calibration_signals.glade:112
 msgid "Pink Noise"
 msgstr "Розовый шум"
 
-#: data/ui/calibration_signals.glade:115
+#: data/ui/calibration_signals.glade:113
 msgid "Sine Table"
 msgstr "Таблица синусоид"
 
-#: data/ui/calibration_signals.glade:116
+#: data/ui/calibration_signals.glade:114
 msgid "Ticks"
 msgstr "Тики"
 
-#: data/ui/calibration_signals.glade:117
+#: data/ui/calibration_signals.glade:115
 msgid "Gaussian Noise"
 msgstr "Гауссовский шум"
 
-#: data/ui/calibration_signals.glade:118
+#: data/ui/calibration_signals.glade:116
 msgid "Red Noise"
 msgstr "Красный шум"
 
-#: data/ui/calibration_signals.glade:119
+#: data/ui/calibration_signals.glade:117
 msgid "Blue Noise"
 msgstr "Голубой шум"
 
-#: data/ui/calibration_signals.glade:120
+#: data/ui/calibration_signals.glade:118
 msgid "Violet Noise"
 msgstr "Фиолетовый шум"
 
-#: data/ui/calibration_mic.glade:29
+#: data/ui/calibration_mic.glade:28
 msgid "Window"
 msgstr "Окно"
 
-#: data/ui/calibration_mic.glade:70
+#: data/ui/calibration_mic.glade:69
 msgid "Measure Noise"
 msgstr "Измерение шума"
 
-#: data/ui/calibration_mic.glade:99
+#: data/ui/calibration_mic.glade:98
 msgid "Subtract Noise"
 msgstr "Вычетание шума"
 
-#: data/ui/compressor.glade:292 data/ui/deesser.glade:483
-#: data/ui/gate.glade:370 data/ui/maximizer.glade:152
-#: data/ui/multiband_compressor.glade:609
+#: data/ui/compressor.glade:290 data/ui/deesser.glade:482
+#: data/ui/gate.glade:413 data/ui/maximizer.glade:153
+#: data/ui/multiband_compressor.glade:607
 #: data/ui/multiband_compressor.glade:983
-#: data/ui/multiband_compressor.glade:1361
-#: data/ui/multiband_compressor.glade:1739 data/ui/multiband_gate.glade:633
-#: data/ui/multiband_gate.glade:1040 data/ui/multiband_gate.glade:1450
-#: data/ui/multiband_gate.glade:1860
+#: data/ui/multiband_compressor.glade:1363
+#: data/ui/multiband_compressor.glade:1743 data/ui/multiband_gate.glade:631
+#: data/ui/multiband_gate.glade:1041 data/ui/multiband_gate.glade:1454
+#: data/ui/multiband_gate.glade:1867
 msgid "Threshold"
 msgstr "Порог срабатывания"
 
-#: data/ui/compressor.glade:325 data/ui/deesser.glade:516
-#: data/ui/gate.glade:403 data/ui/multiband_compressor.glade:642
-#: data/ui/multiband_compressor.glade:1017
-#: data/ui/multiband_compressor.glade:1395
-#: data/ui/multiband_compressor.glade:1773 data/ui/multiband_gate.glade:666
-#: data/ui/multiband_gate.glade:1074 data/ui/multiband_gate.glade:1484
-#: data/ui/multiband_gate.glade:1894
+#: data/ui/compressor.glade:324 data/ui/deesser.glade:516
+#: data/ui/gate.glade:449 data/ui/multiband_compressor.glade:641
+#: data/ui/multiband_compressor.glade:1018
+#: data/ui/multiband_compressor.glade:1398
+#: data/ui/multiband_compressor.glade:1778 data/ui/multiband_gate.glade:665
+#: data/ui/multiband_gate.glade:1076 data/ui/multiband_gate.glade:1489
+#: data/ui/multiband_gate.glade:1902
 msgid "Ratio"
 msgstr "Степень сжатия"
 
-#: data/ui/compressor.glade:357 data/ui/gate.glade:435
-#: data/ui/multiband_compressor.glade:674
-#: data/ui/multiband_compressor.glade:1050
-#: data/ui/multiband_compressor.glade:1428
-#: data/ui/multiband_compressor.glade:1806 data/ui/multiband_gate.glade:698
-#: data/ui/multiband_gate.glade:1107 data/ui/multiband_gate.glade:1517
-#: data/ui/multiband_gate.glade:1927
+#: data/ui/compressor.glade:356 data/ui/gate.glade:483
+#: data/ui/multiband_compressor.glade:673
+#: data/ui/multiband_compressor.glade:1051
+#: data/ui/multiband_compressor.glade:1431
+#: data/ui/multiband_compressor.glade:1811 data/ui/multiband_gate.glade:697
+#: data/ui/multiband_gate.glade:1109 data/ui/multiband_gate.glade:1522
+#: data/ui/multiband_gate.glade:1935
 msgid "Knee"
 msgstr "Колено (излом)"
 
-#: data/ui/compressor.glade:391 data/ui/deesser.glade:547
-#: data/ui/gate.glade:469 data/ui/multiband_compressor.glade:708
-#: data/ui/multiband_compressor.glade:1085
-#: data/ui/multiband_compressor.glade:1463
-#: data/ui/multiband_compressor.glade:1841 data/ui/multiband_gate.glade:732
-#: data/ui/multiband_gate.glade:1142 data/ui/multiband_gate.glade:1552
-#: data/ui/multiband_gate.glade:1962
+#: data/ui/compressor.glade:390 data/ui/deesser.glade:547
+#: data/ui/gate.glade:519 data/ui/multiband_compressor.glade:707
+#: data/ui/multiband_compressor.glade:1086
+#: data/ui/multiband_compressor.glade:1466
+#: data/ui/multiband_compressor.glade:1846 data/ui/multiband_gate.glade:731
+#: data/ui/multiband_gate.glade:1144 data/ui/multiband_gate.glade:1557
+#: data/ui/multiband_gate.glade:1970
 msgid "Makeup"
 msgstr "Компенсирование"
 
-#: data/ui/compressor.glade:425 data/ui/gate.glade:336
-#: data/ui/limiter.glade:310 data/ui/maximizer.glade:178
-#: data/ui/multiband_compressor.glade:575
+#: data/ui/compressor.glade:425 data/ui/gate.glade:377
+#: data/ui/limiter.glade:311 data/ui/maximizer.glade:179
+#: data/ui/multiband_compressor.glade:573
 #: data/ui/multiband_compressor.glade:948
-#: data/ui/multiband_compressor.glade:1326
-#: data/ui/multiband_compressor.glade:1704 data/ui/multiband_gate.glade:599
-#: data/ui/multiband_gate.glade:1005 data/ui/multiband_gate.glade:1415
-#: data/ui/multiband_gate.glade:1825
+#: data/ui/multiband_compressor.glade:1328
+#: data/ui/multiband_compressor.glade:1708 data/ui/multiband_gate.glade:597
+#: data/ui/multiband_gate.glade:1006 data/ui/multiband_gate.glade:1419
+#: data/ui/multiband_gate.glade:1832
 msgid "Release"
 msgstr "Восстановление"
 
-#: data/ui/compressor.glade:438 data/ui/gate.glade:302
-#: data/ui/multiband_compressor.glade:541
+#: data/ui/compressor.glade:438 data/ui/gate.glade:341
+#: data/ui/multiband_compressor.glade:539
 #: data/ui/multiband_compressor.glade:913
-#: data/ui/multiband_compressor.glade:1291
-#: data/ui/multiband_compressor.glade:1669 data/ui/multiband_gate.glade:565
-#: data/ui/multiband_gate.glade:970 data/ui/multiband_gate.glade:1380
-#: data/ui/multiband_gate.glade:1790
+#: data/ui/multiband_compressor.glade:1293
+#: data/ui/multiband_compressor.glade:1673 data/ui/multiband_gate.glade:563
+#: data/ui/multiband_gate.glade:971 data/ui/multiband_gate.glade:1384
+#: data/ui/multiband_gate.glade:1797
 msgid "Attack"
 msgstr "Атака"
 
@@ -538,211 +537,210 @@ msgstr ""
 msgid "Compression Mode"
 msgstr "Редим сжатия"
 
-#: data/ui/compressor.glade:551
+#: data/ui/compressor.glade:552
 msgid "Pre-amplification"
 msgstr "Предварительное усилиние"
 
-#: data/ui/compressor.glade:585
+#: data/ui/compressor.glade:586
 msgid "Reactivity"
 msgstr "Скорость реакции"
 
-#: data/ui/compressor.glade:619 data/ui/limiter.glade:323
+#: data/ui/compressor.glade:620 data/ui/limiter.glade:324
 msgid "Lookahead"
 msgstr "Задержка (lookahead)"
 
-#: data/ui/compressor.glade:632
+#: data/ui/compressor.glade:633
 msgid "Feed-forward"
 msgstr "Прямая связь"
 
-#: data/ui/compressor.glade:633
+#: data/ui/compressor.glade:634
 msgid "Feed-back"
 msgstr "Обратная связь"
 
-#: data/ui/compressor.glade:647 data/ui/equalizer_band.glade:48
+#: data/ui/compressor.glade:648 data/ui/equalizer_band.glade:48
 msgid "Type"
 msgstr "Тип"
 
-#: data/ui/compressor.glade:661 data/ui/deesser.glade:244
-#: data/ui/deesser.glade:354 data/ui/gate.glade:257
-#: data/ui/multiband_compressor.glade:514
+#: data/ui/compressor.glade:662 data/ui/deesser.glade:241
+#: data/ui/gate.glade:213 data/ui/multiband_compressor.glade:512
 #: data/ui/multiband_compressor.glade:886
-#: data/ui/multiband_compressor.glade:1264
-#: data/ui/multiband_compressor.glade:1642 data/ui/multiband_gate.glade:538
-#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1353
-#: data/ui/multiband_gate.glade:1763
+#: data/ui/multiband_compressor.glade:1266
+#: data/ui/multiband_compressor.glade:1646 data/ui/multiband_gate.glade:536
+#: data/ui/multiband_gate.glade:944 data/ui/multiband_gate.glade:1357
+#: data/ui/multiband_gate.glade:1770
 msgid "Peak"
 msgstr "Пик"
 
-#: data/ui/compressor.glade:662 data/ui/deesser.glade:243
-#: data/ui/gate.glade:256 data/ui/multiband_compressor.glade:513
+#: data/ui/compressor.glade:663 data/ui/deesser.glade:240
+#: data/ui/gate.glade:212 data/ui/multiband_compressor.glade:511
 #: data/ui/multiband_compressor.glade:885
-#: data/ui/multiband_compressor.glade:1263
-#: data/ui/multiband_compressor.glade:1641 data/ui/multiband_gate.glade:537
-#: data/ui/multiband_gate.glade:942 data/ui/multiband_gate.glade:1352
-#: data/ui/multiband_gate.glade:1762
+#: data/ui/multiband_compressor.glade:1265
+#: data/ui/multiband_compressor.glade:1645 data/ui/multiband_gate.glade:535
+#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1356
+#: data/ui/multiband_gate.glade:1769
 msgid "RMS"
 msgstr "RMS (среднеквадратичный уровень сигнала)"
 
-#: data/ui/compressor.glade:663
+#: data/ui/compressor.glade:664
 msgid "Low-Pass"
 msgstr "Фильтр низких частот"
 
-#: data/ui/compressor.glade:664
+#: data/ui/compressor.glade:665
 msgid "Uniform"
 msgstr "Равномерно"
 
-#: data/ui/compressor.glade:678 data/ui/deesser.glade:230
-#: data/ui/equalizer.glade:224 data/ui/equalizer_band.glade:79
-#: data/ui/multiband_compressor.glade:324 data/ui/multiband_gate.glade:348
-#: data/ui/stereo_tools.glade:485 data/ui/webrtc.glade:376
+#: data/ui/compressor.glade:679 data/ui/deesser.glade:227
+#: data/ui/equalizer.glade:225 data/ui/equalizer_band.glade:79
+#: data/ui/multiband_compressor.glade:322 data/ui/multiband_gate.glade:346
+#: data/ui/stereo_tools.glade:486 data/ui/webrtc.glade:377
 msgid "Mode"
 msgstr "Режим"
 
-#: data/ui/compressor.glade:692
+#: data/ui/compressor.glade:693
 msgid "Middle"
 msgstr "Средний"
 
 # #, fuzzy
-#: data/ui/compressor.glade:693
+#: data/ui/compressor.glade:694
 msgid "Side"
 msgstr "Усиление ввода [дБ]"
 
-#: data/ui/compressor.glade:694 data/ui/delay.glade:157
-#: data/ui/equalizer.glade:474 data/ui/stereo_tools.glade:548
+#: data/ui/compressor.glade:695 data/ui/delay.glade:158
+#: data/ui/equalizer.glade:475 data/ui/stereo_tools.glade:549
 msgid "Left"
 msgstr "Левый"
 
-#: data/ui/compressor.glade:695 data/ui/delay.glade:189
-#: data/ui/equalizer.glade:515 data/ui/stereo_tools.glade:620
+#: data/ui/compressor.glade:696 data/ui/delay.glade:190
+#: data/ui/equalizer.glade:516 data/ui/stereo_tools.glade:621
 msgid "Right"
 msgstr "Правый"
 
 # #, fuzzy
-#: data/ui/compressor.glade:709
+#: data/ui/compressor.glade:710
 msgid "Source"
 msgstr "Средний источник"
 
 # #, fuzzy
-#: data/ui/compressor.glade:725 data/ui/compressor.glade:1167
+#: data/ui/compressor.glade:726 data/ui/compressor.glade:1170
 msgid "Sidechain"
 msgstr "Усиление ввода [дБ]"
 
-#: data/ui/compressor.glade:821
+#: data/ui/compressor.glade:824
 msgid "Relative Release Threshold"
 msgstr ""
 
-#: data/ui/compressor.glade:832
+#: data/ui/compressor.glade:835
 #, fuzzy
 msgid "Boost Threshold"
 msgstr "Порог срабатывания"
 
-#: data/ui/compressor.glade:843
+#: data/ui/compressor.glade:846
 #, fuzzy
 msgid "High-pass Frequency"
 msgstr "Высокочастотное демпфирование"
 
-#: data/ui/compressor.glade:854
+#: data/ui/compressor.glade:857
 #, fuzzy
 msgid "Low-pass Frequency"
 msgstr "Подсчитать частоты"
 
-#: data/ui/compressor.glade:865
+#: data/ui/compressor.glade:868
 #, fuzzy
 msgid "High-pass Filter Mode"
 msgstr "Высокачастотный фильтр"
 
-#: data/ui/compressor.glade:876
+#: data/ui/compressor.glade:879
 msgid "Low-pass Filter Mode"
 msgstr ""
 
-#: data/ui/compressor.glade:889 data/ui/compressor.glade:906
+#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
 #: data/ui/equalizer_band.glade:60
 msgid "Off"
 msgstr "Выкл"
 
-#: data/ui/compressor.glade:890 data/ui/compressor.glade:907
+#: data/ui/compressor.glade:893 data/ui/compressor.glade:910
 msgid "12 dB/oct"
 msgstr ""
 
-#: data/ui/compressor.glade:891 data/ui/compressor.glade:908
+#: data/ui/compressor.glade:894 data/ui/compressor.glade:911
 msgid "24 dB/oct"
 msgstr ""
 
-#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
+#: data/ui/compressor.glade:895 data/ui/compressor.glade:912
 msgid "36 dB/oct"
 msgstr ""
 
 # #, fuzzy
-#: data/ui/compressor.glade:932
+#: data/ui/compressor.glade:935
 #, fuzzy
 msgid "Advanced"
 msgstr "Параметры"
 
-#: data/ui/compressor.glade:1243
+#: data/ui/compressor.glade:1244
 msgid "Curve"
 msgstr "Кривая"
 
-#: data/ui/convolver.glade:91
+#: data/ui/convolver.glade:92
 msgid "Convolver"
 msgstr "Конвольвер"
 
-#: data/ui/convolver.glade:125
+#: data/ui/convolver.glade:126
 msgid "Import Impulse"
 msgstr "Импортировать импульс"
 
-#: data/ui/convolver.glade:129
+#: data/ui/convolver.glade:130
 msgid "Import Impulse Response File"
 msgstr "Импортировать файл импульсной реакции"
 
-#: data/ui/convolver.glade:247
+#: data/ui/convolver.glade:248
 msgid "L"
 msgstr "Л"
 
-#: data/ui/convolver.glade:261
+#: data/ui/convolver.glade:262
 msgid "R"
 msgstr "Пр"
 
-#: data/ui/convolver.glade:324
+#: data/ui/convolver.glade:325
 msgid "Duration"
 msgstr "Продолжительность"
 
-#: data/ui/convolver.glade:335
+#: data/ui/convolver.glade:336
 msgid "Samples"
 msgstr "Образцы"
 
-#: data/ui/convolver.glade:367 src/convolver_ui.cpp:283
+#: data/ui/convolver.glade:368 src/convolver_ui.cpp:283
 msgid "Impulse Response"
 msgstr "Импульсная реакция"
 
-#: data/ui/convolver.glade:389
+#: data/ui/convolver.glade:390
 msgid "Select the impulse Response File"
 msgstr "Выбрать файл с импульсной реакцией"
 
-#: data/ui/convolver.glade:409 src/spectrum_settings_ui.cpp:176
+#: data/ui/convolver.glade:410 src/spectrum_settings_ui.cpp:176
 msgid "Spectrum"
 msgstr "Спектр"
 
-#: data/ui/convolver.glade:450
+#: data/ui/convolver.glade:451
 msgid "Stereo Width"
 msgstr "Ширина стерео"
 
-#: data/ui/crossfeed.glade:63
+#: data/ui/crossfeed.glade:62
 msgid "Jmeier"
 msgstr ""
 
-#: data/ui/crossfeed.glade:76 data/ui/filter.glade:183 data/ui/reverb.glade:259
+#: data/ui/crossfeed.glade:75 data/ui/filter.glade:184 data/ui/reverb.glade:260
 msgid "Default"
 msgstr "По умолчанию"
 
-#: data/ui/crossfeed.glade:89
+#: data/ui/crossfeed.glade:88
 msgid "Cmoy"
 msgstr ""
 
-#: data/ui/crossfeed.glade:120
+#: data/ui/crossfeed.glade:119
 msgid "Cutoff"
 msgstr "Усечение"
 
-#: data/ui/crossfeed.glade:153
+#: data/ui/crossfeed.glade:152
 msgid "Feed"
 msgstr "Подача"
 
@@ -750,116 +748,133 @@ msgstr "Подача"
 msgid "Crossfeed"
 msgstr "Перекрестная подача"
 
-#: data/ui/crystalizer.glade:115
+#: data/ui/crystalizer.glade:92
 msgid "Crystalizer"
 msgstr "Кристаллизатор"
 
-#: data/ui/crystalizer.glade:187
+#: data/ui/crystalizer.glade:137
 msgid "Aggressive Mode"
 msgstr "Агрессивный режим"
 
-#: data/ui/crystalizer.glade:447
+#: data/ui/crystalizer.glade:395
 msgid "Loudness Range"
 msgstr "Диапазон громкости"
 
-#: data/ui/crystalizer.glade:466
+#: data/ui/crystalizer.glade:414
 msgid "Before"
 msgstr "До"
 
-#: data/ui/crystalizer.glade:479
+#: data/ui/crystalizer.glade:427
 msgid "After"
 msgstr "После"
 
 #: data/ui/crystalizer_band.glade:27 data/ui/equalizer_band.glade:313
-#: data/ui/stereo_tools.glade:574 data/ui/stereo_tools.glade:633
+#: data/ui/stereo_tools.glade:575 data/ui/stereo_tools.glade:634
 msgid "Mute"
 msgstr "Приглушить"
 
-#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:483
+#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:481
 #: data/ui/multiband_compressor.glade:855
-#: data/ui/multiband_compressor.glade:1233
-#: data/ui/multiband_compressor.glade:1611 data/ui/multiband_gate.glade:507
-#: data/ui/multiband_gate.glade:912 data/ui/multiband_gate.glade:1322
-#: data/ui/multiband_gate.glade:1732
+#: data/ui/multiband_compressor.glade:1235
+#: data/ui/multiband_compressor.glade:1615 data/ui/multiband_gate.glade:505
+#: data/ui/multiband_gate.glade:913 data/ui/multiband_gate.glade:1326
+#: data/ui/multiband_gate.glade:1739
 msgid "Bypass"
 msgstr "Обход"
 
 # http://wikisound.org/Деэссер; предназначен для уменьшения или устранения избыточно шипящих звуков в записи человеческого голоса
-#: data/ui/deesser.glade:128
+#: data/ui/deesser.glade:127
 msgid "Deesser"
 msgstr "Антишипение (деэссер)"
 
-#: data/ui/deesser.glade:216 data/ui/gate.glade:195
+#: data/ui/deesser.glade:213 data/ui/gate.glade:198
 msgid "Detection"
 msgstr "Определение"
 
-#: data/ui/deesser.glade:258
+#: data/ui/deesser.glade:255
 msgid "Wide"
 msgstr ""
 
-#: data/ui/deesser.glade:259 data/ui/deesser.glade:288
+#: data/ui/deesser.glade:256
 msgid "Split"
 msgstr "Частота раздела"
 
-#: data/ui/deesser.glade:407
-msgid "Level"
+#: data/ui/deesser.glade:285
+#, fuzzy
+msgid "F1 Split"
+msgstr "Частота раздела"
+
+#: data/ui/deesser.glade:318
+#, fuzzy
+msgid "F1 Gain"
+msgstr "Усиление"
+
+#: data/ui/deesser.glade:352
+#, fuzzy
+msgid "F2 Peak"
+msgstr "Пик"
+
+#: data/ui/deesser.glade:406
+#, fuzzy
+msgid "F2 Level"
 msgstr "Уровень"
 
-#: data/ui/deesser.glade:420
-msgid "Peak Q"
+#: data/ui/deesser.glade:419
+#, fuzzy
+msgid "F2 Peak Q"
 msgstr "Добротность (Q)"
 
-#: data/ui/deesser.glade:452
+#: data/ui/deesser.glade:451
 msgid "Laxity"
 msgstr "Допуск на срабатывание"
 
-#: data/ui/deesser.glade:778 data/ui/multiband_gate.glade:767
-#: data/ui/multiband_gate.glade:1197 data/ui/multiband_gate.glade:1607
-#: data/ui/multiband_gate.glade:2017
+#: data/ui/deesser.glade:779 data/ui/multiband_gate.glade:767
+#: data/ui/multiband_gate.glade:1201 data/ui/multiband_gate.glade:1614
+#: data/ui/multiband_gate.glade:2027
 msgid "Reduction"
 msgstr "Увеличение ослабления"
 
-#: data/ui/deesser.glade:791
+#: data/ui/deesser.glade:792
 msgid "Detected"
 msgstr "Определено"
 
-#: data/ui/delay.glade:91
+#: data/ui/delay.glade:92
 msgid "Delay"
 msgstr "Задержка"
 
-#: data/ui/equalizer.glade:44
+#: data/ui/equalizer.glade:45
 msgid "Equalizer"
 msgstr "Эквалайзер"
 
-#: data/ui/equalizer.glade:153
+#: data/ui/equalizer.glade:154
 msgid "Split Channels"
 msgstr "Разделить каналы"
 
-#: data/ui/equalizer.glade:179
+#: data/ui/equalizer.glade:180
 msgid "IIR"
 msgstr ""
 
-#: data/ui/equalizer.glade:180
+#: data/ui/equalizer.glade:181
 msgid "FIR"
 msgstr ""
 
-#: data/ui/equalizer.glade:181
+#: data/ui/equalizer.glade:182
 msgid "FFT"
 msgstr ""
 
-#: data/ui/equalizer.glade:211
+#: data/ui/equalizer.glade:212
 msgid "Bands"
 msgstr "Кол-во полос эквалайзера"
 
-#: data/ui/equalizer.glade:233
+#: data/ui/equalizer.glade:234
 msgid "Flat Response"
 msgstr "Плоская АЧХ"
 
-#: data/ui/equalizer.glade:248
+#: data/ui/equalizer.glade:249
 msgid "Calculate Frequencies"
 msgstr "Подсчитать частоты"
 
-#: data/ui/equalizer.glade:262
+#: data/ui/equalizer.glade:263
 #, fuzzy
 msgid "Import APO Presets"
 msgstr "Импортировать предустановки"
@@ -888,7 +903,7 @@ msgstr "Низкочастотный полочный фильтр"
 msgid "Notch"
 msgstr ""
 
-#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:314
+#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:315
 msgid "Resonance"
 msgstr "Резонансы"
 
@@ -932,12 +947,12 @@ msgstr "Качество"
 msgid "Width"
 msgstr "Ширина"
 
-#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:496
+#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:494
 #: data/ui/multiband_compressor.glade:868
-#: data/ui/multiband_compressor.glade:1246
-#: data/ui/multiband_compressor.glade:1624 data/ui/multiband_gate.glade:520
-#: data/ui/multiband_gate.glade:925 data/ui/multiband_gate.glade:1335
-#: data/ui/multiband_gate.glade:1745
+#: data/ui/multiband_compressor.glade:1248
+#: data/ui/multiband_compressor.glade:1628 data/ui/multiband_gate.glade:518
+#: data/ui/multiband_gate.glade:926 data/ui/multiband_gate.glade:1339
+#: data/ui/multiband_gate.glade:1752
 msgid "Solo"
 msgstr "Соло"
 
@@ -945,79 +960,79 @@ msgstr "Соло"
 msgid "Apply"
 msgstr "Применить"
 
-#: data/ui/exciter.glade:117
+#: data/ui/exciter.glade:118
 msgid "Exciter"
 msgstr "Генератор"
 
-#: data/ui/exciter.glade:384 data/ui/maximizer.glade:165
+#: data/ui/exciter.glade:384 data/ui/maximizer.glade:166
 msgid "Ceiling"
 msgstr "Верхний порог"
 
-#: data/ui/filter.glade:98
+#: data/ui/filter.glade:99
 msgid "Filter"
 msgstr "Фильтр"
 
-#: data/ui/filter.glade:147
+#: data/ui/filter.glade:148
 msgid "Muted"
 msgstr "Приглушенный"
 
-#: data/ui/filter.glade:159 data/ui/reverb.glade:233
+#: data/ui/filter.glade:160 data/ui/reverb.glade:234
 msgid "Disco"
 msgstr "Диско"
 
-#: data/ui/filter.glade:171
+#: data/ui/filter.glade:172
 msgid "Distant Headphones"
 msgstr "Находящиеся далеко наушники"
 
-#: data/ui/filter.glade:246
+#: data/ui/filter.glade:247
 msgid "12dB/oct Lowpass"
 msgstr ""
 
-#: data/ui/filter.glade:247
+#: data/ui/filter.glade:248
 msgid "24dB/oct Lowpass"
 msgstr ""
 
-#: data/ui/filter.glade:248
+#: data/ui/filter.glade:249
 msgid "36dB/oct Lowpass"
 msgstr ""
 
-#: data/ui/filter.glade:249
+#: data/ui/filter.glade:250
 msgid "12dB/oct Highpass"
 msgstr ""
 
-#: data/ui/filter.glade:250
+#: data/ui/filter.glade:251
 msgid "24dB/oct Highpass"
 msgstr ""
 
-#: data/ui/filter.glade:251
+#: data/ui/filter.glade:252
 msgid "36dB/oct Highpass"
 msgstr ""
 
-#: data/ui/filter.glade:252
+#: data/ui/filter.glade:253
 msgid "6dB/oct Bandpass"
 msgstr ""
 
-#: data/ui/filter.glade:253
+#: data/ui/filter.glade:254
 msgid "12dB/oct Bandpass"
 msgstr ""
 
-#: data/ui/filter.glade:254
+#: data/ui/filter.glade:255
 msgid "18dB/oct Bandpass"
 msgstr ""
 
-#: data/ui/filter.glade:255
+#: data/ui/filter.glade:256
 msgid "6dB/oct Bandreject"
 msgstr ""
 
-#: data/ui/filter.glade:256
+#: data/ui/filter.glade:257
 msgid "12dB/oct Bandreject"
 msgstr ""
 
-#: data/ui/filter.glade:257
+#: data/ui/filter.glade:258
 msgid "18dB/oct Bandreject"
 msgstr ""
 
-#: data/ui/filter.glade:349
+#: data/ui/filter.glade:350
 msgid "Inertia"
 msgstr "Инертность"
 
@@ -1062,52 +1077,53 @@ msgid "Priority"
 msgstr "Приоритет"
 
 # http://wikisound.org/Гейт: шумовой гейт или просто гейт — это электронное устройство или плагин динамической обработки, который используется для контроля уровня звукового сигнала. Гейт пропускает или глушит сигнал в зависимости от установленного порогового значения. Он очень часто используется для подавления шума в паузах.
-#: data/ui/gate.glade:98
+#: data/ui/gate.glade:99
 msgid "Gate"
 msgstr "Шумовые ворота (гейт)"
 
+#: data/ui/gate.glade:240
+#, fuzzy
+msgid "Maximum Gain Reduction"
+msgstr "Увеличение ослабления"
+
 # В данном режиме «Компрессор» обрабатывает сигналы сразу двух каналов (стерео), уравнивая их уровни.
-#: data/ui/gate.glade:209
+#: data/ui/gate.glade:289
 msgid "Stereo Link"
 msgstr "Стереосвязка"
 
-#: data/ui/gate.glade:222 data/ui/maximizer.glade:293
-msgid "Gain Reduction"
-msgstr "Увеличение ослабления"
-
-#: data/ui/gate.glade:273
+#: data/ui/gate.glade:304
 msgid "Average"
 msgstr "Средняя"
 
-#: data/ui/gate.glade:274
+#: data/ui/gate.glade:305
 msgid "Maximum"
 msgstr "Максимум"
 
 # #, fuzzy
-#: data/ui/gate.glade:525
+#: data/ui/gate.glade:578
 #, fuzzy
 msgid "Input Level"
 msgstr "Ограничитель ввода"
 
-#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:811
-#: data/ui/multiband_gate.glade:1220 data/ui/multiband_gate.glade:1630
-#: data/ui/multiband_gate.glade:2040
+#: data/ui/gate.glade:797 data/ui/multiband_gate.glade:812
+#: data/ui/multiband_gate.glade:1224 data/ui/multiband_gate.glade:1637
+#: data/ui/multiband_gate.glade:2050
 msgid "Gating"
 msgstr ""
 
-#: data/ui/limiter.glade:97 data/ui/webrtc.glade:421
+#: data/ui/limiter.glade:98 data/ui/webrtc.glade:422
 msgid "Limiter"
 msgstr "Ограничитель уровня звука (лимитер)"
 
-#: data/ui/limiter.glade:176
+#: data/ui/limiter.glade:175
 msgid "Automatic Smoothing Control"
 msgstr ""
 
-#: data/ui/limiter.glade:190
+#: data/ui/limiter.glade:189
 msgid "Automatic Leveling"
 msgstr ""
 
-#: data/ui/limiter.glade:222
+#: data/ui/limiter.glade:221
 msgid "Input Gain"
 msgstr "Уровень предусиления"
 
@@ -1115,137 +1131,141 @@ msgstr "Уровень предусиления"
 msgid "Limit"
 msgstr "Ограничение"
 
-#: data/ui/limiter.glade:358
+#: data/ui/limiter.glade:359
 msgid "Oversampling"
 msgstr "Передискретизация"
 
-#: data/ui/limiter.glade:411
+#: data/ui/limiter.glade:413
 #, fuzzy
 msgid "Output Gain"
 msgstr "Уровень предусиления"
 
-#: data/ui/limiter.glade:429
+#: data/ui/limiter.glade:431
 msgid "ASC"
 msgstr "Адаптивное управление наклоном"
 
-#: data/ui/limiter.glade:584
+#: data/ui/limiter.glade:586
 msgid "Attenuation"
 msgstr "Затухание"
 
-#: data/ui/loudness.glade:91
+#: data/ui/loudness.glade:92
 msgid "Loudness Compensator"
 msgstr ""
 
-#: data/ui/loudness.glade:147
-msgid "Standard"
-msgstr ""
-
-#: data/ui/loudness.glade:161
-msgid "Flat"
-msgstr ""
-
-#: data/ui/loudness.glade:162
-msgid "ISO226-2003"
-msgstr ""
-
-#: data/ui/loudness.glade:163
-msgid "Fletcher-Munson"
-msgstr ""
-
-#: data/ui/loudness.glade:164
-msgid "Robinson-Dadson"
-msgstr ""
-
-#: data/ui/loudness.glade:174
-msgid "Reference Signal"
-msgstr ""
-
 # Taking lingual shortcuts to squeeze it in the text box
-#: data/ui/loudness.glade:199
+#: data/ui/loudness.glade:155
 #, fuzzy
 msgid "FFT Size"
 msgstr "Размер кадра"
 
-#: data/ui/maximizer.glade:96
+#: data/ui/loudness.glade:205
+msgid "Standard"
+msgstr ""
+
+#: data/ui/loudness.glade:220
+msgid "Flat"
+msgstr ""
+
+#: data/ui/loudness.glade:221
+msgid "ISO226-2003"
+msgstr ""
+
+#: data/ui/loudness.glade:222
+msgid "Fletcher-Munson"
+msgstr ""
+
+#: data/ui/loudness.glade:223
+msgid "Robinson-Dadson"
+msgstr ""
+
+#: data/ui/loudness.glade:259
+msgid "Reference Signal"
+msgstr ""
+
+#: data/ui/maximizer.glade:97
 msgid "Maximizer"
 msgstr "Максимизатор"
 
-#: data/ui/multiband_compressor.glade:140
+#: data/ui/maximizer.glade:296
+msgid "Gain Reduction"
+msgstr "Увеличение ослабления"
+
+#: data/ui/multiband_compressor.glade:141
 msgid "Multiband Compressor"
 msgstr "Многополосный компрессор"
 
-#: data/ui/multiband_compressor.glade:338 data/ui/multiband_gate.glade:362
+#: data/ui/multiband_compressor.glade:336 data/ui/multiband_gate.glade:360
 msgid "LR4"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:339 data/ui/multiband_gate.glade:363
+#: data/ui/multiband_compressor.glade:337 data/ui/multiband_gate.glade:361
 msgid "LR8"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:353 data/ui/multiband_gate.glade:377
+#: data/ui/multiband_compressor.glade:351 data/ui/multiband_gate.glade:375
 msgid "Split 1/2"
 msgstr "Разделение 1/2"
 
-#: data/ui/multiband_compressor.glade:366 data/ui/multiband_gate.glade:390
+#: data/ui/multiband_compressor.glade:364 data/ui/multiband_gate.glade:388
 msgid "Split 2/3"
 msgstr "Разделение 2/3"
 
-#: data/ui/multiband_compressor.glade:379 data/ui/multiband_gate.glade:403
+#: data/ui/multiband_compressor.glade:377 data/ui/multiband_gate.glade:401
 msgid "Split 3/4"
 msgstr "Разделение 3/4"
 
 #: data/ui/multiband_compressor.glade:754
-#: data/ui/multiband_compressor.glade:1131
-#: data/ui/multiband_compressor.glade:1509
-#: data/ui/multiband_compressor.glade:1887
+#: data/ui/multiband_compressor.glade:1133
+#: data/ui/multiband_compressor.glade:1513
+#: data/ui/multiband_compressor.glade:1893
 msgid "Compression"
 msgstr "Сжатие"
 
-#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:894
+#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:895
 msgid "Sub Band"
 msgstr "Поддиапазон"
 
-#: data/ui/multiband_compressor.glade:1214 data/ui/multiband_gate.glade:1303
+#: data/ui/multiband_compressor.glade:1216 data/ui/multiband_gate.glade:1307
 msgid "Low Band"
 msgstr "Фильтр низких частот"
 
-#: data/ui/multiband_compressor.glade:1592 data/ui/multiband_gate.glade:1713
+#: data/ui/multiband_compressor.glade:1596 data/ui/multiband_gate.glade:1720
 msgid "Mid Band"
 msgstr "Средние частоты"
 
-#: data/ui/multiband_compressor.glade:1970 data/ui/multiband_gate.glade:2123
+#: data/ui/multiband_compressor.glade:1976 data/ui/multiband_gate.glade:2133
 msgid "High Band"
 msgstr "Высокие частоты"
 
-#: data/ui/multiband_gate.glade:140
+#: data/ui/multiband_gate.glade:141
 msgid "Multiband Gate"
 msgstr "Многополосные шумовые ворота"
 
-#: data/ui/pitch.glade:103
+#: data/ui/pitch.glade:104
 msgid "Pitch"
 msgstr "Высота тона"
 
-#: data/ui/pitch.glade:178
+#: data/ui/pitch.glade:179
 msgid "Cents"
 msgstr "Центы"
 
-#: data/ui/pitch.glade:209
+#: data/ui/pitch.glade:210
 msgid "Semitones"
 msgstr "Полутона"
 
-#: data/ui/pitch.glade:240
+#: data/ui/pitch.glade:241
 msgid "Octaves"
 msgstr "Октавы"
 
-#: data/ui/pitch.glade:271
+#: data/ui/pitch.glade:272
 msgid "Crispness"
 msgstr "Чёткость"
 
-#: data/ui/pitch.glade:311
+#: data/ui/pitch.glade:312
 msgid "Faster"
 msgstr "Быстрее"
 
-#: data/ui/pitch.glade:325
+#: data/ui/pitch.glade:326
 msgid "Preserve Formant"
 msgstr "Сохранить формат"
 
@@ -1344,85 +1364,85 @@ msgstr ""
 msgid "Pipeline Output"
 msgstr "Эквалайзер - Выход"
 
-#: data/ui/reverb.glade:131
+#: data/ui/reverb.glade:132
 msgid "Reverberation"
 msgstr "Ревербация"
 
-#: data/ui/reverb.glade:181
+#: data/ui/reverb.glade:182
 msgid "Ambience"
 msgstr "Окр. среда"
 
-#: data/ui/reverb.glade:194
+#: data/ui/reverb.glade:195
 msgid "Empty Walls"
 msgstr "Пустые стены"
 
 # Taking lingual shortcuts to squeeze it in the text box
-#: data/ui/reverb.glade:207
+#: data/ui/reverb.glade:208
 msgid "Room"
 msgstr "Комната"
 
-#: data/ui/reverb.glade:220
+#: data/ui/reverb.glade:221
 msgid "Large Empty Hall"
 msgstr "Большой пустой зал"
 
-#: data/ui/reverb.glade:246
+#: data/ui/reverb.glade:247
 msgid "Large Occupied Hall"
 msgstr "Большой занятый чем-то зал"
 
-#: data/ui/reverb.glade:361
+#: data/ui/reverb.glade:362
 msgid "Pre Delay"
 msgstr "Предзадержка"
 
-#: data/ui/reverb.glade:374
+#: data/ui/reverb.glade:375
 msgid "Decay Time"
 msgstr "Время распада"
 
-#: data/ui/reverb.glade:439
+#: data/ui/reverb.glade:441
 msgid "Dry"
 msgstr "Влажность"
 
-#: data/ui/reverb.glade:471
+#: data/ui/reverb.glade:474
 msgid "Bass Cut"
 msgstr "Обрезка басов"
 
-#: data/ui/reverb.glade:522
+#: data/ui/reverb.glade:525
 msgid "Treble Cut"
 msgstr "Обрезка тембра"
 
-#: data/ui/reverb.glade:565
+#: data/ui/reverb.glade:568
 msgid "Diffusion"
 msgstr "Диффузия"
 
 # Taking lingual shortcuts to squeeze it in the text box
-#: data/ui/reverb.glade:577
+#: data/ui/reverb.glade:580
 msgid "Room Size"
 msgstr "Размер комнаты"
 
-#: data/ui/reverb.glade:590
+#: data/ui/reverb.glade:593
 msgid "Small"
 msgstr "Маленькая"
 
-#: data/ui/reverb.glade:591
+#: data/ui/reverb.glade:594
 msgid "Medium"
 msgstr "Средняя"
 
-#: data/ui/reverb.glade:592
+#: data/ui/reverb.glade:595
 msgid "Large"
 msgstr "Огромная"
 
-#: data/ui/reverb.glade:593
+#: data/ui/reverb.glade:596
 msgid "Tunnel"
 msgstr "Туннель"
 
-#: data/ui/reverb.glade:594
+#: data/ui/reverb.glade:597
 msgid "Large/smooth"
 msgstr "Большой/плавный"
 
-#: data/ui/reverb.glade:595
+#: data/ui/reverb.glade:598
 msgid "Experimental"
 msgstr "Экспериментальный"
 
-#: data/ui/reverb.glade:608
+#: data/ui/reverb.glade:611
 msgid "High Frequency Damping"
 msgstr "Высокочастотное демпфирование"
 
@@ -1496,23 +1516,23 @@ msgstr "Высота"
 msgid "Points"
 msgstr "Точки"
 
-#: data/ui/stereo_tools.glade:109
+#: data/ui/stereo_tools.glade:110
 msgid "Stereo Tools"
 msgstr "Стереокорректоры"
 
-#: data/ui/stereo_tools.glade:231
+#: data/ui/stereo_tools.glade:230
 msgid "Softclip"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:255 data/ui/stereo_tools.glade:671
+#: data/ui/stereo_tools.glade:254 data/ui/stereo_tools.glade:672
 msgid "Balance"
 msgstr "Баланс"
 
-#: data/ui/stereo_tools.glade:287
+#: data/ui/stereo_tools.glade:286
 msgid "S/C Level"
 msgstr "Уровень Раздельный/Центр"
 
-#: data/ui/stereo_tools.glade:345
+#: data/ui/stereo_tools.glade:344
 msgid "Side Level"
 msgstr "Боковой уровень"
 
@@ -1520,146 +1540,146 @@ msgstr "Боковой уровень"
 msgid "Side Balance"
 msgstr "Боковой баланс"
 
-#: data/ui/stereo_tools.glade:428
+#: data/ui/stereo_tools.glade:429
 msgid "Middle Level"
 msgstr "Средний уровень"
 
-#: data/ui/stereo_tools.glade:441
+#: data/ui/stereo_tools.glade:442
 msgid "Middle Panorama"
 msgstr "Срединная панорама"
 
-#: data/ui/stereo_tools.glade:499
+#: data/ui/stereo_tools.glade:500
 msgid "LR > LR (Stereo Default)"
 msgstr "Стерео"
 
-#: data/ui/stereo_tools.glade:500
+#: data/ui/stereo_tools.glade:501
 msgid "LR > MS (Stereo to Mid-Side)"
 msgstr "Стерео > Моно-Раздельно"
 
-#: data/ui/stereo_tools.glade:501
+#: data/ui/stereo_tools.glade:502
 msgid "MS > LR (Mid-Side to Stereo)"
 msgstr "Моно-Раздельно > Стерео"
 
-#: data/ui/stereo_tools.glade:502
+#: data/ui/stereo_tools.glade:503
 msgid "LR > LL (Mono Left Channel)"
 msgstr "Стерео > Моно левый канал"
 
-#: data/ui/stereo_tools.glade:503
+#: data/ui/stereo_tools.glade:504
 msgid "LR > RR (Mono Right Channel)"
 msgstr "Стерео > Моно правый канал"
 
-#: data/ui/stereo_tools.glade:504
+#: data/ui/stereo_tools.glade:505
 msgid "LR > L+R (Mono Sum L+R)"
 msgstr "Стерео > Моно левый+правый каналы"
 
-#: data/ui/stereo_tools.glade:505
+#: data/ui/stereo_tools.glade:506
 msgid "LR > RL (Stereo Flip Channels)"
 msgstr "Стерео > Поменять каналы местами"
 
-#: data/ui/stereo_tools.glade:522
+#: data/ui/stereo_tools.glade:523
 msgid "Stereo Matrix"
 msgstr "Стерео матрица"
 
-#: data/ui/stereo_tools.glade:561 data/ui/stereo_tools.glade:602
+#: data/ui/stereo_tools.glade:562 data/ui/stereo_tools.glade:603
 msgid "Invert Phase"
 msgstr "Инвертировать фазу"
 
-#: data/ui/stereo_tools.glade:703
+#: data/ui/stereo_tools.glade:704
 msgid "Delay L/R"
 msgstr "Задержка Л/П"
 
-#: data/ui/stereo_tools.glade:737
+#: data/ui/stereo_tools.glade:738
 msgid "Stereo Base"
 msgstr "Стерео база"
 
-#: data/ui/stereo_tools.glade:770
+#: data/ui/stereo_tools.glade:771
 msgid "Stereo Phase"
 msgstr "Стерео фаза"
 
-#: data/ui/webrtc.glade:97
+#: data/ui/webrtc.glade:98
 msgid "WebRTC"
 msgstr ""
 
-#: data/ui/webrtc.glade:163 data/ui/webrtc.glade:283 data/ui/webrtc.glade:353
-#: data/ui/webrtc.glade:523
+#: data/ui/webrtc.glade:164 data/ui/webrtc.glade:284 data/ui/webrtc.glade:354
+#: data/ui/webrtc.glade:524
 msgid "Enable"
 msgstr "Включить"
 
-#: data/ui/webrtc.glade:184
+#: data/ui/webrtc.glade:185
 msgid "Extended Filter"
 msgstr "Расширенный фильтр"
 
-#: data/ui/webrtc.glade:197
+#: data/ui/webrtc.glade:198
 msgid "Delay Agnostic"
 msgstr "Задержка"
 
-#: data/ui/webrtc.glade:209
+#: data/ui/webrtc.glade:210
 msgid "High Pass Filter"
 msgstr "Высокачастотный фильтр"
 
-#: data/ui/webrtc.glade:238 data/ui/webrtc.glade:306
+#: data/ui/webrtc.glade:239 data/ui/webrtc.glade:307
 msgid "Suppresion Level"
 msgstr "Уровень подавления"
 
-#: data/ui/webrtc.glade:251 data/ui/webrtc.glade:319 data/ui/webrtc.glade:575
+#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
 msgid "Low"
 msgstr "Низкочастотный фильтр"
 
-#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
+#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
 msgid "Moderate"
 msgstr "Средний"
 
-#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
+#: data/ui/webrtc.glade:254 data/ui/webrtc.glade:322 data/ui/webrtc.glade:578
 msgid "High"
 msgstr "Высокий"
 
-#: data/ui/webrtc.glade:270
+#: data/ui/webrtc.glade:271
 msgid "Echo Canceller"
 msgstr "Эхо и шумо подавление"
 
-#: data/ui/webrtc.glade:322
+#: data/ui/webrtc.glade:323
 msgid "Very High"
 msgstr "Очень высокий"
 
-#: data/ui/webrtc.glade:339
+#: data/ui/webrtc.glade:340
 msgid "Noise Suppressor"
 msgstr "Простой шумодав"
 
 # # TODO: Mode/Режим заменить на "Режим сжатия"
-#: data/ui/webrtc.glade:389
+#: data/ui/webrtc.glade:390
 msgid "Adaptive Digital"
 msgstr "Адаптивное цифровое сжатие"
 
-#: data/ui/webrtc.glade:390
+#: data/ui/webrtc.glade:391
 msgid "Fixed Digital"
 msgstr "Фиксированное цифровое сжатие"
 
-#: data/ui/webrtc.glade:407
+#: data/ui/webrtc.glade:408
 msgid "Gain Controller"
 msgstr "Автоконтроль усиления (AGC)"
 
-#: data/ui/webrtc.glade:445
+#: data/ui/webrtc.glade:446
 msgid "Target Level"
 msgstr "Целевой результат"
 
-#: data/ui/webrtc.glade:475
+#: data/ui/webrtc.glade:476
 msgid "Maximum Gain"
 msgstr "Максимальное увеличение"
 
-#: data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:549
 msgid "Detection Likelihood"
 msgstr "Вероятность обнаружения"
 
 # Taking lingual shortcuts to squeeze it in the text box
-#: data/ui/webrtc.glade:561
+#: data/ui/webrtc.glade:562
 msgid "Frame Size"
 msgstr "Размер кадра"
 
-#: data/ui/webrtc.glade:574
+#: data/ui/webrtc.glade:575
 msgid "Very Low"
 msgstr "Очень низкий"
 
-#: data/ui/webrtc.glade:611
+#: data/ui/webrtc.glade:612
 msgid "Voice Detector"
 msgstr "Обнаруживатель голоса"
 
@@ -1754,6 +1774,10 @@ msgstr "Общие"
 #: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Gain Detection"
+#~ msgstr "Увеличение ослабления"
 
 #~ msgid "Scale"
 #~ msgstr "Масштаб"

--- a/po/sk.po
+++ b/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-22 15:29+0200\n"
+"POT-Creation-Date: 2020-08-24 16:51+0200\n"
 "PO-Revision-Date: 2019-09-07 22:19+0200\n"
 "Last-Translator: Mlocik97\n"
 "Language-Team: \n"
@@ -84,8 +84,8 @@ msgid "Input Limiter"
 msgstr "Vstupný Obmedzovač"
 
 #: data/com.github.wwmm.pulseeffects.appdata.xml.in:52
-#: data/ui/compressor.glade:111 data/ui/compressor.glade:494
-#: data/ui/webrtc.glade:509
+#: data/ui/compressor.glade:112 data/ui/compressor.glade:494
+#: data/ui/webrtc.glade:510
 msgid "Compressor"
 msgstr "Kompresor"
 
@@ -118,12 +118,12 @@ msgstr "Aplikácie"
 msgid "Format"
 msgstr "Formát"
 
-#: data/ui/app_info.glade:75 data/ui/convolver.glade:283
+#: data/ui/app_info.glade:75 data/ui/convolver.glade:284
 msgid "Rate"
 msgstr "Kmitočet"
 
 #: data/ui/app_info.glade:102 data/ui/pulse_info.glade:238
-#: data/ui/stereo_tools.glade:653
+#: data/ui/stereo_tools.glade:654
 msgid "Channels"
 msgstr "Kanály"
 
@@ -161,7 +161,7 @@ msgstr "Skúšobné Signály"
 msgid "Global Bypass"
 msgstr "Prepustiť"
 
-#: data/ui/application.glade:170 data/ui/equalizer.glade:277
+#: data/ui/application.glade:170 data/ui/equalizer.glade:278
 #: data/ui/general_settings.glade:107
 msgid "Settings"
 msgstr "Nastavenia"
@@ -170,172 +170,171 @@ msgstr "Nastavenia"
 msgid "Help"
 msgstr "Nápoveda"
 
-#: data/ui/application.glade:215 data/ui/crossfeed.glade:49
-#: data/ui/equalizer.glade:333 data/ui/filter.glade:230
-#: data/ui/reverb.glade:310 src/presets_menu_ui.cpp:113
+#: data/ui/application.glade:215 data/ui/crossfeed.glade:48
+#: data/ui/equalizer.glade:334 data/ui/filter.glade:231
+#: data/ui/reverb.glade:311 src/presets_menu_ui.cpp:113
 #: src/presets_menu_ui.cpp:258 src/presets_menu_ui.cpp:275
 msgid "Presets"
 msgstr "Predvoľby"
 
-#: data/ui/autogain.glade:91
+#: data/ui/autogain.glade:92
 msgid "Auto Gain"
 msgstr "Automatická hlasitosť"
 
-#: data/ui/autogain.glade:171
+#: data/ui/autogain.glade:172
 msgid "Reset History"
 msgstr "Vymazať Históriu"
 
-#: data/ui/autogain.glade:183
+#: data/ui/autogain.glade:184
 #, fuzzy
 msgid "Detect Silence"
 msgstr "Zistenie Ticha"
 
-#: data/ui/autogain.glade:195
+#: data/ui/autogain.glade:196
 #, fuzzy
 msgid "Use Geometric Mean"
 msgstr "Použiť Geometrický Priemer"
 
-#: data/ui/autogain.glade:233
+#: data/ui/autogain.glade:234
 msgid "Target"
 msgstr "Ciel"
 
-#: data/ui/autogain.glade:283 data/ui/autogain.glade:627
+#: data/ui/autogain.glade:286 data/ui/autogain.glade:631
 msgid "Momentary"
 msgstr "Okamžitá"
 
-#: data/ui/autogain.glade:298 data/ui/autogain.glade:640
+#: data/ui/autogain.glade:301 data/ui/autogain.glade:644
 msgid "Short Term"
 msgstr "Krátkodobá"
 
-#: data/ui/autogain.glade:313 data/ui/autogain.glade:653
+#: data/ui/autogain.glade:316 data/ui/autogain.glade:657
 msgid "Integrated"
 msgstr "Integrovaná"
 
-#: data/ui/autogain.glade:388
+#: data/ui/autogain.glade:394
 msgid "Weights"
 msgstr "Váhy"
 
-#: data/ui/autogain.glade:428 data/ui/autogain.glade:917
-#: data/ui/bass_enhancer.glade:504 data/ui/compressor.glade:974
-#: data/ui/convolver.glade:504 data/ui/crossfeed.glade:200
-#: data/ui/crystalizer.glade:255 data/ui/deesser.glade:593
-#: data/ui/delay.glade:236 data/ui/equalizer.glade:543
-#: data/ui/exciter.glade:510 data/ui/filter.glade:396 data/ui/gate.glade:558
-#: data/ui/limiter.glade:483 data/ui/loudness.glade:259
-#: data/ui/loudness.glade:338 data/ui/maximizer.glade:265
-#: data/ui/multiband_compressor.glade:2000 data/ui/multiband_gate.glade:2153
-#: data/ui/pitch.glade:362 data/ui/presets_menu.glade:255
-#: data/ui/reverb.glade:658 data/ui/stereo_tools.glade:323
-#: data/ui/stereo_tools.glade:829 data/ui/webrtc.glade:650
+#: data/ui/autogain.glade:434 data/ui/autogain.glade:921
+#: data/ui/bass_enhancer.glade:506 data/ui/compressor.glade:977
+#: data/ui/convolver.glade:505 data/ui/crossfeed.glade:199
+#: data/ui/crystalizer.glade:205 data/ui/deesser.glade:594
+#: data/ui/delay.glade:237 data/ui/equalizer.glade:544
+#: data/ui/exciter.glade:510 data/ui/filter.glade:397 data/ui/gate.glade:611
+#: data/ui/limiter.glade:485 data/ui/loudness.glade:299
+#: data/ui/loudness.glade:380 data/ui/maximizer.glade:268
+#: data/ui/multiband_compressor.glade:2006 data/ui/multiband_gate.glade:2163
+#: data/ui/pitch.glade:363 data/ui/presets_menu.glade:255
+#: data/ui/reverb.glade:661 data/ui/stereo_tools.glade:322
+#: data/ui/stereo_tools.glade:830 data/ui/webrtc.glade:651
 msgid "Input"
 msgstr "Vstup"
 
-#: data/ui/autogain.glade:443 data/ui/autogain.glade:862
-#: data/ui/bass_enhancer.glade:536 data/ui/compressor.glade:988
-#: data/ui/convolver.glade:519 data/ui/crossfeed.glade:214
-#: data/ui/crystalizer.glade:270 data/ui/deesser.glade:607
-#: data/ui/delay.glade:250 data/ui/equalizer.glade:557
-#: data/ui/exciter.glade:542 data/ui/filter.glade:411 data/ui/gate.glade:572
-#: data/ui/limiter.glade:626 data/ui/loudness.glade:292
-#: data/ui/loudness.glade:352 data/ui/maximizer.glade:279
+#: data/ui/autogain.glade:449 data/ui/autogain.glade:866
+#: data/ui/bass_enhancer.glade:537 data/ui/compressor.glade:991
+#: data/ui/convolver.glade:520 data/ui/crossfeed.glade:213
+#: data/ui/crystalizer.glade:220 data/ui/deesser.glade:608
+#: data/ui/delay.glade:251 data/ui/equalizer.glade:558
+#: data/ui/exciter.glade:541 data/ui/filter.glade:412 data/ui/gate.glade:625
+#: data/ui/limiter.glade:628 data/ui/loudness.glade:333
+#: data/ui/loudness.glade:394 data/ui/maximizer.glade:282
 #: data/ui/multiband_compressor.glade:794
-#: data/ui/multiband_compressor.glade:1171
-#: data/ui/multiband_compressor.glade:1549
-#: data/ui/multiband_compressor.glade:1927
-#: data/ui/multiband_compressor.glade:2015 data/ui/multiband_gate.glade:851
-#: data/ui/multiband_gate.glade:1260 data/ui/multiband_gate.glade:1670
-#: data/ui/multiband_gate.glade:2080 data/ui/multiband_gate.glade:2168
-#: data/ui/pitch.glade:376 data/ui/presets_menu.glade:146
-#: data/ui/reverb.glade:673 data/ui/stereo_tools.glade:800
-#: data/ui/stereo_tools.glade:843 data/ui/webrtc.glade:664
+#: data/ui/multiband_compressor.glade:1173
+#: data/ui/multiband_compressor.glade:1553
+#: data/ui/multiband_compressor.glade:1933
+#: data/ui/multiband_compressor.glade:2021 data/ui/multiband_gate.glade:852
+#: data/ui/multiband_gate.glade:1264 data/ui/multiband_gate.glade:1677
+#: data/ui/multiband_gate.glade:2090 data/ui/multiband_gate.glade:2178
+#: data/ui/pitch.glade:377 data/ui/presets_menu.glade:146
+#: data/ui/reverb.glade:676 data/ui/stereo_tools.glade:801
+#: data/ui/stereo_tools.glade:844 data/ui/webrtc.glade:665
 msgid "Output"
 msgstr "Výstup"
 
-#: data/ui/autogain.glade:744
+#: data/ui/autogain.glade:748
 msgid "Relative"
 msgstr "Relatívna"
 
-#: data/ui/autogain.glade:757 data/ui/compressor.glade:1154
-#: data/ui/deesser.glade:321
+#: data/ui/autogain.glade:761 data/ui/compressor.glade:1157
 msgid "Gain"
 msgstr "Zisk"
 
-#: data/ui/autogain.glade:823
+#: data/ui/autogain.glade:827
 msgid "Loudness"
 msgstr "Hlasitosť"
 
-#: data/ui/autogain.glade:876
+#: data/ui/autogain.glade:880
 msgid "Range"
 msgstr "Rozsah"
 
-#: data/ui/autogain.glade:945 data/ui/bass_enhancer.glade:655
-#: data/ui/compressor.glade:1299 data/ui/convolver.glade:703
-#: data/ui/crossfeed.glade:395 data/ui/crystalizer.glade:566
-#: data/ui/deesser.glade:898 data/ui/delay.glade:434
-#: data/ui/equalizer.glade:743 data/ui/equalizer_band.glade:182
-#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:661
-#: data/ui/filter.glade:595 data/ui/general_settings.glade:116
-#: data/ui/gate.glade:809 data/ui/limiter.glade:733 data/ui/loudness.glade:573
-#: data/ui/maximizer.glade:516 data/ui/multiband_compressor.glade:2199
-#: data/ui/multiband_gate.glade:2352 data/ui/pitch.glade:560
-#: data/ui/reverb.glade:857 data/ui/stereo_tools.glade:1029
-#: data/ui/webrtc.glade:814
+#: data/ui/autogain.glade:949 data/ui/bass_enhancer.glade:650
+#: data/ui/compressor.glade:1300 data/ui/convolver.glade:702
+#: data/ui/crossfeed.glade:394 data/ui/crystalizer.glade:514
+#: data/ui/deesser.glade:899 data/ui/delay.glade:433
+#: data/ui/equalizer.glade:744 data/ui/equalizer_band.glade:182
+#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:654
+#: data/ui/filter.glade:594 data/ui/general_settings.glade:116
+#: data/ui/gate.glade:862 data/ui/limiter.glade:735 data/ui/loudness.glade:615
+#: data/ui/maximizer.glade:519 data/ui/multiband_compressor.glade:2203
+#: data/ui/multiband_gate.glade:2360 data/ui/pitch.glade:559
+#: data/ui/reverb.glade:858 data/ui/stereo_tools.glade:1028
+#: data/ui/webrtc.glade:815
 msgid "Reset"
 msgstr "Obnoviť pôvodné hodnoty"
 
-#: data/ui/autogain.glade:969
+#: data/ui/autogain.glade:973
 msgid "Based on"
 msgstr "Na základe"
 
-#: data/ui/bass_enhancer.glade:117
+#: data/ui/bass_enhancer.glade:118
 msgid "Bass Enhancer"
 msgstr "Vylepšovač Hĺbok"
 
-#: data/ui/bass_enhancer.glade:169 data/ui/compressor.glade:506
-#: data/ui/deesser.glade:188 data/ui/exciter.glade:171
+#: data/ui/bass_enhancer.glade:170 data/ui/compressor.glade:506
+#: data/ui/deesser.glade:185 data/ui/exciter.glade:170
 msgid "Listen"
 msgstr "Počúvať"
 
-#: data/ui/bass_enhancer.glade:210 data/ui/exciter.glade:213
+#: data/ui/bass_enhancer.glade:211 data/ui/exciter.glade:212
 msgid "3rd"
 msgstr "3."
 
-#: data/ui/bass_enhancer.glade:222 data/ui/exciter.glade:225
+#: data/ui/bass_enhancer.glade:223 data/ui/exciter.glade:224
 msgid "2nd"
 msgstr "2."
 
-#: data/ui/bass_enhancer.glade:234 data/ui/exciter.glade:237
+#: data/ui/bass_enhancer.glade:235 data/ui/exciter.glade:236
 msgid "Blend Harmonics"
 msgstr "Miešať Harmonické Kmity"
 
-#: data/ui/bass_enhancer.glade:266 data/ui/exciter.glade:271
-#: data/ui/reverb.glade:407
+#: data/ui/bass_enhancer.glade:267 data/ui/exciter.glade:270
+#: data/ui/reverb.glade:408
 msgid "Amount"
 msgstr "Množstvo"
 
-#: data/ui/bass_enhancer.glade:278 data/ui/bass_enhancer.glade:411
-#: data/ui/exciter.glade:284 data/ui/exciter.glade:417
+#: data/ui/bass_enhancer.glade:279 data/ui/bass_enhancer.glade:413
+#: data/ui/exciter.glade:283 data/ui/exciter.glade:417
 msgid "Harmonics"
 msgstr "Harmonickosť"
 
-#: data/ui/bass_enhancer.glade:290 data/ui/exciter.glade:297
+#: data/ui/bass_enhancer.glade:291 data/ui/exciter.glade:296
 #, fuzzy
 msgid "Scope"
 msgstr "Zrezanie [Hz]"
 
-#: data/ui/bass_enhancer.glade:379
+#: data/ui/bass_enhancer.glade:381
 msgid "Floor"
 msgstr "Spodná hranica"
 
-#: data/ui/bass_enhancer.glade:679 data/ui/compressor.glade:1323
-#: data/ui/crossfeed.glade:419 data/ui/deesser.glade:922
-#: data/ui/delay.glade:458 data/ui/equalizer.glade:767
-#: data/ui/exciter.glade:685 data/ui/filter.glade:619 data/ui/gate.glade:833
-#: data/ui/limiter.glade:757 data/ui/loudness.glade:542
-#: data/ui/maximizer.glade:540 data/ui/multiband_compressor.glade:2223
-#: data/ui/multiband_gate.glade:2376 data/ui/pitch.glade:584
-#: data/ui/reverb.glade:881 data/ui/stereo_tools.glade:1053
-#: data/ui/webrtc.glade:838
+#: data/ui/bass_enhancer.glade:674 data/ui/compressor.glade:1324
+#: data/ui/crossfeed.glade:418 data/ui/deesser.glade:923
+#: data/ui/delay.glade:457 data/ui/equalizer.glade:768
+#: data/ui/exciter.glade:678 data/ui/filter.glade:618 data/ui/gate.glade:886
+#: data/ui/limiter.glade:759 data/ui/loudness.glade:584
+#: data/ui/maximizer.glade:543 data/ui/multiband_compressor.glade:2227
+#: data/ui/multiband_gate.glade:2384 data/ui/pitch.glade:583
+#: data/ui/reverb.glade:882 data/ui/stereo_tools.glade:1052
+#: data/ui/webrtc.glade:839
 msgid "Provided by"
 msgstr "Poskytuje"
 
@@ -370,140 +369,140 @@ msgstr "Výstupné Efekty"
 msgid "Show Blocklisted Apps in Main Tab"
 msgstr "Zobraziť Aplikácie z Blocklistu na Hlavnej Karte"
 
-#: data/ui/calibration_signals.glade:32 data/ui/equalizer_band.glade:152
-#: data/ui/filter.glade:280
+#: data/ui/calibration_signals.glade:30 data/ui/equalizer_band.glade:152
+#: data/ui/filter.glade:281
 msgid "Frequency"
 msgstr "Frekvencia"
 
-#: data/ui/calibration_signals.glade:64
+#: data/ui/calibration_signals.glade:62
 #, fuzzy
 msgid "Volume"
 msgstr "Automatická hlasitosť"
 
-#: data/ui/calibration_signals.glade:108
+#: data/ui/calibration_signals.glade:106
 msgid "Sine"
 msgstr "Sínus"
 
-#: data/ui/calibration_signals.glade:109
+#: data/ui/calibration_signals.glade:107
 msgid "Square"
 msgstr "Štvorec"
 
-#: data/ui/calibration_signals.glade:110
+#: data/ui/calibration_signals.glade:108
 msgid "Saw"
 msgstr "Píla"
 
-#: data/ui/calibration_signals.glade:111
+#: data/ui/calibration_signals.glade:109
 msgid "Triangle"
 msgstr "Trojuholník"
 
-#: data/ui/calibration_signals.glade:112
+#: data/ui/calibration_signals.glade:110
 msgid "Silence"
 msgstr "Ticho"
 
-#: data/ui/calibration_signals.glade:113
+#: data/ui/calibration_signals.glade:111
 msgid "White Noise"
 msgstr "Biely Šum"
 
-#: data/ui/calibration_signals.glade:114
+#: data/ui/calibration_signals.glade:112
 msgid "Pink Noise"
 msgstr "Ružový Šum"
 
-#: data/ui/calibration_signals.glade:115
+#: data/ui/calibration_signals.glade:113
 msgid "Sine Table"
 msgstr "Sínusová Tabuľka"
 
-#: data/ui/calibration_signals.glade:116
+#: data/ui/calibration_signals.glade:114
 msgid "Ticks"
 msgstr "Tiky"
 
-#: data/ui/calibration_signals.glade:117
+#: data/ui/calibration_signals.glade:115
 msgid "Gaussian Noise"
 msgstr "Gaussový Šum"
 
-#: data/ui/calibration_signals.glade:118
+#: data/ui/calibration_signals.glade:116
 msgid "Red Noise"
 msgstr "Červený Šum"
 
-#: data/ui/calibration_signals.glade:119
+#: data/ui/calibration_signals.glade:117
 msgid "Blue Noise"
 msgstr "Modrý Šum"
 
-#: data/ui/calibration_signals.glade:120
+#: data/ui/calibration_signals.glade:118
 msgid "Violet Noise"
 msgstr "Fialový Šum"
 
-#: data/ui/calibration_mic.glade:29
+#: data/ui/calibration_mic.glade:28
 msgid "Window"
 msgstr "Okno"
 
-#: data/ui/calibration_mic.glade:70
+#: data/ui/calibration_mic.glade:69
 msgid "Measure Noise"
 msgstr "Merať Šum"
 
-#: data/ui/calibration_mic.glade:99
+#: data/ui/calibration_mic.glade:98
 msgid "Subtract Noise"
 msgstr "Oddeliť Šum"
 
-#: data/ui/compressor.glade:292 data/ui/deesser.glade:483
-#: data/ui/gate.glade:370 data/ui/maximizer.glade:152
-#: data/ui/multiband_compressor.glade:609
+#: data/ui/compressor.glade:290 data/ui/deesser.glade:482
+#: data/ui/gate.glade:413 data/ui/maximizer.glade:153
+#: data/ui/multiband_compressor.glade:607
 #: data/ui/multiband_compressor.glade:983
-#: data/ui/multiband_compressor.glade:1361
-#: data/ui/multiband_compressor.glade:1739 data/ui/multiband_gate.glade:633
-#: data/ui/multiband_gate.glade:1040 data/ui/multiband_gate.glade:1450
-#: data/ui/multiband_gate.glade:1860
+#: data/ui/multiband_compressor.glade:1363
+#: data/ui/multiband_compressor.glade:1743 data/ui/multiband_gate.glade:631
+#: data/ui/multiband_gate.glade:1041 data/ui/multiband_gate.glade:1454
+#: data/ui/multiband_gate.glade:1867
 #, fuzzy
 msgid "Threshold"
 msgstr "Prah"
 
-#: data/ui/compressor.glade:325 data/ui/deesser.glade:516
-#: data/ui/gate.glade:403 data/ui/multiband_compressor.glade:642
-#: data/ui/multiband_compressor.glade:1017
-#: data/ui/multiband_compressor.glade:1395
-#: data/ui/multiband_compressor.glade:1773 data/ui/multiband_gate.glade:666
-#: data/ui/multiband_gate.glade:1074 data/ui/multiband_gate.glade:1484
-#: data/ui/multiband_gate.glade:1894
+#: data/ui/compressor.glade:324 data/ui/deesser.glade:516
+#: data/ui/gate.glade:449 data/ui/multiband_compressor.glade:641
+#: data/ui/multiband_compressor.glade:1018
+#: data/ui/multiband_compressor.glade:1398
+#: data/ui/multiband_compressor.glade:1778 data/ui/multiband_gate.glade:665
+#: data/ui/multiband_gate.glade:1076 data/ui/multiband_gate.glade:1489
+#: data/ui/multiband_gate.glade:1902
 msgid "Ratio"
 msgstr "Pomer"
 
-#: data/ui/compressor.glade:357 data/ui/gate.glade:435
-#: data/ui/multiband_compressor.glade:674
-#: data/ui/multiband_compressor.glade:1050
-#: data/ui/multiband_compressor.glade:1428
-#: data/ui/multiband_compressor.glade:1806 data/ui/multiband_gate.glade:698
-#: data/ui/multiband_gate.glade:1107 data/ui/multiband_gate.glade:1517
-#: data/ui/multiband_gate.glade:1927
+#: data/ui/compressor.glade:356 data/ui/gate.glade:483
+#: data/ui/multiband_compressor.glade:673
+#: data/ui/multiband_compressor.glade:1051
+#: data/ui/multiband_compressor.glade:1431
+#: data/ui/multiband_compressor.glade:1811 data/ui/multiband_gate.glade:697
+#: data/ui/multiband_gate.glade:1109 data/ui/multiband_gate.glade:1522
+#: data/ui/multiband_gate.glade:1935
 msgid "Knee"
 msgstr "Prechod"
 
-#: data/ui/compressor.glade:391 data/ui/deesser.glade:547
-#: data/ui/gate.glade:469 data/ui/multiband_compressor.glade:708
-#: data/ui/multiband_compressor.glade:1085
-#: data/ui/multiband_compressor.glade:1463
-#: data/ui/multiband_compressor.glade:1841 data/ui/multiband_gate.glade:732
-#: data/ui/multiband_gate.glade:1142 data/ui/multiband_gate.glade:1552
-#: data/ui/multiband_gate.glade:1962
+#: data/ui/compressor.glade:390 data/ui/deesser.glade:547
+#: data/ui/gate.glade:519 data/ui/multiband_compressor.glade:707
+#: data/ui/multiband_compressor.glade:1086
+#: data/ui/multiband_compressor.glade:1466
+#: data/ui/multiband_compressor.glade:1846 data/ui/multiband_gate.glade:731
+#: data/ui/multiband_gate.glade:1144 data/ui/multiband_gate.glade:1557
+#: data/ui/multiband_gate.glade:1970
 msgid "Makeup"
 msgstr "Pozdvihnutie"
 
-#: data/ui/compressor.glade:425 data/ui/gate.glade:336
-#: data/ui/limiter.glade:310 data/ui/maximizer.glade:178
-#: data/ui/multiband_compressor.glade:575
+#: data/ui/compressor.glade:425 data/ui/gate.glade:377
+#: data/ui/limiter.glade:311 data/ui/maximizer.glade:179
+#: data/ui/multiband_compressor.glade:573
 #: data/ui/multiband_compressor.glade:948
-#: data/ui/multiband_compressor.glade:1326
-#: data/ui/multiband_compressor.glade:1704 data/ui/multiband_gate.glade:599
-#: data/ui/multiband_gate.glade:1005 data/ui/multiband_gate.glade:1415
-#: data/ui/multiband_gate.glade:1825
+#: data/ui/multiband_compressor.glade:1328
+#: data/ui/multiband_compressor.glade:1708 data/ui/multiband_gate.glade:597
+#: data/ui/multiband_gate.glade:1006 data/ui/multiband_gate.glade:1419
+#: data/ui/multiband_gate.glade:1832
 msgid "Release"
 msgstr "Uvoľnenie"
 
-#: data/ui/compressor.glade:438 data/ui/gate.glade:302
-#: data/ui/multiband_compressor.glade:541
+#: data/ui/compressor.glade:438 data/ui/gate.glade:341
+#: data/ui/multiband_compressor.glade:539
 #: data/ui/multiband_compressor.glade:913
-#: data/ui/multiband_compressor.glade:1291
-#: data/ui/multiband_compressor.glade:1669 data/ui/multiband_gate.glade:565
-#: data/ui/multiband_gate.glade:970 data/ui/multiband_gate.glade:1380
-#: data/ui/multiband_gate.glade:1790
+#: data/ui/multiband_compressor.glade:1293
+#: data/ui/multiband_compressor.glade:1673 data/ui/multiband_gate.glade:563
+#: data/ui/multiband_gate.glade:971 data/ui/multiband_gate.glade:1384
+#: data/ui/multiband_gate.glade:1797
 msgid "Attack"
 msgstr "Nábeh"
 
@@ -519,207 +518,206 @@ msgstr "Hore"
 msgid "Compression Mode"
 msgstr "Mód Kompresora"
 
-#: data/ui/compressor.glade:551
+#: data/ui/compressor.glade:552
 msgid "Pre-amplification"
 msgstr "Predzosilnenie"
 
-#: data/ui/compressor.glade:585
+#: data/ui/compressor.glade:586
 msgid "Reactivity"
 msgstr "Reaktivita"
 
-#: data/ui/compressor.glade:619 data/ui/limiter.glade:323
+#: data/ui/compressor.glade:620 data/ui/limiter.glade:324
 msgid "Lookahead"
 msgstr "Výhľad"
 
-#: data/ui/compressor.glade:632
+#: data/ui/compressor.glade:633
 msgid "Feed-forward"
 msgstr "Kanál-Vpred"
 
-#: data/ui/compressor.glade:633
+#: data/ui/compressor.glade:634
 msgid "Feed-back"
 msgstr "Kanál-Vzad"
 
-#: data/ui/compressor.glade:647 data/ui/equalizer_band.glade:48
+#: data/ui/compressor.glade:648 data/ui/equalizer_band.glade:48
 msgid "Type"
 msgstr "Typ"
 
-#: data/ui/compressor.glade:661 data/ui/deesser.glade:244
-#: data/ui/deesser.glade:354 data/ui/gate.glade:257
-#: data/ui/multiband_compressor.glade:514
+#: data/ui/compressor.glade:662 data/ui/deesser.glade:241
+#: data/ui/gate.glade:213 data/ui/multiband_compressor.glade:512
 #: data/ui/multiband_compressor.glade:886
-#: data/ui/multiband_compressor.glade:1264
-#: data/ui/multiband_compressor.glade:1642 data/ui/multiband_gate.glade:538
-#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1353
-#: data/ui/multiband_gate.glade:1763
+#: data/ui/multiband_compressor.glade:1266
+#: data/ui/multiband_compressor.glade:1646 data/ui/multiband_gate.glade:536
+#: data/ui/multiband_gate.glade:944 data/ui/multiband_gate.glade:1357
+#: data/ui/multiband_gate.glade:1770
 msgid "Peak"
 msgstr "Vrchol"
 
-#: data/ui/compressor.glade:662 data/ui/deesser.glade:243
-#: data/ui/gate.glade:256 data/ui/multiband_compressor.glade:513
+#: data/ui/compressor.glade:663 data/ui/deesser.glade:240
+#: data/ui/gate.glade:212 data/ui/multiband_compressor.glade:511
 #: data/ui/multiband_compressor.glade:885
-#: data/ui/multiband_compressor.glade:1263
-#: data/ui/multiband_compressor.glade:1641 data/ui/multiband_gate.glade:537
-#: data/ui/multiband_gate.glade:942 data/ui/multiband_gate.glade:1352
-#: data/ui/multiband_gate.glade:1762
+#: data/ui/multiband_compressor.glade:1265
+#: data/ui/multiband_compressor.glade:1645 data/ui/multiband_gate.glade:535
+#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1356
+#: data/ui/multiband_gate.glade:1769
 msgid "RMS"
 msgstr "RMS"
 
-#: data/ui/compressor.glade:663
+#: data/ui/compressor.glade:664
 msgid "Low-Pass"
 msgstr "Dolný Prechod"
 
-#: data/ui/compressor.glade:664
+#: data/ui/compressor.glade:665
 msgid "Uniform"
 msgstr "Rovnomerný"
 
-#: data/ui/compressor.glade:678 data/ui/deesser.glade:230
-#: data/ui/equalizer.glade:224 data/ui/equalizer_band.glade:79
-#: data/ui/multiband_compressor.glade:324 data/ui/multiband_gate.glade:348
-#: data/ui/stereo_tools.glade:485 data/ui/webrtc.glade:376
+#: data/ui/compressor.glade:679 data/ui/deesser.glade:227
+#: data/ui/equalizer.glade:225 data/ui/equalizer_band.glade:79
+#: data/ui/multiband_compressor.glade:322 data/ui/multiband_gate.glade:346
+#: data/ui/stereo_tools.glade:486 data/ui/webrtc.glade:377
 msgid "Mode"
 msgstr "Mód"
 
-#: data/ui/compressor.glade:692
+#: data/ui/compressor.glade:693
 msgid "Middle"
 msgstr "Stredný"
 
-#: data/ui/compressor.glade:693
+#: data/ui/compressor.glade:694
 msgid "Side"
 msgstr "Postranný"
 
-#: data/ui/compressor.glade:694 data/ui/delay.glade:157
-#: data/ui/equalizer.glade:474 data/ui/stereo_tools.glade:548
+#: data/ui/compressor.glade:695 data/ui/delay.glade:158
+#: data/ui/equalizer.glade:475 data/ui/stereo_tools.glade:549
 msgid "Left"
 msgstr "Ľavý"
 
-#: data/ui/compressor.glade:695 data/ui/delay.glade:189
-#: data/ui/equalizer.glade:515 data/ui/stereo_tools.glade:620
+#: data/ui/compressor.glade:696 data/ui/delay.glade:190
+#: data/ui/equalizer.glade:516 data/ui/stereo_tools.glade:621
 msgid "Right"
 msgstr "Pravý"
 
-#: data/ui/compressor.glade:709
+#: data/ui/compressor.glade:710
 msgid "Source"
 msgstr "Zdroj"
 
-#: data/ui/compressor.glade:725 data/ui/compressor.glade:1167
+#: data/ui/compressor.glade:726 data/ui/compressor.glade:1170
 msgid "Sidechain"
 msgstr "Postranný reťazec"
 
-#: data/ui/compressor.glade:821
+#: data/ui/compressor.glade:824
 msgid "Relative Release Threshold"
 msgstr "Relatívny Prah Uvoľnenia"
 
-#: data/ui/compressor.glade:832
+#: data/ui/compressor.glade:835
 #, fuzzy
 msgid "Boost Threshold"
 msgstr "Prah"
 
-#: data/ui/compressor.glade:843
+#: data/ui/compressor.glade:846
 #, fuzzy
 msgid "High-pass Frequency"
 msgstr "Vysokofrekvenčné tlmenie"
 
-#: data/ui/compressor.glade:854
+#: data/ui/compressor.glade:857
 #, fuzzy
 msgid "Low-pass Frequency"
 msgstr "Nízkopriepustná Frekvencia"
 
-#: data/ui/compressor.glade:865
+#: data/ui/compressor.glade:868
 #, fuzzy
 msgid "High-pass Filter Mode"
 msgstr "Horný prechod"
 
-#: data/ui/compressor.glade:876
+#: data/ui/compressor.glade:879
 msgid "Low-pass Filter Mode"
 msgstr "Nízkopriepustný Mód Filtra"
 
-#: data/ui/compressor.glade:889 data/ui/compressor.glade:906
+#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
 #: data/ui/equalizer_band.glade:60
 msgid "Off"
 msgstr "Vypnutý"
 
-#: data/ui/compressor.glade:890 data/ui/compressor.glade:907
+#: data/ui/compressor.glade:893 data/ui/compressor.glade:910
 msgid "12 dB/oct"
 msgstr "Níska pásmová priepusť 12dB/okt"
 
-#: data/ui/compressor.glade:891 data/ui/compressor.glade:908
+#: data/ui/compressor.glade:894 data/ui/compressor.glade:911
 msgid "24 dB/oct"
 msgstr "Níska pásmová priepusť 24dB/okt"
 
-#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
+#: data/ui/compressor.glade:895 data/ui/compressor.glade:912
 msgid "36 dB/oct"
 msgstr "Níska pásmová priepusť 36dB/okt"
 
-#: data/ui/compressor.glade:932
+#: data/ui/compressor.glade:935
 msgid "Advanced"
 msgstr "Pokročilé"
 
-#: data/ui/compressor.glade:1243
+#: data/ui/compressor.glade:1244
 msgid "Curve"
 msgstr "Krivka"
 
-#: data/ui/convolver.glade:91
+#: data/ui/convolver.glade:92
 msgid "Convolver"
 msgstr "Svinovač"
 
-#: data/ui/convolver.glade:125
+#: data/ui/convolver.glade:126
 msgid "Import Impulse"
 msgstr "Načítať Impulz"
 
-#: data/ui/convolver.glade:129
+#: data/ui/convolver.glade:130
 msgid "Import Impulse Response File"
 msgstr "Načitať Odpoveď Impulzu"
 
-#: data/ui/convolver.glade:247
+#: data/ui/convolver.glade:248
 msgid "L"
 msgstr "Ľ"
 
-#: data/ui/convolver.glade:261
+#: data/ui/convolver.glade:262
 msgid "R"
 msgstr "P"
 
-#: data/ui/convolver.glade:324
+#: data/ui/convolver.glade:325
 #, fuzzy
 msgid "Duration"
 msgstr "Zoslabenie"
 
-#: data/ui/convolver.glade:335
+#: data/ui/convolver.glade:336
 msgid "Samples"
 msgstr "Vzorky"
 
-#: data/ui/convolver.glade:367 src/convolver_ui.cpp:283
+#: data/ui/convolver.glade:368 src/convolver_ui.cpp:283
 msgid "Impulse Response"
 msgstr "Odpoveď Impulzu"
 
-#: data/ui/convolver.glade:389
+#: data/ui/convolver.glade:390
 msgid "Select the impulse Response File"
 msgstr "Zvolte Súbor Impulzu"
 
-#: data/ui/convolver.glade:409 src/spectrum_settings_ui.cpp:176
+#: data/ui/convolver.glade:410 src/spectrum_settings_ui.cpp:176
 msgid "Spectrum"
 msgstr "Spektrum"
 
-#: data/ui/convolver.glade:450
+#: data/ui/convolver.glade:451
 msgid "Stereo Width"
 msgstr "Šírka sterea"
 
-#: data/ui/crossfeed.glade:63
+#: data/ui/crossfeed.glade:62
 msgid "Jmeier"
 msgstr "Jmeier"
 
-#: data/ui/crossfeed.glade:76 data/ui/filter.glade:183 data/ui/reverb.glade:259
+#: data/ui/crossfeed.glade:75 data/ui/filter.glade:184 data/ui/reverb.glade:260
 msgid "Default"
 msgstr "Predvolený"
 
-#: data/ui/crossfeed.glade:89
+#: data/ui/crossfeed.glade:88
 msgid "Cmoy"
 msgstr "Slúchadkový zosilovač (CMoy)"
 
-#: data/ui/crossfeed.glade:120
+#: data/ui/crossfeed.glade:119
 msgid "Cutoff"
 msgstr "Zrezanie"
 
-#: data/ui/crossfeed.glade:153
+#: data/ui/crossfeed.glade:152
 msgid "Feed"
 msgstr "Kanál"
 
@@ -727,115 +725,132 @@ msgstr "Kanál"
 msgid "Crossfeed"
 msgstr "Prelínanie kanálov"
 
-#: data/ui/crystalizer.glade:115
+#: data/ui/crystalizer.glade:92
 msgid "Crystalizer"
 msgstr "Kryštalizátor"
 
-#: data/ui/crystalizer.glade:187
+#: data/ui/crystalizer.glade:137
 msgid "Aggressive Mode"
 msgstr "Agresívny Režim"
 
-#: data/ui/crystalizer.glade:447
+#: data/ui/crystalizer.glade:395
 msgid "Loudness Range"
 msgstr "Dynamický Rozsah"
 
-#: data/ui/crystalizer.glade:466
+#: data/ui/crystalizer.glade:414
 msgid "Before"
 msgstr "Pred"
 
-#: data/ui/crystalizer.glade:479
+#: data/ui/crystalizer.glade:427
 msgid "After"
 msgstr "Po"
 
 #: data/ui/crystalizer_band.glade:27 data/ui/equalizer_band.glade:313
-#: data/ui/stereo_tools.glade:574 data/ui/stereo_tools.glade:633
+#: data/ui/stereo_tools.glade:575 data/ui/stereo_tools.glade:634
 msgid "Mute"
 msgstr "Stíšený"
 
-#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:483
+#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:481
 #: data/ui/multiband_compressor.glade:855
-#: data/ui/multiband_compressor.glade:1233
-#: data/ui/multiband_compressor.glade:1611 data/ui/multiband_gate.glade:507
-#: data/ui/multiband_gate.glade:912 data/ui/multiband_gate.glade:1322
-#: data/ui/multiband_gate.glade:1732
+#: data/ui/multiband_compressor.glade:1235
+#: data/ui/multiband_compressor.glade:1615 data/ui/multiband_gate.glade:505
+#: data/ui/multiband_gate.glade:913 data/ui/multiband_gate.glade:1326
+#: data/ui/multiband_gate.glade:1739
 msgid "Bypass"
 msgstr "Prepustiť"
 
-#: data/ui/deesser.glade:128
+#: data/ui/deesser.glade:127
 msgid "Deesser"
 msgstr "Deesser"
 
-#: data/ui/deesser.glade:216 data/ui/gate.glade:195
+#: data/ui/deesser.glade:213 data/ui/gate.glade:198
 msgid "Detection"
 msgstr "Detekcia"
 
-#: data/ui/deesser.glade:258
+#: data/ui/deesser.glade:255
 msgid "Wide"
 msgstr "Široký"
 
-#: data/ui/deesser.glade:259 data/ui/deesser.glade:288
+#: data/ui/deesser.glade:256
 msgid "Split"
 msgstr "Rozdeliť"
 
-#: data/ui/deesser.glade:407
-msgid "Level"
+#: data/ui/deesser.glade:285
+#, fuzzy
+msgid "F1 Split"
+msgstr "Rozdeliť"
+
+#: data/ui/deesser.glade:318
+#, fuzzy
+msgid "F1 Gain"
+msgstr "Zisk"
+
+#: data/ui/deesser.glade:352
+#, fuzzy
+msgid "F2 Peak"
+msgstr "Vrchol"
+
+#: data/ui/deesser.glade:406
+#, fuzzy
+msgid "F2 Level"
 msgstr "Úroveň"
 
-#: data/ui/deesser.glade:420
-msgid "Peak Q"
+#: data/ui/deesser.glade:419
+#, fuzzy
+msgid "F2 Peak Q"
 msgstr "Vrchol Q"
 
-#: data/ui/deesser.glade:452
+#: data/ui/deesser.glade:451
 msgid "Laxity"
 msgstr "Nedbanlivosť"
 
-#: data/ui/deesser.glade:778 data/ui/multiband_gate.glade:767
-#: data/ui/multiband_gate.glade:1197 data/ui/multiband_gate.glade:1607
-#: data/ui/multiband_gate.glade:2017
+#: data/ui/deesser.glade:779 data/ui/multiband_gate.glade:767
+#: data/ui/multiband_gate.glade:1201 data/ui/multiband_gate.glade:1614
+#: data/ui/multiband_gate.glade:2027
 msgid "Reduction"
 msgstr "Redukcia"
 
-#: data/ui/deesser.glade:791
+#: data/ui/deesser.glade:792
 msgid "Detected"
 msgstr "Zistené"
 
-#: data/ui/delay.glade:91
+#: data/ui/delay.glade:92
 msgid "Delay"
 msgstr "Onsekorenie"
 
-#: data/ui/equalizer.glade:44
+#: data/ui/equalizer.glade:45
 msgid "Equalizer"
 msgstr "Ekvalizér"
 
-#: data/ui/equalizer.glade:153
+#: data/ui/equalizer.glade:154
 msgid "Split Channels"
 msgstr "Rozdeliť Kanály"
 
-#: data/ui/equalizer.glade:179
+#: data/ui/equalizer.glade:180
 msgid "IIR"
 msgstr "IIR"
 
-#: data/ui/equalizer.glade:180
+#: data/ui/equalizer.glade:181
 msgid "FIR"
 msgstr "FIR"
 
-#: data/ui/equalizer.glade:181
+#: data/ui/equalizer.glade:182
 msgid "FFT"
 msgstr "FFT"
 
-#: data/ui/equalizer.glade:211
+#: data/ui/equalizer.glade:212
 msgid "Bands"
 msgstr "Bands"
 
-#: data/ui/equalizer.glade:233
+#: data/ui/equalizer.glade:234
 msgid "Flat Response"
 msgstr "Vyhladiť"
 
-#: data/ui/equalizer.glade:248
+#: data/ui/equalizer.glade:249
 msgid "Calculate Frequencies"
 msgstr "Vypočítať Frekvencie"
 
-#: data/ui/equalizer.glade:262
+#: data/ui/equalizer.glade:263
 msgid "Import APO Presets"
 msgstr "Načítať APO predvoľbu"
 
@@ -863,7 +878,7 @@ msgstr "Dolný Prah"
 msgid "Notch"
 msgstr "Zárez"
 
-#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:314
+#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:315
 msgid "Resonance"
 msgstr "Rezonancia"
 
@@ -907,12 +922,12 @@ msgstr "Kvalita"
 msgid "Width"
 msgstr "Šírka"
 
-#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:496
+#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:494
 #: data/ui/multiband_compressor.glade:868
-#: data/ui/multiband_compressor.glade:1246
-#: data/ui/multiband_compressor.glade:1624 data/ui/multiband_gate.glade:520
-#: data/ui/multiband_gate.glade:925 data/ui/multiband_gate.glade:1335
-#: data/ui/multiband_gate.glade:1745
+#: data/ui/multiband_compressor.glade:1248
+#: data/ui/multiband_compressor.glade:1628 data/ui/multiband_gate.glade:518
+#: data/ui/multiband_gate.glade:926 data/ui/multiband_gate.glade:1339
+#: data/ui/multiband_gate.glade:1752
 msgid "Solo"
 msgstr "Sólo"
 
@@ -920,80 +935,80 @@ msgstr "Sólo"
 msgid "Apply"
 msgstr "Použiť"
 
-#: data/ui/exciter.glade:117
+#: data/ui/exciter.glade:118
 msgid "Exciter"
 msgstr "Zvukový budič"
 
-#: data/ui/exciter.glade:384 data/ui/maximizer.glade:165
+#: data/ui/exciter.glade:384 data/ui/maximizer.glade:166
 #, fuzzy
 msgid "Ceiling"
 msgstr "Obmedzenie [dB]"
 
-#: data/ui/filter.glade:98
+#: data/ui/filter.glade:99
 msgid "Filter"
 msgstr "Filter"
 
-#: data/ui/filter.glade:147
+#: data/ui/filter.glade:148
 msgid "Muted"
 msgstr "Stíšený"
 
-#: data/ui/filter.glade:159 data/ui/reverb.glade:233
+#: data/ui/filter.glade:160 data/ui/reverb.glade:234
 msgid "Disco"
 msgstr "Disko"
 
-#: data/ui/filter.glade:171
+#: data/ui/filter.glade:172
 msgid "Distant Headphones"
 msgstr "Vzdialená Slúchadlá"
 
-#: data/ui/filter.glade:246
+#: data/ui/filter.glade:247
 msgid "12dB/oct Lowpass"
 msgstr "Níska pásmová priepusť 12dB/okt"
 
-#: data/ui/filter.glade:247
+#: data/ui/filter.glade:248
 msgid "24dB/oct Lowpass"
 msgstr "Níska pásmová priepusť 24dB/okt"
 
-#: data/ui/filter.glade:248
+#: data/ui/filter.glade:249
 msgid "36dB/oct Lowpass"
 msgstr "Níska pásmová priepusť 36dB/okt"
 
-#: data/ui/filter.glade:249
+#: data/ui/filter.glade:250
 msgid "12dB/oct Highpass"
 msgstr "Vysoká pásmová priepusť 12dB/okt"
 
-#: data/ui/filter.glade:250
+#: data/ui/filter.glade:251
 msgid "24dB/oct Highpass"
 msgstr "Vysoká pásmová priepusť 24dB/okt"
 
-#: data/ui/filter.glade:251
+#: data/ui/filter.glade:252
 msgid "36dB/oct Highpass"
 msgstr "Vysoká pásmová priepusť 36dB/okt"
 
-#: data/ui/filter.glade:252
+#: data/ui/filter.glade:253
 msgid "6dB/oct Bandpass"
 msgstr "Pásmová priepusť 6dB/okt"
 
-#: data/ui/filter.glade:253
+#: data/ui/filter.glade:254
 msgid "12dB/oct Bandpass"
 msgstr "Pásmová priepusť 12dB/okt"
 
-#: data/ui/filter.glade:254
+#: data/ui/filter.glade:255
 msgid "18dB/oct Bandpass"
 msgstr "Pásmová priepusť 18dB/okt"
 
-#: data/ui/filter.glade:255
+#: data/ui/filter.glade:256
 msgid "6dB/oct Bandreject"
 msgstr "Vylúčenie pásma 6dB/okt"
 
-#: data/ui/filter.glade:256
+#: data/ui/filter.glade:257
 msgid "12dB/oct Bandreject"
 msgstr "Vylúčenie pásma 12dB/okt"
 
-#: data/ui/filter.glade:257
+#: data/ui/filter.glade:258
 msgid "18dB/oct Bandreject"
 msgstr "Vylúčenie pásma 18dB/okt"
 
-#: data/ui/filter.glade:349
+#: data/ui/filter.glade:350
 msgid "Inertia"
 msgstr "Zotrvačnosť"
 
@@ -1037,49 +1052,50 @@ msgstr "Spracovať Všetky Vstupy"
 msgid "Priority"
 msgstr "Priorita"
 
-#: data/ui/gate.glade:98
+#: data/ui/gate.glade:99
 msgid "Gate"
 msgstr "Brána"
 
-#: data/ui/gate.glade:209
+#: data/ui/gate.glade:240
+#, fuzzy
+msgid "Maximum Gain Reduction"
+msgstr "Redukcia zosilnenia"
+
+#: data/ui/gate.glade:289
 msgid "Stereo Link"
 msgstr "Spojenie sterea"
 
-#: data/ui/gate.glade:222 data/ui/maximizer.glade:293
-msgid "Gain Reduction"
-msgstr "Redukcia zosilnenia"
-
-#: data/ui/gate.glade:273
+#: data/ui/gate.glade:304
 msgid "Average"
 msgstr "Priemerná"
 
-#: data/ui/gate.glade:274
+#: data/ui/gate.glade:305
 msgid "Maximum"
 msgstr "Maximálna"
 
-#: data/ui/gate.glade:525
+#: data/ui/gate.glade:578
 msgid "Input Level"
 msgstr "Vstupný Obmedzovač"
 
-#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:811
-#: data/ui/multiband_gate.glade:1220 data/ui/multiband_gate.glade:1630
-#: data/ui/multiband_gate.glade:2040
+#: data/ui/gate.glade:797 data/ui/multiband_gate.glade:812
+#: data/ui/multiband_gate.glade:1224 data/ui/multiband_gate.glade:1637
+#: data/ui/multiband_gate.glade:2050
 msgid "Gating"
 msgstr "Hradlo"
 
-#: data/ui/limiter.glade:97 data/ui/webrtc.glade:421
+#: data/ui/limiter.glade:98 data/ui/webrtc.glade:422
 msgid "Limiter"
 msgstr "Obmedzovač"
 
-#: data/ui/limiter.glade:176
+#: data/ui/limiter.glade:175
 msgid "Automatic Smoothing Control"
 msgstr "Automatické Vyhladenie"
 
-#: data/ui/limiter.glade:190
+#: data/ui/limiter.glade:189
 msgid "Automatic Leveling"
 msgstr "Automatické Úrovne"
 
-#: data/ui/limiter.glade:222
+#: data/ui/limiter.glade:221
 #, fuzzy
 msgid "Input Gain"
 msgstr "Vstupné Zosilnenie"
@@ -1088,135 +1104,139 @@ msgstr "Vstupné Zosilnenie"
 msgid "Limit"
 msgstr "Obmedzenie"
 
-#: data/ui/limiter.glade:358
+#: data/ui/limiter.glade:359
 msgid "Oversampling"
 msgstr "Prevzorkovanie"
 
-#: data/ui/limiter.glade:411
+#: data/ui/limiter.glade:413
 msgid "Output Gain"
 msgstr "Výstupný Zisk"
 
-#: data/ui/limiter.glade:429
+#: data/ui/limiter.glade:431
 msgid "ASC"
 msgstr "ASC"
 
-#: data/ui/limiter.glade:584
+#: data/ui/limiter.glade:586
 msgid "Attenuation"
 msgstr "Zoslabenie"
 
-#: data/ui/loudness.glade:91
+#: data/ui/loudness.glade:92
 msgid "Loudness Compensator"
 msgstr "Kompenzácia Hlasitosti"
 
-#: data/ui/loudness.glade:147
-msgid "Standard"
-msgstr "Štandardný"
-
-#: data/ui/loudness.glade:161
-msgid "Flat"
-msgstr "Rovný"
-
-#: data/ui/loudness.glade:162
-msgid "ISO226-2003"
-msgstr "ISO226-2003"
-
-#: data/ui/loudness.glade:163
-msgid "Fletcher-Munson"
-msgstr "Fletcher-Munson"
-
-#: data/ui/loudness.glade:164
-msgid "Robinson-Dadson"
-msgstr "Robinson-Dadson"
-
-#: data/ui/loudness.glade:174
-msgid "Reference Signal"
-msgstr "Referenčný Signál"
-
-#: data/ui/loudness.glade:199
+#: data/ui/loudness.glade:155
 #, fuzzy
 msgid "FFT Size"
 msgstr "Veľkosť miestnosti"
 
-#: data/ui/maximizer.glade:96
+#: data/ui/loudness.glade:205
+msgid "Standard"
+msgstr "Štandardný"
+
+#: data/ui/loudness.glade:220
+msgid "Flat"
+msgstr "Rovný"
+
+#: data/ui/loudness.glade:221
+msgid "ISO226-2003"
+msgstr "ISO226-2003"
+
+#: data/ui/loudness.glade:222
+msgid "Fletcher-Munson"
+msgstr "Fletcher-Munson"
+
+#: data/ui/loudness.glade:223
+msgid "Robinson-Dadson"
+msgstr "Robinson-Dadson"
+
+#: data/ui/loudness.glade:259
+msgid "Reference Signal"
+msgstr "Referenčný Signál"
+
+#: data/ui/maximizer.glade:97
 msgid "Maximizer"
 msgstr "Zosilovač"
 
-#: data/ui/multiband_compressor.glade:140
+#: data/ui/maximizer.glade:296
+msgid "Gain Reduction"
+msgstr "Redukcia zosilnenia"
+
+#: data/ui/multiband_compressor.glade:141
 msgid "Multiband Compressor"
 msgstr "Viacpásmový Kompresor"
 
-#: data/ui/multiband_compressor.glade:338 data/ui/multiband_gate.glade:362
+#: data/ui/multiband_compressor.glade:336 data/ui/multiband_gate.glade:360
 msgid "LR4"
 msgstr "LR4"
 
-#: data/ui/multiband_compressor.glade:339 data/ui/multiband_gate.glade:363
+#: data/ui/multiband_compressor.glade:337 data/ui/multiband_gate.glade:361
 msgid "LR8"
 msgstr "LR8"
 
-#: data/ui/multiband_compressor.glade:353 data/ui/multiband_gate.glade:377
+#: data/ui/multiband_compressor.glade:351 data/ui/multiband_gate.glade:375
 msgid "Split 1/2"
 msgstr "Rozdeliť 1/2"
 
-#: data/ui/multiband_compressor.glade:366 data/ui/multiband_gate.glade:390
+#: data/ui/multiband_compressor.glade:364 data/ui/multiband_gate.glade:388
 msgid "Split 2/3"
 msgstr "Rozdeliť 2/3"
 
-#: data/ui/multiband_compressor.glade:379 data/ui/multiband_gate.glade:403
+#: data/ui/multiband_compressor.glade:377 data/ui/multiband_gate.glade:401
 msgid "Split 3/4"
 msgstr "Rozdeliť 3/4"
 
 #: data/ui/multiband_compressor.glade:754
-#: data/ui/multiband_compressor.glade:1131
-#: data/ui/multiband_compressor.glade:1509
-#: data/ui/multiband_compressor.glade:1887
+#: data/ui/multiband_compressor.glade:1133
+#: data/ui/multiband_compressor.glade:1513
+#: data/ui/multiband_compressor.glade:1893
 msgid "Compression"
 msgstr "Kompresia"
 
-#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:894
+#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:895
 msgid "Sub Band"
 msgstr "Spodné Pásmo"
 
-#: data/ui/multiband_compressor.glade:1214 data/ui/multiband_gate.glade:1303
+#: data/ui/multiband_compressor.glade:1216 data/ui/multiband_gate.glade:1307
 msgid "Low Band"
 msgstr "Nízke Pásmo"
 
-#: data/ui/multiband_compressor.glade:1592 data/ui/multiband_gate.glade:1713
+#: data/ui/multiband_compressor.glade:1596 data/ui/multiband_gate.glade:1720
 msgid "Mid Band"
 msgstr "Stredné Pásmo"
 
-#: data/ui/multiband_compressor.glade:1970 data/ui/multiband_gate.glade:2123
+#: data/ui/multiband_compressor.glade:1976 data/ui/multiband_gate.glade:2133
 msgid "High Band"
 msgstr "Vysoké Pásmo"
 
-#: data/ui/multiband_gate.glade:140
+#: data/ui/multiband_gate.glade:141
 msgid "Multiband Gate"
 msgstr "Viacpásmová Brána"
 
-#: data/ui/pitch.glade:103
+#: data/ui/pitch.glade:104
 msgid "Pitch"
 msgstr "Výška tónu"
 
-#: data/ui/pitch.glade:178
+#: data/ui/pitch.glade:179
 msgid "Cents"
 msgstr "Centy"
 
-#: data/ui/pitch.glade:209
+#: data/ui/pitch.glade:210
 msgid "Semitones"
 msgstr "Poltóny"
 
-#: data/ui/pitch.glade:240
+#: data/ui/pitch.glade:241
 msgid "Octaves"
 msgstr "Okrávy"
 
-#: data/ui/pitch.glade:271
+#: data/ui/pitch.glade:272
 msgid "Crispness"
 msgstr "Krehkosť"
 
-#: data/ui/pitch.glade:311
+#: data/ui/pitch.glade:312
 msgid "Faster"
 msgstr "Rýchlo"
 
-#: data/ui/pitch.glade:325
+#: data/ui/pitch.glade:326
 msgid "Preserve Formant"
 msgstr "Zachovať žložku rozhodujúcu o farbe zvuku"
 
@@ -1314,83 +1334,83 @@ msgstr "Pipeline vstup"
 msgid "Pipeline Output"
 msgstr "Pipeline výstup"
 
-#: data/ui/reverb.glade:131
+#: data/ui/reverb.glade:132
 msgid "Reverberation"
 msgstr "Ozvena"
 
-#: data/ui/reverb.glade:181
+#: data/ui/reverb.glade:182
 msgid "Ambience"
 msgstr "Okolie"
 
-#: data/ui/reverb.glade:194
+#: data/ui/reverb.glade:195
 msgid "Empty Walls"
 msgstr "Prázdne Steny"
 
-#: data/ui/reverb.glade:207
+#: data/ui/reverb.glade:208
 msgid "Room"
 msgstr "Miestnosť"
 
-#: data/ui/reverb.glade:220
+#: data/ui/reverb.glade:221
 msgid "Large Empty Hall"
 msgstr "Veľká Miestnosť (Prázdna)"
 
-#: data/ui/reverb.glade:246
+#: data/ui/reverb.glade:247
 msgid "Large Occupied Hall"
 msgstr "Veľká miestnosť (Plná)"
 
-#: data/ui/reverb.glade:361
+#: data/ui/reverb.glade:362
 msgid "Pre Delay"
 msgstr "Predspozdnenie"
 
-#: data/ui/reverb.glade:374
+#: data/ui/reverb.glade:375
 msgid "Decay Time"
 msgstr "Čas Dozvuku"
 
-#: data/ui/reverb.glade:439
+#: data/ui/reverb.glade:441
 msgid "Dry"
 msgstr "Zkúšobný"
 
-#: data/ui/reverb.glade:471
+#: data/ui/reverb.glade:474
 msgid "Bass Cut"
 msgstr "Odrezanie Bassov"
 
-#: data/ui/reverb.glade:522
+#: data/ui/reverb.glade:525
 msgid "Treble Cut"
 msgstr "Odrezanie Výšok"
 
-#: data/ui/reverb.glade:565
+#: data/ui/reverb.glade:568
 msgid "Diffusion"
 msgstr "Rozptylovanie"
 
-#: data/ui/reverb.glade:577
+#: data/ui/reverb.glade:580
 msgid "Room Size"
 msgstr "Veľkosť Miestnosti"
 
-#: data/ui/reverb.glade:590
+#: data/ui/reverb.glade:593
 msgid "Small"
 msgstr "Malá"
 
-#: data/ui/reverb.glade:591
+#: data/ui/reverb.glade:594
 msgid "Medium"
 msgstr "Stredná"
 
-#: data/ui/reverb.glade:592
+#: data/ui/reverb.glade:595
 msgid "Large"
 msgstr "Veľká"
 
-#: data/ui/reverb.glade:593
+#: data/ui/reverb.glade:596
 msgid "Tunnel"
 msgstr "Tunel"
 
-#: data/ui/reverb.glade:594
+#: data/ui/reverb.glade:597
 msgid "Large/smooth"
 msgstr "Veľký/plynulý"
 
-#: data/ui/reverb.glade:595
+#: data/ui/reverb.glade:598
 msgid "Experimental"
 msgstr "Pokusný"
 
-#: data/ui/reverb.glade:608
+#: data/ui/reverb.glade:611
 msgid "High Frequency Damping"
 msgstr "Vysokofrekvenčné tlmenie"
 
@@ -1462,23 +1482,23 @@ msgstr "Výška"
 msgid "Points"
 msgstr "Body"
 
-#: data/ui/stereo_tools.glade:109
+#: data/ui/stereo_tools.glade:110
 msgid "Stereo Tools"
 msgstr "Stereo Nástroje"
 
-#: data/ui/stereo_tools.glade:231
+#: data/ui/stereo_tools.glade:230
 msgid "Softclip"
 msgstr "Softclip"
 
-#: data/ui/stereo_tools.glade:255 data/ui/stereo_tools.glade:671
+#: data/ui/stereo_tools.glade:254 data/ui/stereo_tools.glade:672
 msgid "Balance"
 msgstr "Vyváženie"
 
-#: data/ui/stereo_tools.glade:287
+#: data/ui/stereo_tools.glade:286
 msgid "S/C Level"
 msgstr "S/C Úroveň"
 
-#: data/ui/stereo_tools.glade:345
+#: data/ui/stereo_tools.glade:344
 #, fuzzy
 msgid "Side Level"
 msgstr "Postranná Úroveň"
@@ -1487,144 +1507,144 @@ msgstr "Postranná Úroveň"
 msgid "Side Balance"
 msgstr "Vyváženie Strán"
 
-#: data/ui/stereo_tools.glade:428
+#: data/ui/stereo_tools.glade:429
 msgid "Middle Level"
 msgstr "Stredová Úroveň"
 
-#: data/ui/stereo_tools.glade:441
+#: data/ui/stereo_tools.glade:442
 msgid "Middle Panorama"
 msgstr "Stredná paronáma"
 
-#: data/ui/stereo_tools.glade:499
+#: data/ui/stereo_tools.glade:500
 msgid "LR > LR (Stereo Default)"
 msgstr "ĽP > PĽ (Štandardné Stereo)"
 
-#: data/ui/stereo_tools.glade:500
+#: data/ui/stereo_tools.glade:501
 msgid "LR > MS (Stereo to Mid-Side)"
 msgstr "ĽP > SS (Stereo ku strejnej strane)"
 
-#: data/ui/stereo_tools.glade:501
+#: data/ui/stereo_tools.glade:502
 msgid "MS > LR (Mid-Side to Stereo)"
 msgstr "SS > ĽP (Stredná strana ku Stereu)"
 
-#: data/ui/stereo_tools.glade:502
+#: data/ui/stereo_tools.glade:503
 msgid "LR > LL (Mono Left Channel)"
 msgstr "ĽP > ĽĽ (Mono Ľavý Kanál)"
 
-#: data/ui/stereo_tools.glade:503
+#: data/ui/stereo_tools.glade:504
 msgid "LR > RR (Mono Right Channel)"
 msgstr "ĽP > PP (Mono Pravý Kanál)"
 
-#: data/ui/stereo_tools.glade:504
+#: data/ui/stereo_tools.glade:505
 msgid "LR > L+R (Mono Sum L+R)"
 msgstr "ĽP > Ľ+P (Mono Sčítanie Ľ+P)"
 
-#: data/ui/stereo_tools.glade:505
+#: data/ui/stereo_tools.glade:506
 msgid "LR > RL (Stereo Flip Channels)"
 msgstr "ĽP > PĽ (Stereo Preklopené Kanály)"
 
-#: data/ui/stereo_tools.glade:522
+#: data/ui/stereo_tools.glade:523
 msgid "Stereo Matrix"
 msgstr "Matrice Sterea"
 
-#: data/ui/stereo_tools.glade:561 data/ui/stereo_tools.glade:602
+#: data/ui/stereo_tools.glade:562 data/ui/stereo_tools.glade:603
 msgid "Invert Phase"
 msgstr "Preklopiť fázu"
 
-#: data/ui/stereo_tools.glade:703
+#: data/ui/stereo_tools.glade:704
 msgid "Delay L/R"
 msgstr "Opozdenie Ľ/P"
 
-#: data/ui/stereo_tools.glade:737
+#: data/ui/stereo_tools.glade:738
 msgid "Stereo Base"
 msgstr "Základ Sterea"
 
-#: data/ui/stereo_tools.glade:770
+#: data/ui/stereo_tools.glade:771
 msgid "Stereo Phase"
 msgstr "Fáza Sterea"
 
-#: data/ui/webrtc.glade:97
+#: data/ui/webrtc.glade:98
 msgid "WebRTC"
 msgstr "WebRTC"
 
-#: data/ui/webrtc.glade:163 data/ui/webrtc.glade:283 data/ui/webrtc.glade:353
-#: data/ui/webrtc.glade:523
+#: data/ui/webrtc.glade:164 data/ui/webrtc.glade:284 data/ui/webrtc.glade:354
+#: data/ui/webrtc.glade:524
 msgid "Enable"
 msgstr "Povolené"
 
-#: data/ui/webrtc.glade:184
+#: data/ui/webrtc.glade:185
 msgid "Extended Filter"
 msgstr "Rozšírený Filter"
 
-#: data/ui/webrtc.glade:197
+#: data/ui/webrtc.glade:198
 msgid "Delay Agnostic"
 msgstr "Absolútne opozdenie"
 
-#: data/ui/webrtc.glade:209
+#: data/ui/webrtc.glade:210
 msgid "High Pass Filter"
 msgstr "Horný prechod"
 
-#: data/ui/webrtc.glade:238 data/ui/webrtc.glade:306
+#: data/ui/webrtc.glade:239 data/ui/webrtc.glade:307
 msgid "Suppresion Level"
 msgstr "Redukcia zosilnenia"
 
-#: data/ui/webrtc.glade:251 data/ui/webrtc.glade:319 data/ui/webrtc.glade:575
+#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
 msgid "Low"
 msgstr "Nízky"
 
-#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
+#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
 msgid "Moderate"
 msgstr "Stredný"
 
-#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
+#: data/ui/webrtc.glade:254 data/ui/webrtc.glade:322 data/ui/webrtc.glade:578
 msgid "High"
 msgstr "Vysoký"
 
-#: data/ui/webrtc.glade:270
+#: data/ui/webrtc.glade:271
 msgid "Echo Canceller"
 msgstr "Zrušiť Ozvenu"
 
-#: data/ui/webrtc.glade:322
+#: data/ui/webrtc.glade:323
 msgid "Very High"
 msgstr "Veľmi vysoká"
 
-#: data/ui/webrtc.glade:339
+#: data/ui/webrtc.glade:340
 msgid "Noise Suppressor"
 msgstr "Potláčač Šumu"
 
-#: data/ui/webrtc.glade:389
+#: data/ui/webrtc.glade:390
 msgid "Adaptive Digital"
 msgstr "Prispôsobivý Digitálny"
 
-#: data/ui/webrtc.glade:390
+#: data/ui/webrtc.glade:391
 msgid "Fixed Digital"
 msgstr "Pevný Digitálny"
 
-#: data/ui/webrtc.glade:407
+#: data/ui/webrtc.glade:408
 msgid "Gain Controller"
 msgstr "Ovládač Zosilnenia"
 
-#: data/ui/webrtc.glade:445
+#: data/ui/webrtc.glade:446
 msgid "Target Level"
 msgstr "Cielová Úroveň"
 
-#: data/ui/webrtc.glade:475
+#: data/ui/webrtc.glade:476
 msgid "Maximum Gain"
 msgstr "Maximálny Zisk"
 
-#: data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:549
 msgid "Detection Likelihood"
 msgstr "Pravdepodobnosť Zistenia"
 
-#: data/ui/webrtc.glade:561
+#: data/ui/webrtc.glade:562
 msgid "Frame Size"
 msgstr "Veľkosť Rámca"
 
-#: data/ui/webrtc.glade:574
+#: data/ui/webrtc.glade:575
 msgid "Very Low"
 msgstr "Veľmi nízka"
 
-#: data/ui/webrtc.glade:611
+#: data/ui/webrtc.glade:612
 msgid "Voice Detector"
 msgstr "Detekcia Reči"
 
@@ -1718,6 +1738,10 @@ msgstr "Všeobecné"
 #: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr "Pulseaudio"
+
+#, fuzzy
+#~ msgid "Gain Detection"
+#~ msgstr "Redukcia zosilnenia"
 
 #~ msgid "Scale"
 #~ msgstr "Mierka"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-22 15:29+0200\n"
+"POT-Creation-Date: 2020-08-24 16:51+0200\n"
 "PO-Revision-Date: 2017-10-14 10:20+0200\n"
 "Last-Translator: Patrik Nilsson <translation_AT_hembas.se>\n"
 "Language-Team: \n"
@@ -86,8 +86,8 @@ msgid "Input Limiter"
 msgstr "Ingångs-begränsning"
 
 #: data/com.github.wwmm.pulseeffects.appdata.xml.in:52
-#: data/ui/compressor.glade:111 data/ui/compressor.glade:494
-#: data/ui/webrtc.glade:509
+#: data/ui/compressor.glade:112 data/ui/compressor.glade:494
+#: data/ui/webrtc.glade:510
 msgid "Compressor"
 msgstr "Kompressor"
 
@@ -122,12 +122,12 @@ msgstr "Program"
 msgid "Format"
 msgstr "Format"
 
-#: data/ui/app_info.glade:75 data/ui/convolver.glade:283
+#: data/ui/app_info.glade:75 data/ui/convolver.glade:284
 msgid "Rate"
 msgstr "Takt"
 
 #: data/ui/app_info.glade:102 data/ui/pulse_info.glade:238
-#: data/ui/stereo_tools.glade:653
+#: data/ui/stereo_tools.glade:654
 msgid "Channels"
 msgstr "Kanaler"
 
@@ -166,7 +166,7 @@ msgstr "Testsignal"
 msgid "Global Bypass"
 msgstr ""
 
-#: data/ui/application.glade:170 data/ui/equalizer.glade:277
+#: data/ui/application.glade:170 data/ui/equalizer.glade:278
 #: data/ui/general_settings.glade:107
 msgid "Settings"
 msgstr "Inställningar"
@@ -175,175 +175,174 @@ msgstr "Inställningar"
 msgid "Help"
 msgstr ""
 
-#: data/ui/application.glade:215 data/ui/crossfeed.glade:49
-#: data/ui/equalizer.glade:333 data/ui/filter.glade:230
-#: data/ui/reverb.glade:310 src/presets_menu_ui.cpp:113
+#: data/ui/application.glade:215 data/ui/crossfeed.glade:48
+#: data/ui/equalizer.glade:334 data/ui/filter.glade:231
+#: data/ui/reverb.glade:311 src/presets_menu_ui.cpp:113
 #: src/presets_menu_ui.cpp:258 src/presets_menu_ui.cpp:275
 msgid "Presets"
 msgstr "Profiler"
 
-#: data/ui/autogain.glade:91
+#: data/ui/autogain.glade:92
 #, fuzzy
 msgid "Auto Gain"
 msgstr "Ingångsförstärkning (dB)"
 
-#: data/ui/autogain.glade:171
+#: data/ui/autogain.glade:172
 #, fuzzy
 msgid "Reset History"
 msgstr "Återställ kvalitet"
 
-#: data/ui/autogain.glade:183
+#: data/ui/autogain.glade:184
 #, fuzzy
 msgid "Detect Silence"
 msgstr "Försvagning"
 
-#: data/ui/autogain.glade:195
+#: data/ui/autogain.glade:196
 msgid "Use Geometric Mean"
 msgstr ""
 
-#: data/ui/autogain.glade:233
+#: data/ui/autogain.glade:234
 #, fuzzy
 msgid "Target"
 msgstr "Målvärde (dB)"
 
-#: data/ui/autogain.glade:283 data/ui/autogain.glade:627
+#: data/ui/autogain.glade:286 data/ui/autogain.glade:631
 msgid "Momentary"
 msgstr ""
 
-#: data/ui/autogain.glade:298 data/ui/autogain.glade:640
+#: data/ui/autogain.glade:301 data/ui/autogain.glade:644
 msgid "Short Term"
 msgstr ""
 
-#: data/ui/autogain.glade:313 data/ui/autogain.glade:653
+#: data/ui/autogain.glade:316 data/ui/autogain.glade:657
 msgid "Integrated"
 msgstr ""
 
-#: data/ui/autogain.glade:388
+#: data/ui/autogain.glade:394
 msgid "Weights"
 msgstr ""
 
-#: data/ui/autogain.glade:428 data/ui/autogain.glade:917
-#: data/ui/bass_enhancer.glade:504 data/ui/compressor.glade:974
-#: data/ui/convolver.glade:504 data/ui/crossfeed.glade:200
-#: data/ui/crystalizer.glade:255 data/ui/deesser.glade:593
-#: data/ui/delay.glade:236 data/ui/equalizer.glade:543
-#: data/ui/exciter.glade:510 data/ui/filter.glade:396 data/ui/gate.glade:558
-#: data/ui/limiter.glade:483 data/ui/loudness.glade:259
-#: data/ui/loudness.glade:338 data/ui/maximizer.glade:265
-#: data/ui/multiband_compressor.glade:2000 data/ui/multiband_gate.glade:2153
-#: data/ui/pitch.glade:362 data/ui/presets_menu.glade:255
-#: data/ui/reverb.glade:658 data/ui/stereo_tools.glade:323
-#: data/ui/stereo_tools.glade:829 data/ui/webrtc.glade:650
+#: data/ui/autogain.glade:434 data/ui/autogain.glade:921
+#: data/ui/bass_enhancer.glade:506 data/ui/compressor.glade:977
+#: data/ui/convolver.glade:505 data/ui/crossfeed.glade:199
+#: data/ui/crystalizer.glade:205 data/ui/deesser.glade:594
+#: data/ui/delay.glade:237 data/ui/equalizer.glade:544
+#: data/ui/exciter.glade:510 data/ui/filter.glade:397 data/ui/gate.glade:611
+#: data/ui/limiter.glade:485 data/ui/loudness.glade:299
+#: data/ui/loudness.glade:380 data/ui/maximizer.glade:268
+#: data/ui/multiband_compressor.glade:2006 data/ui/multiband_gate.glade:2163
+#: data/ui/pitch.glade:363 data/ui/presets_menu.glade:255
+#: data/ui/reverb.glade:661 data/ui/stereo_tools.glade:322
+#: data/ui/stereo_tools.glade:830 data/ui/webrtc.glade:651
 msgid "Input"
 msgstr "Ingång"
 
-#: data/ui/autogain.glade:443 data/ui/autogain.glade:862
-#: data/ui/bass_enhancer.glade:536 data/ui/compressor.glade:988
-#: data/ui/convolver.glade:519 data/ui/crossfeed.glade:214
-#: data/ui/crystalizer.glade:270 data/ui/deesser.glade:607
-#: data/ui/delay.glade:250 data/ui/equalizer.glade:557
-#: data/ui/exciter.glade:542 data/ui/filter.glade:411 data/ui/gate.glade:572
-#: data/ui/limiter.glade:626 data/ui/loudness.glade:292
-#: data/ui/loudness.glade:352 data/ui/maximizer.glade:279
+#: data/ui/autogain.glade:449 data/ui/autogain.glade:866
+#: data/ui/bass_enhancer.glade:537 data/ui/compressor.glade:991
+#: data/ui/convolver.glade:520 data/ui/crossfeed.glade:213
+#: data/ui/crystalizer.glade:220 data/ui/deesser.glade:608
+#: data/ui/delay.glade:251 data/ui/equalizer.glade:558
+#: data/ui/exciter.glade:541 data/ui/filter.glade:412 data/ui/gate.glade:625
+#: data/ui/limiter.glade:628 data/ui/loudness.glade:333
+#: data/ui/loudness.glade:394 data/ui/maximizer.glade:282
 #: data/ui/multiband_compressor.glade:794
-#: data/ui/multiband_compressor.glade:1171
-#: data/ui/multiband_compressor.glade:1549
-#: data/ui/multiband_compressor.glade:1927
-#: data/ui/multiband_compressor.glade:2015 data/ui/multiband_gate.glade:851
-#: data/ui/multiband_gate.glade:1260 data/ui/multiband_gate.glade:1670
-#: data/ui/multiband_gate.glade:2080 data/ui/multiband_gate.glade:2168
-#: data/ui/pitch.glade:376 data/ui/presets_menu.glade:146
-#: data/ui/reverb.glade:673 data/ui/stereo_tools.glade:800
-#: data/ui/stereo_tools.glade:843 data/ui/webrtc.glade:664
+#: data/ui/multiband_compressor.glade:1173
+#: data/ui/multiband_compressor.glade:1553
+#: data/ui/multiband_compressor.glade:1933
+#: data/ui/multiband_compressor.glade:2021 data/ui/multiband_gate.glade:852
+#: data/ui/multiband_gate.glade:1264 data/ui/multiband_gate.glade:1677
+#: data/ui/multiband_gate.glade:2090 data/ui/multiband_gate.glade:2178
+#: data/ui/pitch.glade:377 data/ui/presets_menu.glade:146
+#: data/ui/reverb.glade:676 data/ui/stereo_tools.glade:801
+#: data/ui/stereo_tools.glade:844 data/ui/webrtc.glade:665
 msgid "Output"
 msgstr "Utgång"
 
-#: data/ui/autogain.glade:744
+#: data/ui/autogain.glade:748
 msgid "Relative"
 msgstr ""
 
-#: data/ui/autogain.glade:757 data/ui/compressor.glade:1154
-#: data/ui/deesser.glade:321
+#: data/ui/autogain.glade:761 data/ui/compressor.glade:1157
 #, fuzzy
 msgid "Gain"
 msgstr "Ingångsförstärkning (dB)"
 
-#: data/ui/autogain.glade:823
+#: data/ui/autogain.glade:827
 msgid "Loudness"
 msgstr ""
 
-#: data/ui/autogain.glade:876
+#: data/ui/autogain.glade:880
 msgid "Range"
 msgstr ""
 
-#: data/ui/autogain.glade:945 data/ui/bass_enhancer.glade:655
-#: data/ui/compressor.glade:1299 data/ui/convolver.glade:703
-#: data/ui/crossfeed.glade:395 data/ui/crystalizer.glade:566
-#: data/ui/deesser.glade:898 data/ui/delay.glade:434
-#: data/ui/equalizer.glade:743 data/ui/equalizer_band.glade:182
-#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:661
-#: data/ui/filter.glade:595 data/ui/general_settings.glade:116
-#: data/ui/gate.glade:809 data/ui/limiter.glade:733 data/ui/loudness.glade:573
-#: data/ui/maximizer.glade:516 data/ui/multiband_compressor.glade:2199
-#: data/ui/multiband_gate.glade:2352 data/ui/pitch.glade:560
-#: data/ui/reverb.glade:857 data/ui/stereo_tools.glade:1029
-#: data/ui/webrtc.glade:814
+#: data/ui/autogain.glade:949 data/ui/bass_enhancer.glade:650
+#: data/ui/compressor.glade:1300 data/ui/convolver.glade:702
+#: data/ui/crossfeed.glade:394 data/ui/crystalizer.glade:514
+#: data/ui/deesser.glade:899 data/ui/delay.glade:433
+#: data/ui/equalizer.glade:744 data/ui/equalizer_band.glade:182
+#: data/ui/equalizer_band.glade:228 data/ui/exciter.glade:654
+#: data/ui/filter.glade:594 data/ui/general_settings.glade:116
+#: data/ui/gate.glade:862 data/ui/limiter.glade:735 data/ui/loudness.glade:615
+#: data/ui/maximizer.glade:519 data/ui/multiband_compressor.glade:2203
+#: data/ui/multiband_gate.glade:2360 data/ui/pitch.glade:559
+#: data/ui/reverb.glade:858 data/ui/stereo_tools.glade:1028
+#: data/ui/webrtc.glade:815
 msgid "Reset"
 msgstr "Återställ"
 
-#: data/ui/autogain.glade:969
+#: data/ui/autogain.glade:973
 msgid "Based on"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:117
+#: data/ui/bass_enhancer.glade:118
 #, fuzzy
 msgid "Bass Enhancer"
 msgstr "Ljudförstärkare"
 
-#: data/ui/bass_enhancer.glade:169 data/ui/compressor.glade:506
-#: data/ui/deesser.glade:188 data/ui/exciter.glade:171
+#: data/ui/bass_enhancer.glade:170 data/ui/compressor.glade:506
+#: data/ui/deesser.glade:185 data/ui/exciter.glade:170
 msgid "Listen"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:210 data/ui/exciter.glade:213
+#: data/ui/bass_enhancer.glade:211 data/ui/exciter.glade:212
 msgid "3rd"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:222 data/ui/exciter.glade:225
+#: data/ui/bass_enhancer.glade:223 data/ui/exciter.glade:224
 msgid "2nd"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:234 data/ui/exciter.glade:237
+#: data/ui/bass_enhancer.glade:235 data/ui/exciter.glade:236
 msgid "Blend Harmonics"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:266 data/ui/exciter.glade:271
-#: data/ui/reverb.glade:407
+#: data/ui/bass_enhancer.glade:267 data/ui/exciter.glade:270
+#: data/ui/reverb.glade:408
 msgid "Amount"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:278 data/ui/bass_enhancer.glade:411
-#: data/ui/exciter.glade:284 data/ui/exciter.glade:417
+#: data/ui/bass_enhancer.glade:279 data/ui/bass_enhancer.glade:413
+#: data/ui/exciter.glade:283 data/ui/exciter.glade:417
 msgid "Harmonics"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:290 data/ui/exciter.glade:297
+#: data/ui/bass_enhancer.glade:291 data/ui/exciter.glade:296
 msgid "Scope"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:379
+#: data/ui/bass_enhancer.glade:381
 msgid "Floor"
 msgstr ""
 
-#: data/ui/bass_enhancer.glade:679 data/ui/compressor.glade:1323
-#: data/ui/crossfeed.glade:419 data/ui/deesser.glade:922
-#: data/ui/delay.glade:458 data/ui/equalizer.glade:767
-#: data/ui/exciter.glade:685 data/ui/filter.glade:619 data/ui/gate.glade:833
-#: data/ui/limiter.glade:757 data/ui/loudness.glade:542
-#: data/ui/maximizer.glade:540 data/ui/multiband_compressor.glade:2223
-#: data/ui/multiband_gate.glade:2376 data/ui/pitch.glade:584
-#: data/ui/reverb.glade:881 data/ui/stereo_tools.glade:1053
-#: data/ui/webrtc.glade:838
+#: data/ui/bass_enhancer.glade:674 data/ui/compressor.glade:1324
+#: data/ui/crossfeed.glade:418 data/ui/deesser.glade:923
+#: data/ui/delay.glade:457 data/ui/equalizer.glade:768
+#: data/ui/exciter.glade:678 data/ui/filter.glade:618 data/ui/gate.glade:886
+#: data/ui/limiter.glade:759 data/ui/loudness.glade:584
+#: data/ui/maximizer.glade:543 data/ui/multiband_compressor.glade:2227
+#: data/ui/multiband_gate.glade:2384 data/ui/pitch.glade:583
+#: data/ui/reverb.glade:882 data/ui/stereo_tools.glade:1052
+#: data/ui/webrtc.glade:839
 msgid "Provided by"
 msgstr ""
 
@@ -381,146 +380,146 @@ msgstr "Ingångs-begränsning"
 msgid "Show Blocklisted Apps in Main Tab"
 msgstr ""
 
-#: data/ui/calibration_signals.glade:32 data/ui/equalizer_band.glade:152
-#: data/ui/filter.glade:280
+#: data/ui/calibration_signals.glade:30 data/ui/equalizer_band.glade:152
+#: data/ui/filter.glade:281
 #, fuzzy
 msgid "Frequency"
 msgstr "Frekvens (Hz)"
 
-#: data/ui/calibration_signals.glade:64
+#: data/ui/calibration_signals.glade:62
 msgid "Volume"
 msgstr "Volym"
 
-#: data/ui/calibration_signals.glade:108
+#: data/ui/calibration_signals.glade:106
 msgid "Sine"
 msgstr "Sinus"
 
-#: data/ui/calibration_signals.glade:109
+#: data/ui/calibration_signals.glade:107
 msgid "Square"
 msgstr "Fyrkant"
 
-#: data/ui/calibration_signals.glade:110
+#: data/ui/calibration_signals.glade:108
 msgid "Saw"
 msgstr "Sågtand"
 
-#: data/ui/calibration_signals.glade:111
+#: data/ui/calibration_signals.glade:109
 msgid "Triangle"
 msgstr "Triangel"
 
-#: data/ui/calibration_signals.glade:112
+#: data/ui/calibration_signals.glade:110
 #, fuzzy
 msgid "Silence"
 msgstr "Tystnad"
 
-#: data/ui/calibration_signals.glade:113
+#: data/ui/calibration_signals.glade:111
 msgid "White Noise"
 msgstr "Vitt brus"
 
-#: data/ui/calibration_signals.glade:114
+#: data/ui/calibration_signals.glade:112
 msgid "Pink Noise"
 msgstr "Skärt brus"
 
-#: data/ui/calibration_signals.glade:115
+#: data/ui/calibration_signals.glade:113
 msgid "Sine Table"
 msgstr "Sinustabell"
 
-#: data/ui/calibration_signals.glade:116
+#: data/ui/calibration_signals.glade:114
 msgid "Ticks"
 msgstr "Tickande"
 
-#: data/ui/calibration_signals.glade:117
+#: data/ui/calibration_signals.glade:115
 msgid "Gaussian Noise"
 msgstr "Gaussiskt brus"
 
-#: data/ui/calibration_signals.glade:118
+#: data/ui/calibration_signals.glade:116
 msgid "Red Noise"
 msgstr "Rött brus"
 
-#: data/ui/calibration_signals.glade:119
+#: data/ui/calibration_signals.glade:117
 msgid "Blue Noise"
 msgstr "Blått brus"
 
-#: data/ui/calibration_signals.glade:120
+#: data/ui/calibration_signals.glade:118
 msgid "Violet Noise"
 msgstr "Violett brus"
 
-#: data/ui/calibration_mic.glade:29
+#: data/ui/calibration_mic.glade:28
 #, fuzzy
 msgid "Window"
 msgstr "Mellanrum (s)"
 
-#: data/ui/calibration_mic.glade:70
+#: data/ui/calibration_mic.glade:69
 msgid "Measure Noise"
 msgstr "Mät brus"
 
-#: data/ui/calibration_mic.glade:99
+#: data/ui/calibration_mic.glade:98
 msgid "Subtract Noise"
 msgstr "Ta bort brus"
 
-#: data/ui/compressor.glade:292 data/ui/deesser.glade:483
-#: data/ui/gate.glade:370 data/ui/maximizer.glade:152
-#: data/ui/multiband_compressor.glade:609
+#: data/ui/compressor.glade:290 data/ui/deesser.glade:482
+#: data/ui/gate.glade:413 data/ui/maximizer.glade:153
+#: data/ui/multiband_compressor.glade:607
 #: data/ui/multiband_compressor.glade:983
-#: data/ui/multiband_compressor.glade:1361
-#: data/ui/multiband_compressor.glade:1739 data/ui/multiband_gate.glade:633
-#: data/ui/multiband_gate.glade:1040 data/ui/multiband_gate.glade:1450
-#: data/ui/multiband_gate.glade:1860
+#: data/ui/multiband_compressor.glade:1363
+#: data/ui/multiband_compressor.glade:1743 data/ui/multiband_gate.glade:631
+#: data/ui/multiband_gate.glade:1041 data/ui/multiband_gate.glade:1454
+#: data/ui/multiband_gate.glade:1867
 #, fuzzy
 msgid "Threshold"
 msgstr "Tröskelvärde (dB)"
 
-#: data/ui/compressor.glade:325 data/ui/deesser.glade:516
-#: data/ui/gate.glade:403 data/ui/multiband_compressor.glade:642
-#: data/ui/multiband_compressor.glade:1017
-#: data/ui/multiband_compressor.glade:1395
-#: data/ui/multiband_compressor.glade:1773 data/ui/multiband_gate.glade:666
-#: data/ui/multiband_gate.glade:1074 data/ui/multiband_gate.glade:1484
-#: data/ui/multiband_gate.glade:1894
+#: data/ui/compressor.glade:324 data/ui/deesser.glade:516
+#: data/ui/gate.glade:449 data/ui/multiband_compressor.glade:641
+#: data/ui/multiband_compressor.glade:1018
+#: data/ui/multiband_compressor.glade:1398
+#: data/ui/multiband_compressor.glade:1778 data/ui/multiband_gate.glade:665
+#: data/ui/multiband_gate.glade:1076 data/ui/multiband_gate.glade:1489
+#: data/ui/multiband_gate.glade:1902
 #, fuzzy
 msgid "Ratio"
 msgstr "Förhållande (n:1)"
 
-#: data/ui/compressor.glade:357 data/ui/gate.glade:435
-#: data/ui/multiband_compressor.glade:674
-#: data/ui/multiband_compressor.glade:1050
-#: data/ui/multiband_compressor.glade:1428
-#: data/ui/multiband_compressor.glade:1806 data/ui/multiband_gate.glade:698
-#: data/ui/multiband_gate.glade:1107 data/ui/multiband_gate.glade:1517
-#: data/ui/multiband_gate.glade:1927
+#: data/ui/compressor.glade:356 data/ui/gate.glade:483
+#: data/ui/multiband_compressor.glade:673
+#: data/ui/multiband_compressor.glade:1051
+#: data/ui/multiband_compressor.glade:1431
+#: data/ui/multiband_compressor.glade:1811 data/ui/multiband_gate.glade:697
+#: data/ui/multiband_gate.glade:1109 data/ui/multiband_gate.glade:1522
+#: data/ui/multiband_gate.glade:1935
 #, fuzzy
 msgid "Knee"
 msgstr "Knee-värde (dB)"
 
-#: data/ui/compressor.glade:391 data/ui/deesser.glade:547
-#: data/ui/gate.glade:469 data/ui/multiband_compressor.glade:708
-#: data/ui/multiband_compressor.glade:1085
-#: data/ui/multiband_compressor.glade:1463
-#: data/ui/multiband_compressor.glade:1841 data/ui/multiband_gate.glade:732
-#: data/ui/multiband_gate.glade:1142 data/ui/multiband_gate.glade:1552
-#: data/ui/multiband_gate.glade:1962
+#: data/ui/compressor.glade:390 data/ui/deesser.glade:547
+#: data/ui/gate.glade:519 data/ui/multiband_compressor.glade:707
+#: data/ui/multiband_compressor.glade:1086
+#: data/ui/multiband_compressor.glade:1466
+#: data/ui/multiband_compressor.glade:1846 data/ui/multiband_gate.glade:731
+#: data/ui/multiband_gate.glade:1144 data/ui/multiband_gate.glade:1557
+#: data/ui/multiband_gate.glade:1970
 #, fuzzy
 msgid "Makeup"
 msgstr "Makeup (dB)"
 
-#: data/ui/compressor.glade:425 data/ui/gate.glade:336
-#: data/ui/limiter.glade:310 data/ui/maximizer.glade:178
-#: data/ui/multiband_compressor.glade:575
+#: data/ui/compressor.glade:425 data/ui/gate.glade:377
+#: data/ui/limiter.glade:311 data/ui/maximizer.glade:179
+#: data/ui/multiband_compressor.glade:573
 #: data/ui/multiband_compressor.glade:948
-#: data/ui/multiband_compressor.glade:1326
-#: data/ui/multiband_compressor.glade:1704 data/ui/multiband_gate.glade:599
-#: data/ui/multiband_gate.glade:1005 data/ui/multiband_gate.glade:1415
-#: data/ui/multiband_gate.glade:1825
+#: data/ui/multiband_compressor.glade:1328
+#: data/ui/multiband_compressor.glade:1708 data/ui/multiband_gate.glade:597
+#: data/ui/multiband_gate.glade:1006 data/ui/multiband_gate.glade:1419
+#: data/ui/multiband_gate.glade:1832
 #, fuzzy
 msgid "Release"
 msgstr "Release (s)"
 
-#: data/ui/compressor.glade:438 data/ui/gate.glade:302
-#: data/ui/multiband_compressor.glade:541
+#: data/ui/compressor.glade:438 data/ui/gate.glade:341
+#: data/ui/multiband_compressor.glade:539
 #: data/ui/multiband_compressor.glade:913
-#: data/ui/multiband_compressor.glade:1291
-#: data/ui/multiband_compressor.glade:1669 data/ui/multiband_gate.glade:565
-#: data/ui/multiband_gate.glade:970 data/ui/multiband_gate.glade:1380
-#: data/ui/multiband_gate.glade:1790
+#: data/ui/multiband_compressor.glade:1293
+#: data/ui/multiband_compressor.glade:1673 data/ui/multiband_gate.glade:563
+#: data/ui/multiband_gate.glade:971 data/ui/multiband_gate.glade:1384
+#: data/ui/multiband_gate.glade:1797
 #, fuzzy
 msgid "Attack"
 msgstr "Attack (ms)"
@@ -538,220 +537,219 @@ msgstr ""
 msgid "Compression Mode"
 msgstr "Ingen komprimering"
 
-#: data/ui/compressor.glade:551
+#: data/ui/compressor.glade:552
 #, fuzzy
 msgid "Pre-amplification"
 msgstr "Program"
 
-#: data/ui/compressor.glade:585
+#: data/ui/compressor.glade:586
 msgid "Reactivity"
 msgstr ""
 
-#: data/ui/compressor.glade:619 data/ui/limiter.glade:323
+#: data/ui/compressor.glade:620 data/ui/limiter.glade:324
 msgid "Lookahead"
 msgstr ""
 
-#: data/ui/compressor.glade:632
+#: data/ui/compressor.glade:633
 msgid "Feed-forward"
 msgstr ""
 
-#: data/ui/compressor.glade:633
+#: data/ui/compressor.glade:634
 #, fuzzy
 msgid "Feed-back"
 msgstr "Knee-värde (dB)"
 
-#: data/ui/compressor.glade:647 data/ui/equalizer_band.glade:48
+#: data/ui/compressor.glade:648 data/ui/equalizer_band.glade:48
 msgid "Type"
 msgstr ""
 
-#: data/ui/compressor.glade:661 data/ui/deesser.glade:244
-#: data/ui/deesser.glade:354 data/ui/gate.glade:257
-#: data/ui/multiband_compressor.glade:514
+#: data/ui/compressor.glade:662 data/ui/deesser.glade:241
+#: data/ui/gate.glade:213 data/ui/multiband_compressor.glade:512
 #: data/ui/multiband_compressor.glade:886
-#: data/ui/multiband_compressor.glade:1264
-#: data/ui/multiband_compressor.glade:1642 data/ui/multiband_gate.glade:538
-#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1353
-#: data/ui/multiband_gate.glade:1763
+#: data/ui/multiband_compressor.glade:1266
+#: data/ui/multiband_compressor.glade:1646 data/ui/multiband_gate.glade:536
+#: data/ui/multiband_gate.glade:944 data/ui/multiband_gate.glade:1357
+#: data/ui/multiband_gate.glade:1770
 msgid "Peak"
 msgstr "Peak"
 
-#: data/ui/compressor.glade:662 data/ui/deesser.glade:243
-#: data/ui/gate.glade:256 data/ui/multiband_compressor.glade:513
+#: data/ui/compressor.glade:663 data/ui/deesser.glade:240
+#: data/ui/gate.glade:212 data/ui/multiband_compressor.glade:511
 #: data/ui/multiband_compressor.glade:885
-#: data/ui/multiband_compressor.glade:1263
-#: data/ui/multiband_compressor.glade:1641 data/ui/multiband_gate.glade:537
-#: data/ui/multiband_gate.glade:942 data/ui/multiband_gate.glade:1352
-#: data/ui/multiband_gate.glade:1762
+#: data/ui/multiband_compressor.glade:1265
+#: data/ui/multiband_compressor.glade:1645 data/ui/multiband_gate.glade:535
+#: data/ui/multiband_gate.glade:943 data/ui/multiband_gate.glade:1356
+#: data/ui/multiband_gate.glade:1769
 msgid "RMS"
 msgstr ""
 
-#: data/ui/compressor.glade:663
+#: data/ui/compressor.glade:664
 #, fuzzy
 msgid "Low-Pass"
 msgstr "Lågpass"
 
-#: data/ui/compressor.glade:664
+#: data/ui/compressor.glade:665
 msgid "Uniform"
 msgstr ""
 
-#: data/ui/compressor.glade:678 data/ui/deesser.glade:230
-#: data/ui/equalizer.glade:224 data/ui/equalizer_band.glade:79
-#: data/ui/multiband_compressor.glade:324 data/ui/multiband_gate.glade:348
-#: data/ui/stereo_tools.glade:485 data/ui/webrtc.glade:376
+#: data/ui/compressor.glade:679 data/ui/deesser.glade:227
+#: data/ui/equalizer.glade:225 data/ui/equalizer_band.glade:79
+#: data/ui/multiband_compressor.glade:322 data/ui/multiband_gate.glade:346
+#: data/ui/stereo_tools.glade:486 data/ui/webrtc.glade:377
 msgid "Mode"
 msgstr ""
 
-#: data/ui/compressor.glade:692
+#: data/ui/compressor.glade:693
 #, fuzzy
 msgid "Middle"
 msgstr "Nivå"
 
-#: data/ui/compressor.glade:693
+#: data/ui/compressor.glade:694
 #, fuzzy
 msgid "Side"
 msgstr "Ingångsförstärkning (dB)"
 
-#: data/ui/compressor.glade:694 data/ui/delay.glade:157
-#: data/ui/equalizer.glade:474 data/ui/stereo_tools.glade:548
+#: data/ui/compressor.glade:695 data/ui/delay.glade:158
+#: data/ui/equalizer.glade:475 data/ui/stereo_tools.glade:549
 msgid "Left"
 msgstr ""
 
-#: data/ui/compressor.glade:695 data/ui/delay.glade:189
-#: data/ui/equalizer.glade:515 data/ui/stereo_tools.glade:620
+#: data/ui/compressor.glade:696 data/ui/delay.glade:190
+#: data/ui/equalizer.glade:516 data/ui/stereo_tools.glade:621
 msgid "Right"
 msgstr ""
 
-#: data/ui/compressor.glade:709
+#: data/ui/compressor.glade:710
 msgid "Source"
 msgstr ""
 
-#: data/ui/compressor.glade:725 data/ui/compressor.glade:1167
+#: data/ui/compressor.glade:726 data/ui/compressor.glade:1170
 #, fuzzy
 msgid "Sidechain"
 msgstr "Ingångsförstärkning (dB)"
 
-#: data/ui/compressor.glade:821
+#: data/ui/compressor.glade:824
 msgid "Relative Release Threshold"
 msgstr ""
 
-#: data/ui/compressor.glade:832
+#: data/ui/compressor.glade:835
 #, fuzzy
 msgid "Boost Threshold"
 msgstr "Tröskelvärde (dB)"
 
-#: data/ui/compressor.glade:843
+#: data/ui/compressor.glade:846
 #, fuzzy
 msgid "High-pass Frequency"
 msgstr "Återställ frekvens"
 
-#: data/ui/compressor.glade:854
+#: data/ui/compressor.glade:857
 #, fuzzy
 msgid "Low-pass Frequency"
 msgstr "Återställ frekvens"
 
-#: data/ui/compressor.glade:865
+#: data/ui/compressor.glade:868
 #, fuzzy
 msgid "High-pass Filter Mode"
 msgstr "Högpass"
 
-#: data/ui/compressor.glade:876
+#: data/ui/compressor.glade:879
 msgid "Low-pass Filter Mode"
 msgstr ""
 
-#: data/ui/compressor.glade:889 data/ui/compressor.glade:906
+#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
 #: data/ui/equalizer_band.glade:60
 msgid "Off"
 msgstr ""
 
-#: data/ui/compressor.glade:890 data/ui/compressor.glade:907
+#: data/ui/compressor.glade:893 data/ui/compressor.glade:910
 msgid "12 dB/oct"
 msgstr ""
 
-#: data/ui/compressor.glade:891 data/ui/compressor.glade:908
+#: data/ui/compressor.glade:894 data/ui/compressor.glade:911
 msgid "24 dB/oct"
 msgstr ""
 
-#: data/ui/compressor.glade:892 data/ui/compressor.glade:909
+#: data/ui/compressor.glade:895 data/ui/compressor.glade:912
 msgid "36 dB/oct"
 msgstr ""
 
-#: data/ui/compressor.glade:932
+#: data/ui/compressor.glade:935
 #, fuzzy
 msgid "Advanced"
 msgstr "Inställningar"
 
-#: data/ui/compressor.glade:1243
+#: data/ui/compressor.glade:1244
 msgid "Curve"
 msgstr ""
 
-#: data/ui/convolver.glade:91
+#: data/ui/convolver.glade:92
 msgid "Convolver"
 msgstr ""
 
-#: data/ui/convolver.glade:125
+#: data/ui/convolver.glade:126
 #, fuzzy
 msgid "Import Impulse"
 msgstr "Platt respons"
 
-#: data/ui/convolver.glade:129
+#: data/ui/convolver.glade:130
 msgid "Import Impulse Response File"
 msgstr ""
 
-#: data/ui/convolver.glade:247
+#: data/ui/convolver.glade:248
 msgid "L"
 msgstr "V"
 
-#: data/ui/convolver.glade:261
+#: data/ui/convolver.glade:262
 msgid "R"
 msgstr "H"
 
-#: data/ui/convolver.glade:324
+#: data/ui/convolver.glade:325
 #, fuzzy
 msgid "Duration"
 msgstr "Kalibrering"
 
-#: data/ui/convolver.glade:335
+#: data/ui/convolver.glade:336
 #, fuzzy
 msgid "Samples"
 msgstr "Resampler"
 
-#: data/ui/convolver.glade:367 src/convolver_ui.cpp:283
+#: data/ui/convolver.glade:368 src/convolver_ui.cpp:283
 #, fuzzy
 msgid "Impulse Response"
 msgstr "Platt respons"
 
-#: data/ui/convolver.glade:389
+#: data/ui/convolver.glade:390
 #, fuzzy
 msgid "Select the impulse Response File"
 msgstr "Platt respons"
 
-#: data/ui/convolver.glade:409 src/spectrum_settings_ui.cpp:176
+#: data/ui/convolver.glade:410 src/spectrum_settings_ui.cpp:176
 msgid "Spectrum"
 msgstr "Spektrum"
 
-#: data/ui/convolver.glade:450
+#: data/ui/convolver.glade:451
 #, fuzzy
 msgid "Stereo Width"
 msgstr "Ljudförstärkare"
 
-#: data/ui/crossfeed.glade:63
+#: data/ui/crossfeed.glade:62
 msgid "Jmeier"
 msgstr ""
 
-#: data/ui/crossfeed.glade:76 data/ui/filter.glade:183 data/ui/reverb.glade:259
+#: data/ui/crossfeed.glade:75 data/ui/filter.glade:184 data/ui/reverb.glade:260
 msgid "Default"
 msgstr ""
 
-#: data/ui/crossfeed.glade:89
+#: data/ui/crossfeed.glade:88
 msgid "Cmoy"
 msgstr ""
 
-#: data/ui/crossfeed.glade:120
+#: data/ui/crossfeed.glade:119
 #, fuzzy
 msgid "Cutoff"
 msgstr "Cut-off (Hz)"
 
-#: data/ui/crossfeed.glade:153
+#: data/ui/crossfeed.glade:152
 #, fuzzy
 msgid "Feed"
 msgstr "Knee-värde (dB)"
@@ -760,123 +758,138 @@ msgstr "Knee-värde (dB)"
 msgid "Crossfeed"
 msgstr ""
 
-#: data/ui/crystalizer.glade:115
+#: data/ui/crystalizer.glade:92
 #, fuzzy
 msgid "Crystalizer"
 msgstr "Utjämnare"
 
-#: data/ui/crystalizer.glade:187
+#: data/ui/crystalizer.glade:137
 #, fuzzy
 msgid "Aggressive Mode"
 msgstr "Ingen komprimering"
 
-#: data/ui/crystalizer.glade:447
+#: data/ui/crystalizer.glade:395
 msgid "Loudness Range"
 msgstr ""
 
-#: data/ui/crystalizer.glade:466
+#: data/ui/crystalizer.glade:414
 msgid "Before"
 msgstr ""
 
-#: data/ui/crystalizer.glade:479
+#: data/ui/crystalizer.glade:427
 msgid "After"
 msgstr ""
 
 #: data/ui/crystalizer_band.glade:27 data/ui/equalizer_band.glade:313
-#: data/ui/stereo_tools.glade:574 data/ui/stereo_tools.glade:633
+#: data/ui/stereo_tools.glade:575 data/ui/stereo_tools.glade:634
 msgid "Mute"
 msgstr ""
 
-#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:483
+#: data/ui/crystalizer_band.glade:39 data/ui/multiband_compressor.glade:481
 #: data/ui/multiband_compressor.glade:855
-#: data/ui/multiband_compressor.glade:1233
-#: data/ui/multiband_compressor.glade:1611 data/ui/multiband_gate.glade:507
-#: data/ui/multiband_gate.glade:912 data/ui/multiband_gate.glade:1322
-#: data/ui/multiband_gate.glade:1732
+#: data/ui/multiband_compressor.glade:1235
+#: data/ui/multiband_compressor.glade:1615 data/ui/multiband_gate.glade:505
+#: data/ui/multiband_gate.glade:913 data/ui/multiband_gate.glade:1326
+#: data/ui/multiband_gate.glade:1739
 msgid "Bypass"
 msgstr ""
 
-#: data/ui/deesser.glade:128
+#: data/ui/deesser.glade:127
 msgid "Deesser"
 msgstr ""
 
-#: data/ui/deesser.glade:216 data/ui/gate.glade:195
+#: data/ui/deesser.glade:213 data/ui/gate.glade:198
 #, fuzzy
 msgid "Detection"
 msgstr "Försvagning"
 
-#: data/ui/deesser.glade:258
+#: data/ui/deesser.glade:255
 msgid "Wide"
 msgstr ""
 
-#: data/ui/deesser.glade:259 data/ui/deesser.glade:288
+#: data/ui/deesser.glade:256
 msgid "Split"
 msgstr ""
 
-#: data/ui/deesser.glade:407
-msgid "Level"
-msgstr "Nivå"
+#: data/ui/deesser.glade:285
+msgid "F1 Split"
+msgstr ""
 
-#: data/ui/deesser.glade:420
+#: data/ui/deesser.glade:318
 #, fuzzy
-msgid "Peak Q"
+msgid "F1 Gain"
+msgstr "Ingångsförstärkning (dB)"
+
+#: data/ui/deesser.glade:352
+#, fuzzy
+msgid "F2 Peak"
 msgstr "Peak"
 
-#: data/ui/deesser.glade:452
+#: data/ui/deesser.glade:406
+#, fuzzy
+msgid "F2 Level"
+msgstr "Nivå"
+
+#: data/ui/deesser.glade:419
+#, fuzzy
+msgid "F2 Peak Q"
+msgstr "Peak"
+
+#: data/ui/deesser.glade:451
 msgid "Laxity"
 msgstr ""
 
-#: data/ui/deesser.glade:778 data/ui/multiband_gate.glade:767
-#: data/ui/multiband_gate.glade:1197 data/ui/multiband_gate.glade:1607
-#: data/ui/multiband_gate.glade:2017
+#: data/ui/deesser.glade:779 data/ui/multiband_gate.glade:767
+#: data/ui/multiband_gate.glade:1201 data/ui/multiband_gate.glade:1614
+#: data/ui/multiband_gate.glade:2027
 #, fuzzy
 msgid "Reduction"
 msgstr "Förstärkningsreducering"
 
-#: data/ui/deesser.glade:791
+#: data/ui/deesser.glade:792
 #, fuzzy
 msgid "Detected"
 msgstr "Försvagning"
 
-#: data/ui/delay.glade:91
+#: data/ui/delay.glade:92
 #, fuzzy
 msgid "Delay"
 msgstr "Release (ms)"
 
-#: data/ui/equalizer.glade:44
+#: data/ui/equalizer.glade:45
 msgid "Equalizer"
 msgstr "Utjämnare"
 
-#: data/ui/equalizer.glade:153
+#: data/ui/equalizer.glade:154
 #, fuzzy
 msgid "Split Channels"
 msgstr "Kanaler"
 
-#: data/ui/equalizer.glade:179
+#: data/ui/equalizer.glade:180
 msgid "IIR"
 msgstr ""
 
-#: data/ui/equalizer.glade:180
+#: data/ui/equalizer.glade:181
 msgid "FIR"
 msgstr ""
 
-#: data/ui/equalizer.glade:181
+#: data/ui/equalizer.glade:182
 msgid "FFT"
 msgstr ""
 
-#: data/ui/equalizer.glade:211
+#: data/ui/equalizer.glade:212
 msgid "Bands"
 msgstr ""
 
-#: data/ui/equalizer.glade:233
+#: data/ui/equalizer.glade:234
 msgid "Flat Response"
 msgstr "Platt respons"
 
-#: data/ui/equalizer.glade:248
+#: data/ui/equalizer.glade:249
 msgid "Calculate Frequencies"
 msgstr ""
 
-#: data/ui/equalizer.glade:262
+#: data/ui/equalizer.glade:263
 #, fuzzy
 msgid "Import APO Presets"
 msgstr "Öppna förinställning"
@@ -906,7 +919,7 @@ msgstr "Low Shelf"
 msgid "Notch"
 msgstr ""
 
-#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:314
+#: data/ui/equalizer_band.glade:67 data/ui/filter.glade:315
 msgid "Resonance"
 msgstr ""
 
@@ -950,12 +963,12 @@ msgstr "Kvalitet"
 msgid "Width"
 msgstr "Bredd"
 
-#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:496
+#: data/ui/equalizer_band.glade:301 data/ui/multiband_compressor.glade:494
 #: data/ui/multiband_compressor.glade:868
-#: data/ui/multiband_compressor.glade:1246
-#: data/ui/multiband_compressor.glade:1624 data/ui/multiband_gate.glade:520
-#: data/ui/multiband_gate.glade:925 data/ui/multiband_gate.glade:1335
-#: data/ui/multiband_gate.glade:1745
+#: data/ui/multiband_compressor.glade:1248
+#: data/ui/multiband_compressor.glade:1628 data/ui/multiband_gate.glade:518
+#: data/ui/multiband_gate.glade:926 data/ui/multiband_gate.glade:1339
+#: data/ui/multiband_gate.glade:1752
 msgid "Solo"
 msgstr ""
 
@@ -963,81 +976,81 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: data/ui/exciter.glade:117
+#: data/ui/exciter.glade:118
 msgid "Exciter"
 msgstr ""
 
-#: data/ui/exciter.glade:384 data/ui/maximizer.glade:165
+#: data/ui/exciter.glade:384 data/ui/maximizer.glade:166
 #, fuzzy
 msgid "Ceiling"
 msgstr "Gränsvärde (dB)"
 
-#: data/ui/filter.glade:98
+#: data/ui/filter.glade:99
 #, fuzzy
 msgid "Filter"
 msgstr "Filter typ"
 
-#: data/ui/filter.glade:147
+#: data/ui/filter.glade:148
 msgid "Muted"
 msgstr ""
 
-#: data/ui/filter.glade:159 data/ui/reverb.glade:233
+#: data/ui/filter.glade:160 data/ui/reverb.glade:234
 msgid "Disco"
 msgstr ""
 
-#: data/ui/filter.glade:171
+#: data/ui/filter.glade:172
 msgid "Distant Headphones"
 msgstr ""
 
-#: data/ui/filter.glade:246
+#: data/ui/filter.glade:247
 msgid "12dB/oct Lowpass"
 msgstr ""
 
-#: data/ui/filter.glade:247
+#: data/ui/filter.glade:248
 msgid "24dB/oct Lowpass"
 msgstr ""
 
-#: data/ui/filter.glade:248
+#: data/ui/filter.glade:249
 msgid "36dB/oct Lowpass"
 msgstr ""
 
-#: data/ui/filter.glade:249
+#: data/ui/filter.glade:250
 msgid "12dB/oct Highpass"
 msgstr ""
 
-#: data/ui/filter.glade:250
+#: data/ui/filter.glade:251
 msgid "24dB/oct Highpass"
 msgstr ""
 
-#: data/ui/filter.glade:251
+#: data/ui/filter.glade:252
 msgid "36dB/oct Highpass"
 msgstr ""
 
-#: data/ui/filter.glade:252
+#: data/ui/filter.glade:253
 msgid "6dB/oct Bandpass"
 msgstr ""
 
-#: data/ui/filter.glade:253
+#: data/ui/filter.glade:254
 msgid "12dB/oct Bandpass"
 msgstr ""
 
-#: data/ui/filter.glade:254
+#: data/ui/filter.glade:255
 msgid "18dB/oct Bandpass"
 msgstr ""
 
-#: data/ui/filter.glade:255
+#: data/ui/filter.glade:256
 msgid "6dB/oct Bandreject"
 msgstr ""
 
-#: data/ui/filter.glade:256
+#: data/ui/filter.glade:257
 msgid "12dB/oct Bandreject"
 msgstr ""
 
-#: data/ui/filter.glade:257
+#: data/ui/filter.glade:258
 msgid "18dB/oct Bandreject"
 msgstr ""
 
-#: data/ui/filter.glade:349
+#: data/ui/filter.glade:350
 msgid "Inertia"
 msgstr ""
 
@@ -1081,52 +1094,53 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: data/ui/gate.glade:98
+#: data/ui/gate.glade:99
 msgid "Gate"
 msgstr ""
 
-#: data/ui/gate.glade:209
+#: data/ui/gate.glade:240
+#, fuzzy
+msgid "Maximum Gain Reduction"
+msgstr "Förstärkningsreducering"
+
+#: data/ui/gate.glade:289
 #, fuzzy
 msgid "Stereo Link"
 msgstr "Ljudförstärkare"
 
-#: data/ui/gate.glade:222 data/ui/maximizer.glade:293
-msgid "Gain Reduction"
-msgstr "Förstärkningsreducering"
-
-#: data/ui/gate.glade:273
+#: data/ui/gate.glade:304
 msgid "Average"
 msgstr ""
 
-#: data/ui/gate.glade:274
+#: data/ui/gate.glade:305
 msgid "Maximum"
 msgstr ""
 
-#: data/ui/gate.glade:525
+#: data/ui/gate.glade:578
 #, fuzzy
 msgid "Input Level"
 msgstr "Ingångs-begränsning"
 
-#: data/ui/gate.glade:744 data/ui/multiband_gate.glade:811
-#: data/ui/multiband_gate.glade:1220 data/ui/multiband_gate.glade:1630
-#: data/ui/multiband_gate.glade:2040
+#: data/ui/gate.glade:797 data/ui/multiband_gate.glade:812
+#: data/ui/multiband_gate.glade:1224 data/ui/multiband_gate.glade:1637
+#: data/ui/multiband_gate.glade:2050
 msgid "Gating"
 msgstr ""
 
-#: data/ui/limiter.glade:97 data/ui/webrtc.glade:421
+#: data/ui/limiter.glade:98 data/ui/webrtc.glade:422
 #, fuzzy
 msgid "Limiter"
 msgstr "Gränsvärde (dB)"
 
-#: data/ui/limiter.glade:176
+#: data/ui/limiter.glade:175
 msgid "Automatic Smoothing Control"
 msgstr ""
 
-#: data/ui/limiter.glade:190
+#: data/ui/limiter.glade:189
 msgid "Automatic Leveling"
 msgstr ""
 
-#: data/ui/limiter.glade:222
+#: data/ui/limiter.glade:221
 #, fuzzy
 msgid "Input Gain"
 msgstr "Ingångsförstärkning (dB)"
@@ -1136,143 +1150,147 @@ msgstr "Ingångsförstärkning (dB)"
 msgid "Limit"
 msgstr "Gränsvärde (dB)"
 
-#: data/ui/limiter.glade:358
+#: data/ui/limiter.glade:359
 msgid "Oversampling"
 msgstr ""
 
-#: data/ui/limiter.glade:411
+#: data/ui/limiter.glade:413
 #, fuzzy
 msgid "Output Gain"
 msgstr "Ingångsförstärkning (dB)"
 
-#: data/ui/limiter.glade:429
+#: data/ui/limiter.glade:431
 msgid "ASC"
 msgstr ""
 
-#: data/ui/limiter.glade:584
+#: data/ui/limiter.glade:586
 msgid "Attenuation"
 msgstr "Försvagning"
 
-#: data/ui/loudness.glade:91
+#: data/ui/loudness.glade:92
 msgid "Loudness Compensator"
 msgstr ""
 
-#: data/ui/loudness.glade:147
-msgid "Standard"
-msgstr ""
-
-#: data/ui/loudness.glade:161
-msgid "Flat"
-msgstr ""
-
-#: data/ui/loudness.glade:162
-msgid "ISO226-2003"
-msgstr ""
-
-#: data/ui/loudness.glade:163
-msgid "Fletcher-Munson"
-msgstr ""
-
-#: data/ui/loudness.glade:164
-msgid "Robinson-Dadson"
-msgstr ""
-
-#: data/ui/loudness.glade:174
-msgid "Reference Signal"
-msgstr ""
-
-#: data/ui/loudness.glade:199
+#: data/ui/loudness.glade:155
 #, fuzzy
 msgid "FFT Size"
 msgstr "Rumsstorlek"
 
-#: data/ui/maximizer.glade:96
+#: data/ui/loudness.glade:205
+msgid "Standard"
+msgstr ""
+
+#: data/ui/loudness.glade:220
+msgid "Flat"
+msgstr ""
+
+#: data/ui/loudness.glade:221
+msgid "ISO226-2003"
+msgstr ""
+
+#: data/ui/loudness.glade:222
+msgid "Fletcher-Munson"
+msgstr ""
+
+#: data/ui/loudness.glade:223
+msgid "Robinson-Dadson"
+msgstr ""
+
+#: data/ui/loudness.glade:259
+msgid "Reference Signal"
+msgstr ""
+
+#: data/ui/maximizer.glade:97
 msgid "Maximizer"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:140
+#: data/ui/maximizer.glade:296
+msgid "Gain Reduction"
+msgstr "Förstärkningsreducering"
+
+#: data/ui/multiband_compressor.glade:141
 #, fuzzy
 msgid "Multiband Compressor"
 msgstr "Kompressor"
 
-#: data/ui/multiband_compressor.glade:338 data/ui/multiband_gate.glade:362
+#: data/ui/multiband_compressor.glade:336 data/ui/multiband_gate.glade:360
 msgid "LR4"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:339 data/ui/multiband_gate.glade:363
+#: data/ui/multiband_compressor.glade:337 data/ui/multiband_gate.glade:361
 msgid "LR8"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:353 data/ui/multiband_gate.glade:377
+#: data/ui/multiband_compressor.glade:351 data/ui/multiband_gate.glade:375
 msgid "Split 1/2"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:366 data/ui/multiband_gate.glade:390
+#: data/ui/multiband_compressor.glade:364 data/ui/multiband_gate.glade:388
 msgid "Split 2/3"
 msgstr ""
 
-#: data/ui/multiband_compressor.glade:379 data/ui/multiband_gate.glade:403
+#: data/ui/multiband_compressor.glade:377 data/ui/multiband_gate.glade:401
 msgid "Split 3/4"
 msgstr ""
 
 #: data/ui/multiband_compressor.glade:754
-#: data/ui/multiband_compressor.glade:1131
-#: data/ui/multiband_compressor.glade:1509
-#: data/ui/multiband_compressor.glade:1887
+#: data/ui/multiband_compressor.glade:1133
+#: data/ui/multiband_compressor.glade:1513
+#: data/ui/multiband_compressor.glade:1893
 #, fuzzy
 msgid "Compression"
 msgstr "Ingen komprimering"
 
-#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:894
+#: data/ui/multiband_compressor.glade:837 data/ui/multiband_gate.glade:895
 #, fuzzy
 msgid "Sub Band"
 msgstr "Ljudstyrka (dB) (in)"
 
-#: data/ui/multiband_compressor.glade:1214 data/ui/multiband_gate.glade:1303
+#: data/ui/multiband_compressor.glade:1216 data/ui/multiband_gate.glade:1307
 #, fuzzy
 msgid "Low Band"
 msgstr "Lågpass"
 
-#: data/ui/multiband_compressor.glade:1592 data/ui/multiband_gate.glade:1713
+#: data/ui/multiband_compressor.glade:1596 data/ui/multiband_gate.glade:1720
 #, fuzzy
 msgid "Mid Band"
 msgstr "Ingångsförstärkning (dB)"
 
-#: data/ui/multiband_compressor.glade:1970 data/ui/multiband_gate.glade:2123
+#: data/ui/multiband_compressor.glade:1976 data/ui/multiband_gate.glade:2133
 #, fuzzy
 msgid "High Band"
 msgstr "Högpass"
 
-#: data/ui/multiband_gate.glade:140
+#: data/ui/multiband_gate.glade:141
 #, fuzzy
 msgid "Multiband Gate"
 msgstr "Kompressor"
 
-#: data/ui/pitch.glade:103
+#: data/ui/pitch.glade:104
 msgid "Pitch"
 msgstr ""
 
-#: data/ui/pitch.glade:178
+#: data/ui/pitch.glade:179
 msgid "Cents"
 msgstr ""
 
-#: data/ui/pitch.glade:209
+#: data/ui/pitch.glade:210
 msgid "Semitones"
 msgstr ""
 
-#: data/ui/pitch.glade:240
+#: data/ui/pitch.glade:241
 msgid "Octaves"
 msgstr ""
 
-#: data/ui/pitch.glade:271
+#: data/ui/pitch.glade:272
 msgid "Crispness"
 msgstr ""
 
-#: data/ui/pitch.glade:311
+#: data/ui/pitch.glade:312
 msgid "Faster"
 msgstr ""
 
-#: data/ui/pitch.glade:325
+#: data/ui/pitch.glade:326
 msgid "Preserve Formant"
 msgstr ""
 
@@ -1374,88 +1392,88 @@ msgstr ""
 msgid "Pipeline Output"
 msgstr "Ljudutjämnare - Utgång"
 
-#: data/ui/reverb.glade:131
+#: data/ui/reverb.glade:132
 msgid "Reverberation"
 msgstr "Efterljud (eko)"
 
-#: data/ui/reverb.glade:181
+#: data/ui/reverb.glade:182
 #, fuzzy
 msgid "Ambience"
 msgstr "Tystnad"
 
-#: data/ui/reverb.glade:194
+#: data/ui/reverb.glade:195
 msgid "Empty Walls"
 msgstr ""
 
-#: data/ui/reverb.glade:207
+#: data/ui/reverb.glade:208
 #, fuzzy
 msgid "Room"
 msgstr "Rumsstorlek"
 
-#: data/ui/reverb.glade:220
+#: data/ui/reverb.glade:221
 msgid "Large Empty Hall"
 msgstr ""
 
-#: data/ui/reverb.glade:246
+#: data/ui/reverb.glade:247
 msgid "Large Occupied Hall"
 msgstr ""
 
-#: data/ui/reverb.glade:361
+#: data/ui/reverb.glade:362
 #, fuzzy
 msgid "Pre Delay"
 msgstr "Release (ms)"
 
-#: data/ui/reverb.glade:374
+#: data/ui/reverb.glade:375
 msgid "Decay Time"
 msgstr ""
 
-#: data/ui/reverb.glade:439
+#: data/ui/reverb.glade:441
 msgid "Dry"
 msgstr ""
 
-#: data/ui/reverb.glade:471
+#: data/ui/reverb.glade:474
 msgid "Bass Cut"
 msgstr ""
 
-#: data/ui/reverb.glade:522
+#: data/ui/reverb.glade:525
 msgid "Treble Cut"
 msgstr ""
 
-#: data/ui/reverb.glade:565
+#: data/ui/reverb.glade:568
 msgid "Diffusion"
 msgstr ""
 
-#: data/ui/reverb.glade:577
+#: data/ui/reverb.glade:580
 msgid "Room Size"
 msgstr "Rumsstorlek"
 
-#: data/ui/reverb.glade:590
+#: data/ui/reverb.glade:593
 #, fuzzy
 msgid "Small"
 msgstr "Litet rum"
 
-#: data/ui/reverb.glade:591
+#: data/ui/reverb.glade:594
 msgid "Medium"
 msgstr ""
 
-#: data/ui/reverb.glade:592
+#: data/ui/reverb.glade:595
 #, fuzzy
 msgid "Large"
 msgstr "Målvärde (dB)"
 
-#: data/ui/reverb.glade:593
+#: data/ui/reverb.glade:596
 msgid "Tunnel"
 msgstr ""
 
-#: data/ui/reverb.glade:594
+#: data/ui/reverb.glade:597
 msgid "Large/smooth"
 msgstr ""
 
-#: data/ui/reverb.glade:595
+#: data/ui/reverb.glade:598
 msgid "Experimental"
 msgstr ""
 
-#: data/ui/reverb.glade:608
+#: data/ui/reverb.glade:611
 msgid "High Frequency Damping"
 msgstr ""
 
@@ -1534,26 +1552,26 @@ msgstr ""
 msgid "Points"
 msgstr "Punkter"
 
-#: data/ui/stereo_tools.glade:109
+#: data/ui/stereo_tools.glade:110
 #, fuzzy
 msgid "Stereo Tools"
 msgstr "Ljudförstärkare"
 
-#: data/ui/stereo_tools.glade:231
+#: data/ui/stereo_tools.glade:230
 msgid "Softclip"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:255 data/ui/stereo_tools.glade:671
+#: data/ui/stereo_tools.glade:254 data/ui/stereo_tools.glade:672
 #, fuzzy
 msgid "Balance"
 msgstr "Ljudförstärkare"
 
-#: data/ui/stereo_tools.glade:287
+#: data/ui/stereo_tools.glade:286
 #, fuzzy
 msgid "S/C Level"
 msgstr "Nivå"
 
-#: data/ui/stereo_tools.glade:345
+#: data/ui/stereo_tools.glade:344
 #, fuzzy
 msgid "Side Level"
 msgstr "Nivå"
@@ -1563,162 +1581,162 @@ msgstr "Nivå"
 msgid "Side Balance"
 msgstr "Ljudförstärkare"
 
-#: data/ui/stereo_tools.glade:428
+#: data/ui/stereo_tools.glade:429
 #, fuzzy
 msgid "Middle Level"
 msgstr "Nivå"
 
-#: data/ui/stereo_tools.glade:441
+#: data/ui/stereo_tools.glade:442
 #, fuzzy
 msgid "Middle Panorama"
 msgstr "Panorama"
 
-#: data/ui/stereo_tools.glade:499
+#: data/ui/stereo_tools.glade:500
 msgid "LR > LR (Stereo Default)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:500
+#: data/ui/stereo_tools.glade:501
 msgid "LR > MS (Stereo to Mid-Side)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:501
+#: data/ui/stereo_tools.glade:502
 msgid "MS > LR (Mid-Side to Stereo)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:502
+#: data/ui/stereo_tools.glade:503
 #, fuzzy
 msgid "LR > LL (Mono Left Channel)"
 msgstr "Kanaler"
 
-#: data/ui/stereo_tools.glade:503
+#: data/ui/stereo_tools.glade:504
 #, fuzzy
 msgid "LR > RR (Mono Right Channel)"
 msgstr "Kanaler"
 
-#: data/ui/stereo_tools.glade:504
+#: data/ui/stereo_tools.glade:505
 msgid "LR > L+R (Mono Sum L+R)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:505
+#: data/ui/stereo_tools.glade:506
 msgid "LR > RL (Stereo Flip Channels)"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:522
+#: data/ui/stereo_tools.glade:523
 #, fuzzy
 msgid "Stereo Matrix"
 msgstr "Ljudförstärkare"
 
-#: data/ui/stereo_tools.glade:561 data/ui/stereo_tools.glade:602
+#: data/ui/stereo_tools.glade:562 data/ui/stereo_tools.glade:603
 msgid "Invert Phase"
 msgstr ""
 
-#: data/ui/stereo_tools.glade:703
+#: data/ui/stereo_tools.glade:704
 #, fuzzy
 msgid "Delay L/R"
 msgstr "Release (ms)"
 
-#: data/ui/stereo_tools.glade:737
+#: data/ui/stereo_tools.glade:738
 #, fuzzy
 msgid "Stereo Base"
 msgstr "Ljudförstärkare"
 
-#: data/ui/stereo_tools.glade:770
+#: data/ui/stereo_tools.glade:771
 #, fuzzy
 msgid "Stereo Phase"
 msgstr "Ljudförstärkare"
 
-#: data/ui/webrtc.glade:97
+#: data/ui/webrtc.glade:98
 msgid "WebRTC"
 msgstr ""
 
-#: data/ui/webrtc.glade:163 data/ui/webrtc.glade:283 data/ui/webrtc.glade:353
-#: data/ui/webrtc.glade:523
+#: data/ui/webrtc.glade:164 data/ui/webrtc.glade:284 data/ui/webrtc.glade:354
+#: data/ui/webrtc.glade:524
 #, fuzzy
 msgid "Enable"
 msgstr "Sinustabell"
 
-#: data/ui/webrtc.glade:184
+#: data/ui/webrtc.glade:185
 msgid "Extended Filter"
 msgstr ""
 
-#: data/ui/webrtc.glade:197
+#: data/ui/webrtc.glade:198
 msgid "Delay Agnostic"
 msgstr ""
 
-#: data/ui/webrtc.glade:209
+#: data/ui/webrtc.glade:210
 #, fuzzy
 msgid "High Pass Filter"
 msgstr "Högpass"
 
-#: data/ui/webrtc.glade:238 data/ui/webrtc.glade:306
+#: data/ui/webrtc.glade:239 data/ui/webrtc.glade:307
 #, fuzzy
 msgid "Suppresion Level"
 msgstr "Förstärkningsreducering"
 
-#: data/ui/webrtc.glade:251 data/ui/webrtc.glade:319 data/ui/webrtc.glade:575
+#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
 msgid "Low"
 msgstr ""
 
-#: data/ui/webrtc.glade:252 data/ui/webrtc.glade:320 data/ui/webrtc.glade:576
+#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
 msgid "Moderate"
 msgstr ""
 
-#: data/ui/webrtc.glade:253 data/ui/webrtc.glade:321 data/ui/webrtc.glade:577
+#: data/ui/webrtc.glade:254 data/ui/webrtc.glade:322 data/ui/webrtc.glade:578
 #, fuzzy
 msgid "High"
 msgstr "Högpass"
 
-#: data/ui/webrtc.glade:270
+#: data/ui/webrtc.glade:271
 #, fuzzy
 msgid "Echo Canceller"
 msgstr "Ljudförstärkare"
 
-#: data/ui/webrtc.glade:322
+#: data/ui/webrtc.glade:323
 #, fuzzy
 msgid "Very High"
 msgstr "Högpass"
 
-#: data/ui/webrtc.glade:339
+#: data/ui/webrtc.glade:340
 #, fuzzy
 msgid "Noise Suppressor"
 msgstr "Kompressor"
 
-#: data/ui/webrtc.glade:389
+#: data/ui/webrtc.glade:390
 msgid "Adaptive Digital"
 msgstr ""
 
-#: data/ui/webrtc.glade:390
+#: data/ui/webrtc.glade:391
 msgid "Fixed Digital"
 msgstr ""
 
-#: data/ui/webrtc.glade:407
+#: data/ui/webrtc.glade:408
 msgid "Gain Controller"
 msgstr ""
 
-#: data/ui/webrtc.glade:445
+#: data/ui/webrtc.glade:446
 #, fuzzy
 msgid "Target Level"
 msgstr "Målvärde (dB)"
 
-#: data/ui/webrtc.glade:475
+#: data/ui/webrtc.glade:476
 msgid "Maximum Gain"
 msgstr ""
 
-#: data/ui/webrtc.glade:548
+#: data/ui/webrtc.glade:549
 #, fuzzy
 msgid "Detection Likelihood"
 msgstr "Försvagning"
 
-#: data/ui/webrtc.glade:561
+#: data/ui/webrtc.glade:562
 #, fuzzy
 msgid "Frame Size"
 msgstr "Rumsstorlek"
 
-#: data/ui/webrtc.glade:574
+#: data/ui/webrtc.glade:575
 msgid "Very Low"
 msgstr ""
 
-#: data/ui/webrtc.glade:611
+#: data/ui/webrtc.glade:612
 #, fuzzy
 msgid "Voice Detector"
 msgstr "Försvagning"
@@ -1820,3 +1838,7 @@ msgstr "Allmänt"
 #: src/pulse_settings_ui.cpp:149
 msgid "Pulseaudio"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Gain Detection"
+#~ msgstr "Förstärkningsreducering"


### PR DESCRIPTION
Unfortunately I didn't notice this before the latest release, but controls for dB values are inconsistent between plugins. In most of them we can set integer values, but in crossfeed there's 1 digit precision and in knee and equalizer levels even 2 digits.

PulseEffects gives the ability to set high precision for ms values having 2 digits. In example, we can set the lowest value in the multiband compressor/gate for attack control which is exactly 0,01. Desktop environment systems change the output level on the percent size which can modify the gain in steps lower than 1 db, but most of the times these are higher in PulseEffects.

Given that, I modified the precision and the step for dB values to 0,1 (anche only to controls previously specified as integers).

I also made other adjustments and some clean up to other glades.