### PR TITLE
Show sign on global level meter

### DIFF
--- a/data/ui/app_button_row.glade
+++ b/data/ui/app_button_row.glade
@@ -71,7 +71,6 @@
           <object class="GtkImage" id="saturation_icon">
             <property name="can_focus">False</property>
             <property name="no_show_all">True</property>
-            <property name="halign">center</property>
             <property name="margin_end">4</property>
             <property name="icon_name">dialog-warning-symbolic</property>
           </object>
@@ -85,10 +84,10 @@
           <object class="GtkLabel" id="global_output_level_left">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="halign">center</property>
-            <property name="justify">right</property>
             <property name="width_chars">4</property>
+            <property name="single_line_mode">True</property>
             <property name="max_width_chars">4</property>
+            <property name="xalign">1</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -100,10 +99,10 @@
           <object class="GtkLabel" id="global_output_level_right">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="halign">center</property>
-            <property name="justify">right</property>
             <property name="width_chars">4</property>
+            <property name="single_line_mode">True</property>
             <property name="max_width_chars">4</property>
+            <property name="xalign">1</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -115,12 +114,12 @@
           <object class="GtkLabel" id="db_unit_label">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="halign">center</property>
             <property name="margin_start">4</property>
             <property name="label">dB</property>
             <property name="justify">right</property>
-            <property name="width_chars">2</property>
-            <property name="max_width_chars">2</property>
+            <property name="width_chars">3</property>
+            <property name="single_line_mode">True</property>
+            <property name="xalign">1</property>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/data/ui/calibration_signals.glade
+++ b/data/ui/calibration_signals.glade
@@ -73,7 +73,7 @@
         <property name="valign">center</property>
         <property name="hexpand">True</property>
         <property name="adjustment">volume_adjustment</property>
-        <property name="round_digits">1</property>
+        <property name="round_digits">2</property>
         <property name="digits">2</property>
         <property name="value_pos">right</property>
       </object>

--- a/data/ui/equalizer.glade
+++ b/data/ui/equalizer.glade
@@ -106,8 +106,8 @@
   <object class="GtkAdjustment" id="input_gain">
     <property name="lower">-20</property>
     <property name="upper">20</property>
-    <property name="step_increment">0.01</property>
-    <property name="page_increment">0.1</property>
+    <property name="step_increment">0.1</property>
+    <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="nbands">
     <property name="lower">1</property>
@@ -355,8 +355,8 @@
   <object class="GtkAdjustment" id="output_gain">
     <property name="lower">-20</property>
     <property name="upper">20</property>
-    <property name="step_increment">0.01</property>
-    <property name="page_increment">0.1</property>
+    <property name="step_increment">0.1</property>
+    <property name="page_increment">1</property>
   </object>
   <object class="GtkGrid" id="widgets_grid">
     <property name="visible">True</property>

--- a/include/plugin_ui_base.hpp
+++ b/include/plugin_ui_base.hpp
@@ -51,6 +51,7 @@ class PluginUiBase {
   void on_new_input_level_db(const std::array<double, 2>& peak);
   void on_new_output_level_db(const std::array<double, 2>& peak);
   static auto level_to_str(const double& value, const int& places) -> std::string;
+  static auto level_to_str_showpos(const double& value, const int& places) -> std::string;
 
   // reset plugin method
   virtual void reset() = 0;

--- a/src/effects_base_ui.cpp
+++ b/src/effects_base_ui.cpp
@@ -125,7 +125,7 @@ void EffectsBaseUi::on_new_output_level_db(const std::array<double, 2>& peak) {
 
   // show the grid only if something is playing/recording
 
-  if (left < -99.0 && right < -99.0) {
+  if (left <= -100.0 && right <= -100.0) {
     global_level_meter_grid->set_visible(false);
 
     return;
@@ -133,9 +133,9 @@ void EffectsBaseUi::on_new_output_level_db(const std::array<double, 2>& peak) {
 
   global_level_meter_grid->set_visible(true);
 
-  global_output_level_left->set_text(PluginUiBase::level_to_str(left, 0));
+  global_output_level_left->set_text(PluginUiBase::level_to_str_showpos(left, 0));
 
-  global_output_level_right->set_text(PluginUiBase::level_to_str(right, 0));
+  global_output_level_right->set_text(PluginUiBase::level_to_str_showpos(right, 0));
 
   // saturation icon notification
 

--- a/src/plugin_ui_base.cpp
+++ b/src/plugin_ui_base.cpp
@@ -51,6 +51,15 @@ auto PluginUiBase::level_to_str(const double& value, const int& places) -> std::
   return msg.str();
 }
 
+auto PluginUiBase::level_to_str_showpos(const double& value, const int& places) -> std::string {
+  std::ostringstream msg;
+
+  msg.precision(places);
+  msg << ((value > 0.0) ? "+" : "") << std::fixed << value;
+
+  return msg.str();
+}
+
 void PluginUiBase::on_new_input_level(const std::array<double, 2>& peak) {
   update_level(input_level_left, input_level_left_label, input_level_right, input_level_right_label, peak);
 }


### PR DESCRIPTION
I wanted to test std::showpos on global level meter and I liked it.

Not really needed, but the plus sign shows better that the clipping is happening above 0, combined with the saturation icon.

Anyway, I didn't like the fact that std::showpos shows the positive sign also on zero, which is unsigned. So I modified it.

Then I made some adjustments on step increments that I previously forgot.