### PR TITLE
Positive sign on gain/intensity EQ/Cryst; locale formatted values

### DIFF
--- a/data/ui/crystalizer.glade
+++ b/data/ui/crystalizer.glade
@@ -150,7 +150,7 @@
           <object class="GtkGrid" id="bands_grid">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="halign">center</property>
+            <property name="hexpand">True</property>
             <property name="vexpand">True</property>
             <property name="column-spacing">12</property>
             <property name="column-homogeneous">True</property>

--- a/data/ui/crystalizer_band.glade
+++ b/data/ui/crystalizer_band.glade
@@ -84,7 +84,6 @@
         <property name="orientation">vertical</property>
         <property name="adjustment">band_intensity</property>
         <property name="inverted">True</property>
-        <property name="round-digits">1</property>
         <property name="digits">0</property>
         <property name="draw-value">False</property>
         <property name="has-origin">False</property>

--- a/data/ui/crystalizer_band.glade
+++ b/data/ui/crystalizer_band.glade
@@ -55,6 +55,7 @@
     <property name="visible">True</property>
     <property name="can-focus">False</property>
     <property name="halign">center</property>
+    <property name="hexpand">True</property>
     <property name="vexpand">True</property>
     <property name="row-spacing">4</property>
     <child>
@@ -62,7 +63,6 @@
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="label">band</property>
-        <property name="width-chars">9</property>
         <style>
           <class name="dim-label"/>
         </style>
@@ -78,6 +78,8 @@
         <property name="visible">True</property>
         <property name="can-focus">True</property>
         <property name="halign">center</property>
+        <property name="margin-start">6</property>
+        <property name="margin-end">6</property>
         <property name="vexpand">True</property>
         <property name="orientation">vertical</property>
         <property name="adjustment">band_intensity</property>
@@ -119,7 +121,6 @@
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="label">intensity</property>
-        <property name="width-chars">9</property>
         <style>
           <class name="dim-label"/>
         </style>

--- a/data/ui/crystalizer_band.glade
+++ b/data/ui/crystalizer_band.glade
@@ -50,7 +50,7 @@
       </object>
     </child>
   </object>
-  <!-- n-columns=1 n-rows=3 -->
+  <!-- n-columns=1 n-rows=4 -->
   <object class="GtkGrid" id="band_grid">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
@@ -62,7 +62,7 @@
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="label">band</property>
-        <property name="max-width-chars">7</property>
+        <property name="width-chars">9</property>
         <style>
           <class name="dim-label"/>
         </style>
@@ -84,11 +84,12 @@
         <property name="inverted">True</property>
         <property name="round-digits">1</property>
         <property name="digits">0</property>
+        <property name="draw-value">False</property>
         <property name="has-origin">False</property>
       </object>
       <packing>
         <property name="left-attach">0</property>
-        <property name="top-attach">2</property>
+        <property name="top-attach">3</property>
       </packing>
     </child>
     <child>
@@ -111,6 +112,21 @@
       <packing>
         <property name="left-attach">0</property>
         <property name="top-attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="band_intensity_label">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="label">intensity</property>
+        <property name="width-chars">9</property>
+        <style>
+          <class name="dim-label"/>
+        </style>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">2</property>
       </packing>
     </child>
   </object>

--- a/data/ui/equalizer.glade
+++ b/data/ui/equalizer.glade
@@ -463,7 +463,7 @@
                       <object class="GtkGrid" id="bands_grid_left">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="halign">center</property>
+                        <property name="hexpand">True</property>
                         <property name="vexpand">True</property>
                         <property name="column-spacing">12</property>
                         <property name="column-homogeneous">True</property>
@@ -477,32 +477,14 @@
                       </packing>
                     </child>
                     <child>
-                      <!-- n-columns=3 n-rows=3 -->
+                      <!-- n-columns=0 n-rows=3 -->
                       <object class="GtkGrid" id="bands_grid_right">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="halign">center</property>
+                        <property name="hexpand">True</property>
                         <property name="vexpand">True</property>
                         <property name="column-spacing">12</property>
                         <property name="column-homogeneous">True</property>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
                         <child>
                           <placeholder/>
                         </child>

--- a/data/ui/equalizer_band.glade
+++ b/data/ui/equalizer_band.glade
@@ -11,7 +11,7 @@
   <object class="GtkAdjustment" id="band_gain">
     <property name="lower">-35</property>
     <property name="upper">35</property>
-    <property name="step-increment">0.1</property>
+    <property name="step-increment">0.01</property>
     <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="band_quality">
@@ -365,7 +365,6 @@
         <property name="orientation">vertical</property>
         <property name="adjustment">band_gain</property>
         <property name="inverted">True</property>
-        <property name="round-digits">1</property>
         <property name="draw-value">False</property>
         <property name="has-origin">False</property>
       </object>

--- a/data/ui/equalizer_band.glade
+++ b/data/ui/equalizer_band.glade
@@ -331,7 +331,7 @@
       </object>
     </child>
   </object>
-  <!-- n-columns=1 n-rows=4 -->
+  <!-- n-columns=1 n-rows=5 -->
   <object class="GtkGrid" id="band_grid">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
@@ -343,7 +343,7 @@
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="label">band</property>
-        <property name="max-width-chars">7</property>
+        <property name="width-chars">9</property>
         <style>
           <class name="dim-label"/>
         </style>
@@ -363,11 +363,12 @@
         <property name="adjustment">band_gain</property>
         <property name="inverted">True</property>
         <property name="round-digits">1</property>
+        <property name="draw-value">False</property>
         <property name="has-origin">False</property>
       </object>
       <packing>
         <property name="left-attach">0</property>
-        <property name="top-attach">3</property>
+        <property name="top-attach">4</property>
       </packing>
     </child>
     <child>
@@ -396,8 +397,8 @@
       <object class="GtkLabel" id="band_quality_label">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="label" translatable="yes">Q</property>
-        <property name="max-width-chars">7</property>
+        <property name="label">Q</property>
+        <property name="width-chars">9</property>
         <style>
           <class name="dim-label"/>
         </style>
@@ -405,6 +406,21 @@
       <packing>
         <property name="left-attach">0</property>
         <property name="top-attach">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="band_gain_label">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="label">gain</property>
+        <property name="width-chars">9</property>
+        <style>
+          <class name="dim-label"/>
+        </style>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">3</property>
       </packing>
     </child>
   </object>

--- a/data/ui/equalizer_band.glade
+++ b/data/ui/equalizer_band.glade
@@ -336,6 +336,7 @@
     <property name="visible">True</property>
     <property name="can-focus">False</property>
     <property name="halign">center</property>
+    <property name="hexpand">True</property>
     <property name="vexpand">True</property>
     <property name="row-spacing">4</property>
     <child>
@@ -343,7 +344,6 @@
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="label">band</property>
-        <property name="width-chars">9</property>
         <style>
           <class name="dim-label"/>
         </style>
@@ -358,6 +358,9 @@
         <property name="height-request">100</property>
         <property name="visible">True</property>
         <property name="can-focus">True</property>
+        <property name="halign">center</property>
+        <property name="margin-start">8</property>
+        <property name="margin-end">8</property>
         <property name="vexpand">True</property>
         <property name="orientation">vertical</property>
         <property name="adjustment">band_gain</property>
@@ -398,7 +401,6 @@
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="label">Q</property>
-        <property name="width-chars">9</property>
         <style>
           <class name="dim-label"/>
         </style>
@@ -413,7 +415,6 @@
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="label">gain</property>
-        <property name="width-chars">9</property>
         <style>
           <class name="dim-label"/>
         </style>

--- a/include/app_info_ui.hpp
+++ b/include/app_info_ui.hpp
@@ -8,8 +8,13 @@
 #include <gtkmm/label.h>
 #include <gtkmm/scale.h>
 #include <gtkmm/switch.h>
+#include <glibmm/i18n.h>
 #include <gtkmm/togglebutton.h>
+#include "blocklist_settings_ui.hpp"
+#include "plugin_ui_base.hpp"
+#include "preset_type.hpp"
 #include "pulse_manager.hpp"
+#include "util.hpp"
 
 class AppInfoUi : public Gtk::Grid {
  public:
@@ -63,8 +68,6 @@ class AppInfoUi : public Gtk::Grid {
   void init_widgets();
 
   void connect_signals();
-
-  static auto latency_to_str(uint value) -> std::string;
 
   auto on_enable_app(bool state) -> bool;
 

--- a/include/plugin_ui_base.hpp
+++ b/include/plugin_ui_base.hpp
@@ -51,7 +51,9 @@ class PluginUiBase {
   void on_new_input_level_db(const std::array<double, 2>& peak);
   void on_new_output_level_db(const std::array<double, 2>& peak);
   static auto level_to_str(const double& value, const int& places) -> std::string;
+  static auto level_to_str(const float& value, const int& places) -> std::string;
   static auto level_to_str_showpos(const double& value, const int& places) -> std::string;
+  static auto level_to_str_showpos(const float& value, const int& places) -> std::string;
 
   // reset plugin method
   virtual void reset() = 0;

--- a/include/plugin_ui_base.hpp
+++ b/include/plugin_ui_base.hpp
@@ -70,6 +70,8 @@ class PluginUiBase {
   Gtk::Label *input_level_left_label = nullptr, *input_level_right_label = nullptr;
   Gtk::Label *output_level_left_label = nullptr, *output_level_right_label = nullptr;
 
+  static std::locale syslocale;
+
   std::vector<sigc::connection> connections;
 
   static void get_object(const Glib::RefPtr<Gtk::Builder>& builder,

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -4,6 +4,7 @@
 #include <glib-object.h>
 #include <glib.h>
 #include <iostream>
+#include <locale>
 #include <thread>
 #include <vector>
 

--- a/src/app_info_ui.cpp
+++ b/src/app_info_ui.cpp
@@ -1,9 +1,4 @@
 #include "app_info_ui.hpp"
-#include <glibmm/i18n.h>
-#include <sstream>
-#include "blocklist_settings_ui.hpp"
-#include "preset_type.hpp"
-#include "util.hpp"
 
 AppInfoUi::AppInfoUi(BaseObjectType* cobject,
                      const Glib::RefPtr<Gtk::Builder>& builder,
@@ -58,17 +53,9 @@ AppInfoUi::~AppInfoUi() {
   util::debug(log_tag + app_info->name + " info ui destroyed");
 }
 
-auto AppInfoUi::latency_to_str(uint value) -> std::string {
-  std::ostringstream msg;
+void AppInfoUi::init_widgets() {
   const float ms_factor = 0.001F;
 
-  msg.precision(1);
-  msg << std::fixed << value * ms_factor << " ms";
-
-  return msg.str();
-}
-
-void AppInfoUi::init_widgets() {
   enable->set_active(is_enabled && !is_blocklisted);
   enable->set_sensitive(!is_blocklisted);
 
@@ -98,9 +85,9 @@ void AppInfoUi::init_widgets() {
 
   resampler->set_text(app_info->resampler);
 
-  buffer->set_text(latency_to_str(app_info->buffer));
+  buffer->set_text(PluginUiBase::level_to_str(app_info->buffer * ms_factor, 1) + " ms");
 
-  latency->set_text(latency_to_str(app_info->latency));
+  latency->set_text(PluginUiBase::level_to_str(app_info->latency * ms_factor, 1) + " ms");
 
   if (app_info->corked != 0) {
     state->set_text(_("paused"));

--- a/src/convolver_ui.cpp
+++ b/src/convolver_ui.cpp
@@ -416,12 +416,7 @@ void ConvolverUi::get_irs_info() {
     label_sampling_rate->set_text(std::to_string(rate) + " Hz");
     label_samples->set_text(std::to_string(frames_in));
 
-    std::ostringstream msg;
-
-    msg.precision(3);
-    msg << duration << " s";
-
-    label_duration->set_text(msg.str());
+    label_duration->set_text(level_to_str(duration, 3) + " s");
 
     auto fpath = boost::filesystem::path{path};
 

--- a/src/crystalizer_ui.cpp
+++ b/src/crystalizer_ui.cpp
@@ -81,17 +81,31 @@ void CrystalizerUi::build_bands(const int& nbands) {
 
     Gtk::Grid* band_grid;
     Gtk::Label* band_label;
+    Gtk::Label* band_intensity_label;
     Gtk::ToggleButton* band_mute;
     Gtk::ToggleButton* band_bypass;
     Gtk::Scale* band_scale;
 
     B->get_widget("band_grid", band_grid);
     B->get_widget("band_label", band_label);
+    B->get_widget("band_intensity_label", band_intensity_label);
     B->get_widget("band_mute", band_mute);
     B->get_widget("band_bypass", band_bypass);
     B->get_widget("band_scale", band_scale);
 
     auto band_intensity = Glib::RefPtr<Gtk::Adjustment>::cast_dynamic(B->get_object("band_intensity"));
+
+    // set initial band intensity in relative label
+
+    band_intensity_label->set_text(level_to_str_showpos(band_intensity->get_value(), 0));
+
+    // connections
+
+    connections.emplace_back(band_intensity->signal_value_changed().connect([=]() {
+      auto bi = band_intensity->get_value();
+
+      band_intensity_label->set_text(level_to_str_showpos(bi, 0));
+    }));
 
     connections.emplace_back(band_mute->signal_toggled().connect([=]() {
       if (band_mute->get_active()) {

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -345,22 +345,12 @@ void EqualizerUi::build_bands(Gtk::Grid* bands_grid, const Glib::RefPtr<Gio::Set
     auto update_quality_width = [=]() {
       auto q = band_quality->get_value();
 
-      std::ostringstream q_msg;
-
-      q_msg.precision(2);
-      q_msg << "Q " << std::fixed << q;
-
-      band_quality_label->set_text(q_msg.str());
+      band_quality_label->set_text(level_to_str(q, 2));
 
       if (q > 0.0) {
         auto f = band_frequency->get_value();
 
-        std::ostringstream w_msg;
-
-        w_msg.precision(1);
-        w_msg << std::fixed << f / q << " Hz";
-
-        band_width->set_text(w_msg.str());
+        band_width->set_text(level_to_str(f / q, 1) + " Hz");
       } else {
         band_width->set_text(_("infinity"));
       }
@@ -369,17 +359,11 @@ void EqualizerUi::build_bands(Gtk::Grid* bands_grid, const Glib::RefPtr<Gio::Set
     auto update_band_label = [=]() {
       auto f = band_frequency->get_value();
 
-      std::ostringstream msg;
-
       if (f > 1000.0) {
-        msg.precision(1);
-        msg << std::fixed << f / 1000.0 << " kHz";
+        band_label->set_text(level_to_str(f / 1000.0, 1) + " kHz");
       } else {
-        msg.precision(0);
-        msg << std::fixed << f << " Hz";
+        band_label->set_text(level_to_str(f, 0) + " Hz");
       }
-
-      band_label->set_text(msg.str());
     };
 
     connections_bands.emplace_back(band_frequency->signal_value_changed().connect(update_quality_width));
@@ -478,22 +462,12 @@ void EqualizerUi::build_unified_bands(const int& nbands) {
     auto update_quality_width = [=]() {
       auto q = band_quality->get_value();
 
-      std::ostringstream q_msg;
-
-      q_msg.precision(2);
-      q_msg << "Q " << std::fixed << q;
-
-      band_quality_label->set_text(q_msg.str());
+      band_quality_label->set_text(level_to_str(q, 2));
 
       if (q > 0.0) {
         auto f = band_frequency->get_value();
 
-        std::ostringstream w_msg;
-
-        w_msg.precision(1);
-        w_msg << std::fixed << f / q << " Hz";
-
-        band_width->set_text(w_msg.str());
+        band_width->set_text(level_to_str(f / q, 1) + " Hz");
       } else {
         band_width->set_text(_("infinity"));
       }
@@ -502,17 +476,11 @@ void EqualizerUi::build_unified_bands(const int& nbands) {
     auto update_band_label = [=]() {
       auto f = band_frequency->get_value();
 
-      std::ostringstream msg;
-
       if (f > 1000.0) {
-        msg.precision(1);
-        msg << std::fixed << f / 1000 << " kHz";
+        band_label->set_text(level_to_str(f / 1000.0, 1) + " kHz");
       } else {
-        msg.precision(0);
-        msg << std::fixed << f << " Hz";
+        band_label->set_text(level_to_str(f, 0) + " Hz");
       }
-
-      band_label->set_text(msg.str());
     };
 
     connections_bands.emplace_back(band_frequency->signal_value_changed().connect(update_quality_width));

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -319,6 +319,7 @@ void EqualizerUi::build_bands(Gtk::Grid* bands_grid, const Glib::RefPtr<Gio::Set
     Gtk::Label* band_width = nullptr;
     Gtk::Label* band_label = nullptr;
     Gtk::Label* band_quality_label = nullptr;
+    Gtk::Label* band_gain_label = nullptr;
     Gtk::Button* reset_frequency = nullptr;
     Gtk::Button* reset_quality = nullptr;
     Gtk::ToggleButton* band_solo = nullptr;
@@ -332,6 +333,7 @@ void EqualizerUi::build_bands(Gtk::Grid* bands_grid, const Glib::RefPtr<Gio::Set
     B->get_widget("band_width", band_width);
     B->get_widget("band_label", band_label);
     B->get_widget("band_quality_label", band_quality_label);
+    B->get_widget("band_gain_label", band_gain_label);
     B->get_widget("band_solo", band_solo);
     B->get_widget("band_mute", band_mute);
     B->get_widget("band_scale", band_scale);
@@ -345,7 +347,7 @@ void EqualizerUi::build_bands(Gtk::Grid* bands_grid, const Glib::RefPtr<Gio::Set
     auto update_quality_width = [=]() {
       auto q = band_quality->get_value();
 
-      band_quality_label->set_text(level_to_str(q, 2));
+      band_quality_label->set_text("Q " + level_to_str(q, 2));
 
       if (q > 0.0) {
         auto f = band_frequency->get_value();
@@ -366,11 +368,25 @@ void EqualizerUi::build_bands(Gtk::Grid* bands_grid, const Glib::RefPtr<Gio::Set
       }
     };
 
+    auto update_gain = [=]() {
+      auto g = band_gain->get_value();
+
+      band_gain_label->set_text(level_to_str_showpos(g, 2));
+    };
+
+    // set initial band gain in relative label
+
+    band_gain_label->set_text(level_to_str_showpos(band_gain->get_value(), 2));
+
+    // connections
+
     connections_bands.emplace_back(band_frequency->signal_value_changed().connect(update_quality_width));
 
     connections_bands.emplace_back(band_frequency->signal_value_changed().connect(update_band_label));
 
     connections_bands.emplace_back(band_quality->signal_value_changed().connect(update_quality_width));
+
+    connections_bands.emplace_back(band_gain->signal_value_changed().connect(update_gain));
 
     connections_bands.emplace_back(reset_frequency->signal_clicked().connect(
         [=]() { cfg->reset(std::string("band" + std::to_string(n) + "-frequency")); }));
@@ -436,6 +452,7 @@ void EqualizerUi::build_unified_bands(const int& nbands) {
     Gtk::Label* band_width = nullptr;
     Gtk::Label* band_label = nullptr;
     Gtk::Label* band_quality_label = nullptr;
+    Gtk::Label* band_gain_label = nullptr;
     Gtk::Button* reset_frequency = nullptr;
     Gtk::Button* reset_quality = nullptr;
     Gtk::ToggleButton* band_solo = nullptr;
@@ -449,6 +466,7 @@ void EqualizerUi::build_unified_bands(const int& nbands) {
     B->get_widget("band_width", band_width);
     B->get_widget("band_label", band_label);
     B->get_widget("band_quality_label", band_quality_label);
+    B->get_widget("band_gain_label", band_gain_label);
     B->get_widget("band_solo", band_solo);
     B->get_widget("band_mute", band_mute);
     B->get_widget("band_scale", band_scale);
@@ -462,7 +480,7 @@ void EqualizerUi::build_unified_bands(const int& nbands) {
     auto update_quality_width = [=]() {
       auto q = band_quality->get_value();
 
-      band_quality_label->set_text(level_to_str(q, 2));
+      band_quality_label->set_text("Q " + level_to_str(q, 2));
 
       if (q > 0.0) {
         auto f = band_frequency->get_value();
@@ -483,11 +501,25 @@ void EqualizerUi::build_unified_bands(const int& nbands) {
       }
     };
 
+    auto update_gain = [=]() {
+      auto g = band_gain->get_value();
+
+      band_gain_label->set_text(level_to_str_showpos(g, 2));
+    };
+
+    // set initial band gain in relative label
+
+    band_gain_label->set_text(level_to_str_showpos(band_gain->get_value(), 2));
+
+    // connections
+
     connections_bands.emplace_back(band_frequency->signal_value_changed().connect(update_quality_width));
 
     connections_bands.emplace_back(band_frequency->signal_value_changed().connect(update_band_label));
 
     connections_bands.emplace_back(band_quality->signal_value_changed().connect(update_quality_width));
+
+    connections_bands.emplace_back(band_gain->signal_value_changed().connect(update_gain));
 
     /*right channel
       we need the bindgins below for the right channel equalizer to be updated

--- a/src/plugin_ui_base.cpp
+++ b/src/plugin_ui_base.cpp
@@ -1,5 +1,7 @@
 #include "plugin_ui_base.hpp"
 
+std::locale PluginUiBase::syslocale = std::locale("");
+
 PluginUiBase::PluginUiBase(const Glib::RefPtr<Gtk::Builder>& builder,
                            const std::string& schema,
                            const std::string& schema_path)
@@ -45,7 +47,9 @@ PluginUiBase::~PluginUiBase() {
 auto PluginUiBase::level_to_str(const double& value, const int& places) -> std::string {
   std::ostringstream msg;
 
+  msg.imbue(syslocale);
   msg.precision(places);
+
   msg << std::fixed << value;
 
   return msg.str();
@@ -54,7 +58,9 @@ auto PluginUiBase::level_to_str(const double& value, const int& places) -> std::
 auto PluginUiBase::level_to_str_showpos(const double& value, const int& places) -> std::string {
   std::ostringstream msg;
 
+  msg.imbue(syslocale);
   msg.precision(places);
+
   msg << ((value > 0.0) ? "+" : "") << std::fixed << value;
 
   return msg.str();
@@ -63,7 +69,9 @@ auto PluginUiBase::level_to_str_showpos(const double& value, const int& places) 
 auto PluginUiBase::level_to_str(const float& value, const int& places) -> std::string {
   std::ostringstream msg;
 
+  msg.imbue(syslocale);
   msg.precision(places);
+
   msg << std::fixed << value;
 
   return msg.str();
@@ -72,7 +80,9 @@ auto PluginUiBase::level_to_str(const float& value, const int& places) -> std::s
 auto PluginUiBase::level_to_str_showpos(const float& value, const int& places) -> std::string {
   std::ostringstream msg;
 
+  msg.imbue(syslocale);
   msg.precision(places);
+
   msg << ((value > 0.0F) ? "+" : "") << std::fixed << value;
 
   return msg.str();

--- a/src/plugin_ui_base.cpp
+++ b/src/plugin_ui_base.cpp
@@ -60,6 +60,24 @@ auto PluginUiBase::level_to_str_showpos(const double& value, const int& places) 
   return msg.str();
 }
 
+auto PluginUiBase::level_to_str(const float& value, const int& places) -> std::string {
+  std::ostringstream msg;
+
+  msg.precision(places);
+  msg << std::fixed << value;
+
+  return msg.str();
+}
+
+auto PluginUiBase::level_to_str_showpos(const float& value, const int& places) -> std::string {
+  std::ostringstream msg;
+
+  msg.precision(places);
+  msg << ((value > 0.0F) ? "+" : "") << std::fixed << value;
+
+  return msg.str();
+}
+
 void PluginUiBase::on_new_input_level(const std::array<double, 2>& peak) {
   update_level(input_level_left, input_level_left_label, input_level_right, input_level_right_label, peak);
 }


### PR DESCRIPTION
- scale drawn value have been hided in equalizer and crystalizer
- a new label has been added to show the gain/intensity property in equalizer/crystalizer
- make use of `level_to_str`/`level_to_str_showpos` functions to format values where possible, adding also a float version to both
- show positive sign for gain/intensity values in equalizer/crystalizer
- widget values are formatted according to locale (i.e on my Italian system, decimal separator is the comma) while `level_to_str` strings weren't (always point separator), so they have been modified to return a locale value also
- band columns in equalizer/crystalizer ui have been modified to expand in homogeneous columns having the same space between them like widgets in all other plugin ui

The only issue I encountered is with gain/intensity values not been updated when the initial value is 0. I don't know why this was happening, but I added a workaround initializing the label in the band constructor.  