### PR TITLE
New app row and show level meter only during playback/recording

### DIFF
--- a/data/ui/app_button_row.glade
+++ b/data/ui/app_button_row.glade
@@ -5,25 +5,21 @@
   <object class="GtkBox" id="app_button_row">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="margin_end">2</property>
-    <property name="margin_top">4</property>
-    <property name="margin_bottom">4</property>
-    <property name="spacing">6</property>
+    <property name="margin_top">7</property>
+    <property name="margin_bottom">7</property>
+    <property name="spacing">12</property>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="halign">start</property>
-        <property name="valign">center</property>
         <property name="spacing">6</property>
         <child>
-          <object class="GtkLabel" id="app_label">
-            <property name="visible">True</property>
+          <object class="GtkImage" id="app_output_icon">
             <property name="can_focus">False</property>
-            <property name="halign">start</property>
-            <property name="valign">center</property>
-            <property name="hexpand">False</property>
-            <property name="label" translatable="yes">Applications</property>
+            <property name="no_show_all">True</property>
+            <property name="halign">center</property>
+            <property name="icon_name">audio-speakers-symbolic</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -32,17 +28,30 @@
           </packing>
         </child>
         <child>
-          <object class="GtkImage" id="saturation_icon">
+          <object class="GtkImage" id="app_input_icon">
             <property name="can_focus">False</property>
             <property name="no_show_all">True</property>
-            <property name="halign">start</property>
-            <property name="valign">center</property>
-            <property name="icon_name">dialog-warning-symbolic</property>
+            <property name="halign">center</property>
+            <property name="icon_name">audio-input-microphone-symbolic</property>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="app_label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">center</property>
+            <property name="margin_bottom">2</property>
+            <property name="label" translatable="yes">Applications</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>
@@ -53,22 +62,18 @@
       </packing>
     </child>
     <child>
-      <object class="GtkBox">
-        <property name="visible">True</property>
+      <object class="GtkBox" id="global_level_meter_grid">
         <property name="can_focus">False</property>
+        <property name="no_show_all">True</property>
         <property name="halign">end</property>
-        <property name="valign">center</property>
-        <property name="spacing">4</property>
+        <property name="margin_end">2</property>
         <child>
-          <object class="GtkLabel" id="global_output_level_left">
-            <property name="visible">True</property>
+          <object class="GtkImage" id="saturation_icon">
             <property name="can_focus">False</property>
+            <property name="no_show_all">True</property>
             <property name="halign">center</property>
-            <property name="valign">center</property>
-            <property name="label">-99</property>
-            <property name="justify">right</property>
-            <property name="width_chars">3</property>
-            <property name="max_width_chars">3</property>
+            <property name="margin_end">4</property>
+            <property name="icon_name">dialog-warning-symbolic</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -77,15 +82,13 @@
           </packing>
         </child>
         <child>
-          <object class="GtkLabel" id="global_output_level_right">
+          <object class="GtkLabel" id="global_output_level_left">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="halign">center</property>
-            <property name="valign">center</property>
-            <property name="label">-99</property>
             <property name="justify">right</property>
-            <property name="width_chars">3</property>
-            <property name="max_width_chars">3</property>
+            <property name="width_chars">4</property>
+            <property name="max_width_chars">4</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -94,11 +97,26 @@
           </packing>
         </child>
         <child>
+          <object class="GtkLabel" id="global_output_level_right">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">center</property>
+            <property name="justify">right</property>
+            <property name="width_chars">4</property>
+            <property name="max_width_chars">4</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkLabel" id="db_unit_label">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="halign">center</property>
-            <property name="valign">center</property>
+            <property name="margin_start">4</property>
             <property name="label">dB</property>
             <property name="justify">right</property>
             <property name="width_chars">2</property>
@@ -107,7 +125,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/data/ui/app_info.glade
+++ b/data/ui/app_info.glade
@@ -56,8 +56,8 @@
         <child>
           <object class="GtkLabel">
             <property name="visible">True</property>
+            <property name="sensitive">False</property>
             <property name="can_focus">False</property>
-            <property name="opacity">0.7</property>
             <property name="margin_start">1</property>
             <property name="label">%</property>
           </object>

--- a/include/effects_base_ui.hpp
+++ b/include/effects_base_ui.hpp
@@ -5,6 +5,7 @@
 #include <gtkmm/box.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/eventbox.h>
+#include <gtkmm/grid.h>
 #include <gtkmm/label.h>
 #include <gtkmm/listbox.h>
 #include <gtkmm/stack.h>
@@ -37,9 +38,10 @@ class EffectsBaseUi {
   Glib::RefPtr<Gio::Settings> settings;
   Gtk::ListBox* listbox = nullptr;
   Gtk::Stack* stack = nullptr;
-  Gtk::Box *apps_box = nullptr, *app_button_row = nullptr;
+
+  Gtk::Box *apps_box = nullptr, *app_button_row = nullptr, *global_level_meter_grid = nullptr;
+  Gtk::Image *app_input_icon = nullptr, *app_output_icon = nullptr, *saturation_icon = nullptr;
   Gtk::Label *global_output_level_left = nullptr, *global_output_level_right = nullptr;
-  Gtk::Image* saturation_icon = nullptr;
 
   PulseManager* pm = nullptr;
 

--- a/include/loudness_ui.hpp
+++ b/include/loudness_ui.hpp
@@ -1,9 +1,6 @@
 #ifndef LOUDNESS_UI_HPP
 #define LOUDNESS_UI_HPP
 
-#include <gtkmm/comboboxtext.h>
-#include <gtkmm/grid.h>
-#include <gtkmm/togglebutton.h>
 #include "plugin_ui_base.hpp"
 
 class LoudnessUi : public Gtk::Grid, public PluginUiBase {

--- a/include/plugin_ui_base.hpp
+++ b/include/plugin_ui_base.hpp
@@ -136,7 +136,7 @@ class PluginUiBase {
     auto left_db = util::linear_to_db(left);
     auto right_db = util::linear_to_db(right);
 
-    if (left_db >= -99.0f) {
+    if (left_db >= -99.0) {
       w_left->set_value(left);
       w_left_label->set_text(level_to_str(left_db, 0));
     } else {
@@ -144,7 +144,7 @@ class PluginUiBase {
       w_left_label->set_text("-99");
     }
 
-    if (right_db >= -99.0f) {
+    if (right_db >= -99.0) {
       w_right->set_value(right);
       w_right_label->set_text(level_to_str(right_db, 0));
     } else {
@@ -165,10 +165,10 @@ class PluginUiBase {
     if (left >= -99.0) {
       auto db_value = util::db_to_linear(left);
 
-      if (db_value < 0.0f) {
-        db_value = 0;
-      } else if (db_value > 1.0f) {
-        db_value = 1;
+      if (db_value < 0.0) {
+        db_value = 0.0;
+      } else if (db_value > 1.0) {
+        db_value = 1.0;
       }
 
       w_left->set_value(db_value);
@@ -181,10 +181,10 @@ class PluginUiBase {
     if (right >= -99.0) {
       auto db_value = util::db_to_linear(right);
 
-      if (db_value < 0.0f) {
-        db_value = 0;
-      } else if (db_value > 1.0f) {
-        db_value = 1;
+      if (db_value < 0.0) {
+        db_value = 0.0;
+      } else if (db_value > 1.0) {
+        db_value = 1.0;
       }
 
       w_right->set_value(db_value);

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -10,7 +10,9 @@
 namespace util {
 
 const float minimum_db_level = -99.0F;
+const double minimum_db_d_level = -99.0;
 const float minimum_linear_level = 0.00001F;
+const double minimum_linear_d_level = 0.00001;
 
 void debug(const std::string& s);
 void error(const std::string& s);
@@ -22,8 +24,10 @@ auto logspace(const float& start, const float& stop, const uint& npoints) -> std
 auto linspace(const float& start, const float& stop, const uint& npoints) -> std::vector<float>;
 
 auto linear_to_db(const float& amp) -> float;
+auto linear_to_db(const double& amp) -> double;
 
 auto db_to_linear(const float& db) -> float;
+auto db_to_linear(const double& db) -> double;
 
 auto db20_gain_to_linear(GValue* value, GVariant* variant, gpointer user_data) -> gboolean;
 

--- a/src/bass_enhancer_ui.cpp
+++ b/src/bass_enhancer_ui.cpp
@@ -79,5 +79,5 @@ void BassEnhancerUi::reset() {
 void BassEnhancerUi::on_new_harmonics_level(double value) {
   harmonics_levelbar->set_value(value);
 
-  harmonics_levelbar_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  harmonics_levelbar_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }

--- a/src/compressor_ui.cpp
+++ b/src/compressor_ui.cpp
@@ -299,17 +299,17 @@ void CompressorUi::reset() {
 void CompressorUi::on_new_reduction(double value) {
   reduction->set_value(value);
 
-  reduction_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  reduction_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }
 
 void CompressorUi::on_new_sidechain(double value) {
   sidechain->set_value(value);
 
-  sidechain_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  sidechain_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }
 
 void CompressorUi::on_new_curve(double value) {
   curve->set_value(value);
 
-  curve_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  curve_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }

--- a/src/crystalizer_ui.cpp
+++ b/src/crystalizer_ui.cpp
@@ -168,13 +168,13 @@ void CrystalizerUi::build_bands(const int& nbands) {
 }
 
 void CrystalizerUi::on_new_range_before(double value) {
-  range_before->set_value(util::db_to_linear(static_cast<float>(value)));
+  range_before->set_value(util::db_to_linear(value));
 
   range_before_label->set_text(level_to_str(value, 2));
 }
 
 void CrystalizerUi::on_new_range_after(double value) {
-  range_after->set_value(util::db_to_linear(static_cast<float>(value)));
+  range_after->set_value(util::db_to_linear(value));
 
   range_after_label->set_text(level_to_str(value, 2));
 }

--- a/src/deesser_ui.cpp
+++ b/src/deesser_ui.cpp
@@ -148,11 +148,11 @@ void DeesserUi::reset() {
 void DeesserUi::on_new_compression(double value) {
   compression->set_value(1.0 - value);
 
-  compression_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  compression_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }
 
 void DeesserUi::on_new_detected(double value) {
   detected->set_value(value);
 
-  detected_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  detected_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }

--- a/src/effects_base_ui.cpp
+++ b/src/effects_base_ui.cpp
@@ -1,6 +1,5 @@
 #include "effects_base_ui.hpp"
 #include <glibmm/i18n.h>
-#include <gtkmm/button.h>
 #include "plugin_ui_base.hpp"
 
 EffectsBaseUi::EffectsBaseUi(const Glib::RefPtr<Gtk::Builder>& builder,
@@ -17,6 +16,9 @@ EffectsBaseUi::EffectsBaseUi(const Glib::RefPtr<Gtk::Builder>& builder,
   auto b_app_button_row = Gtk::Builder::create_from_resource("/com/github/wwmm/pulseeffects/ui/app_button_row.glade");
 
   b_app_button_row->get_widget("app_button_row", app_button_row);
+  b_app_button_row->get_widget("app_input_icon", app_input_icon);
+  b_app_button_row->get_widget("app_output_icon", app_output_icon);
+  b_app_button_row->get_widget("global_level_meter_grid", global_level_meter_grid);
   b_app_button_row->get_widget("global_output_level_left", global_output_level_left);
   b_app_button_row->get_widget("global_output_level_right", global_output_level_right);
   b_app_button_row->get_widget("saturation_icon", saturation_icon);
@@ -121,27 +123,25 @@ void EffectsBaseUi::on_new_output_level_db(const std::array<double, 2>& peak) {
   auto left = peak[0];
   auto right = peak[1];
 
+  // show the grid only if something is playing/recording
+
+  if (left < -99.0 && right < -99.0) {
+    global_level_meter_grid->set_visible(false);
+
+    return;
+  }
+
+  global_level_meter_grid->set_visible(true);
+
+  global_output_level_left->set_text(PluginUiBase::level_to_str(left, 0));
+
+  global_output_level_right->set_text(PluginUiBase::level_to_str(right, 0));
+
   // saturation icon notification
 
   if (left > 0.0 || right > 0.0) {
     saturation_icon->set_visible(true);
   } else {
     saturation_icon->set_visible(false);
-  }
-
-  // right channel
-
-  if (left >= -99.0) {
-    global_output_level_left->set_text(PluginUiBase::level_to_str(left, 0));
-  } else {
-    global_output_level_left->set_text("-99");
-  }
-
-  // left channel
-
-  if (right >= -99.0) {
-    global_output_level_right->set_text(PluginUiBase::level_to_str(right, 0));
-  } else {
-    global_output_level_right->set_text("-99");
   }
 }

--- a/src/exciter_ui.cpp
+++ b/src/exciter_ui.cpp
@@ -79,5 +79,5 @@ void ExciterUi::reset() {
 void ExciterUi::on_new_harmonics_level(double value) {
   harmonics_levelbar->set_value(value);
 
-  harmonics_levelbar_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  harmonics_levelbar_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }

--- a/src/gate_ui.cpp
+++ b/src/gate_ui.cpp
@@ -138,5 +138,5 @@ void GateUi::reset() {
 void GateUi::on_new_gating(double value) {
   gating->set_value(1.0 - value);
 
-  gating_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  gating_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }

--- a/src/limiter_ui.cpp
+++ b/src/limiter_ui.cpp
@@ -80,5 +80,5 @@ void LimiterUi::reset() {
 void LimiterUi::on_new_attenuation(double value) {
   attenuation->set_value(1.0 - value);
 
-  attenuation_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  attenuation_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }

--- a/src/multiband_compressor_ui.cpp
+++ b/src/multiband_compressor_ui.cpp
@@ -296,47 +296,47 @@ void MultibandCompressorUi::reset() {
 void MultibandCompressorUi::on_new_output0(double value) {
   output0->set_value(value);
 
-  output0_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  output0_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }
 
 void MultibandCompressorUi::on_new_output1(double value) {
   output1->set_value(value);
 
-  output1_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  output1_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }
 
 void MultibandCompressorUi::on_new_output2(double value) {
   output2->set_value(value);
 
-  output2_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  output2_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }
 
 void MultibandCompressorUi::on_new_output3(double value) {
   output3->set_value(value);
 
-  output3_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  output3_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }
 
 void MultibandCompressorUi::on_new_compression0(double value) {
   compression0->set_value(1.0 - value);
 
-  compression0_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  compression0_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }
 
 void MultibandCompressorUi::on_new_compression1(double value) {
   compression1->set_value(1.0 - value);
 
-  compression1_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  compression1_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }
 
 void MultibandCompressorUi::on_new_compression2(double value) {
   compression2->set_value(1.0 - value);
 
-  compression2_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  compression2_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }
 
 void MultibandCompressorUi::on_new_compression3(double value) {
   compression3->set_value(1.0 - value);
 
-  compression3_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  compression3_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }

--- a/src/multiband_gate_ui.cpp
+++ b/src/multiband_gate_ui.cpp
@@ -312,47 +312,47 @@ void MultibandGateUi::reset() {
 void MultibandGateUi::on_new_output0(double value) {
   output0->set_value(value);
 
-  output0_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  output0_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }
 
 void MultibandGateUi::on_new_output1(double value) {
   output1->set_value(value);
 
-  output1_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  output1_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }
 
 void MultibandGateUi::on_new_output2(double value) {
   output2->set_value(value);
 
-  output2_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  output2_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }
 
 void MultibandGateUi::on_new_output3(double value) {
   output3->set_value(value);
 
-  output3_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  output3_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }
 
 void MultibandGateUi::on_new_gating0(double value) {
   gating0->set_value(1.0 - value);
 
-  gating0_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  gating0_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }
 
 void MultibandGateUi::on_new_gating1(double value) {
   gating1->set_value(1.0 - value);
 
-  gating1_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  gating1_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }
 
 void MultibandGateUi::on_new_gating2(double value) {
   gating2->set_value(1.0 - value);
 
-  gating2_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  gating2_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }
 
 void MultibandGateUi::on_new_gating3(double value) {
   gating3->set_value(1.0 - value);
 
-  gating3_label->set_text(level_to_str(util::linear_to_db(static_cast<float>(value)), 0));
+  gating3_label->set_text(level_to_str(util::linear_to_db(value), 0));
 }

--- a/src/reverb_ui.cpp
+++ b/src/reverb_ui.cpp
@@ -142,8 +142,8 @@ void ReverbUi::init_presets_buttons() {
     hf_damp->set_value(5508.46);
     room_size->set_active(4);
     diffusion->set_value(0.54);
-    amount->set_value(util::linear_to_db(0.469761f));
-    dry->set_value(util::linear_to_db(1.0f));
+    amount->set_value(util::linear_to_db(0.469761));
+    dry->set_value(util::linear_to_db(1.0));
     predelay->set_value(25.0);
     bass_cut->set_value(257.65);
     treble_cut->set_value(20000.0);
@@ -154,8 +154,8 @@ void ReverbUi::init_presets_buttons() {
     hf_damp->set_value(3971.64);
     room_size->set_active(4);
     diffusion->set_value(0.17);
-    amount->set_value(util::linear_to_db(0.198884f));
-    dry->set_value(util::linear_to_db(1.0f));
+    amount->set_value(util::linear_to_db(0.198884));
+    dry->set_value(util::linear_to_db(1.0));
     predelay->set_value(13.0);
     bass_cut->set_value(240.453);
     treble_cut->set_value(3303.47);
@@ -166,8 +166,8 @@ void ReverbUi::init_presets_buttons() {
     hf_damp->set_value(2182.58);
     room_size->set_active(4);
     diffusion->set_value(0.69);
-    amount->set_value(util::linear_to_db(0.291183f));
-    dry->set_value(util::linear_to_db(1.0f));
+    amount->set_value(util::linear_to_db(0.291183));
+    dry->set_value(util::linear_to_db(1.0));
     predelay->set_value(6.5);
     bass_cut->set_value(514.079);
     treble_cut->set_value(4064.15);
@@ -176,7 +176,7 @@ void ReverbUi::init_presets_buttons() {
   preset_large_empty_hall->signal_clicked().connect([=]() {
     decay_time->set_value(2.00689);
     hf_damp->set_value(20000.0);
-    amount->set_value(util::linear_to_db(0.366022f));
+    amount->set_value(util::linear_to_db(0.366022));
     settings->reset("room-size");
     settings->reset("diffusion");
     settings->reset("dry");
@@ -188,7 +188,7 @@ void ReverbUi::init_presets_buttons() {
   preset_disco->signal_clicked().connect([=]() {
     decay_time->set_value(1.0);
     hf_damp->set_value(3396.49);
-    amount->set_value(util::linear_to_db(0.269807f));
+    amount->set_value(util::linear_to_db(0.269807));
     settings->reset("room-size");
     settings->reset("diffusion");
     settings->reset("dry");
@@ -200,7 +200,7 @@ void ReverbUi::init_presets_buttons() {
   preset_large_occupied_hall->signal_clicked().connect([=]() {
     decay_time->set_value(1.45397);
     hf_damp->set_value(9795.58);
-    amount->set_value(util::linear_to_db(0.184284f));
+    amount->set_value(util::linear_to_db(0.184284));
     settings->reset("room-size");
     settings->reset("diffusion");
     settings->reset("dry");

--- a/src/sink_input_effects_ui.cpp
+++ b/src/sink_input_effects_ui.cpp
@@ -139,6 +139,10 @@ SinkInputEffectsUi::SinkInputEffectsUi(BaseObjectType* cobject,
   add_to_listbox(autogain_ui);
   add_to_listbox(delay_ui);
 
+  // show only speaker icon before "Application" label
+
+  app_output_icon->set_visible(true);
+
   level_meters_connections();
   up_down_connections();
 

--- a/src/source_output_effects_ui.cpp
+++ b/src/source_output_effects_ui.cpp
@@ -114,6 +114,10 @@ SourceOutputEffectsUi::SourceOutputEffectsUi(BaseObjectType* cobject,
   add_to_listbox(stereo_tools_ui);
   add_to_listbox(maximizer_ui);
 
+  // show only mic icon before "Application" label
+
+  app_input_icon->set_visible(true);
+
   level_meters_connections();
   up_down_connections();
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -75,8 +75,20 @@ auto linear_to_db(const float& amp) -> float {
   return minimum_db_level;
 }
 
+auto linear_to_db(const double& amp) -> double {
+  if (amp >= minimum_linear_d_level) {
+    return 20.0 * log10f(amp);
+  }
+
+  return minimum_db_d_level;
+}
+
 auto db_to_linear(const float& db) -> float {
   return expf((db / 20.0F) * logf(10.0F));
+}
+
+auto db_to_linear(const double& db) -> double {
+  return expf((db / 20.0) * logf(10.0));
 }
 
 auto db20_gain_to_linear(GValue* value, GVariant* variant, gpointer user_data) -> gboolean {


### PR DESCRIPTION
Following the discussion in #772, I redesigned the app row applying the same height of the plugins row. An icon is added before the label and the level meter grid is only shown when something is playing/recording avoiding to show two -99 when nothing is happening.

The other commit is another optimization on types.