### PR TITLE
Regex optimized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Added
+
+- Band Quality factor exposed in the equalizer main interface.
+
+### Fixed
+
+- Values outside GTK widgets are now shown according to system locale settings.
+- Equalizer and Crystalizer UI redesigned: band wrapper is extended to fit all available horizontal space and homogeneous property
+  has been applied to get same space between band sliders.
+
 ## [4.8.2]
 
 ### Fixed
@@ -17,8 +27,8 @@
 - Deesser UI redesigned and applied homogeneous property to all plugin UI to get same space between controls and make them fit
   all the available horizontal space.
 - Modified `Applications` row in the left side plugin list to show an icon according to input/output effects while the pipeline
-  global level meter is only shown when something is recording/playing
-- The feature that shows the last used preset in the preset menu button label was improved. When seeing input effects
+  global level meter is only shown when something is recording/playing.
+- The feature that shows the last used preset in the preset menu button label was improved. When seeing input effects.
   widget it shows the last used input preset. And when seeing output effects widgets it shows the last used output preset.
 - New application icon.
 

--- a/src/equalizer_ui.cpp
+++ b/src/equalizer_ui.cpp
@@ -869,11 +869,13 @@ void EqualizerUi::on_import_apo_preset_clicked() {
 // returns false if we cannot parse given line successfully
 auto EqualizerUi::parse_apo_filter(const std::string& line, struct ImportedBand& filter) -> bool {
   std::smatch matches;
-  std::regex re_filter_type(R"(Filter[\s]+[\d]*:[\s]*ON[\s]+([\w]+))");
-  std::regex re_freq(R"([\s]+Fc[\s]*([\d]*[.]?[\d]*)[\s]*Hz)");
-  std::regex re_dB_per_octave(R"(Filter[\s]+[\d]*:[\s]*ON[\s]+[\w]+[\s]+([+-]?[\d]*[.]?[\d]*)[\s]*dB)");
-  std::regex re_gain(R"(Gain[\s]*([+-]?[\d]*[.]?[\d]*)[\s]*dB)");
-  std::regex re_quality_factor(R"([\s]+Q[\s]+([\d]*[.]?[\d]*))");
+
+  auto i = std::regex::icase;
+  std::regex re_filter_type("filter\\s++\\d*+:\\s*+on\\s++(\\w++)", i);
+  std::regex re_freq("\\s++fc\\s*+(\\d*+\\.?+\\d*+)\\s*+hz", i);
+  std::regex re_dB_per_octave("filter\\s++\\d*+:\\s*+on\\s++\\w++\\s++([\\+-]?+\\d*+\\.?+\\d*+)\\s*+db", i);
+  std::regex re_gain("gain\\s*+([\\+-]?+\\d*+\\.?+\\d*+)\\s*+db", i);
+  std::regex re_quality_factor("\\s++q\\s++(\\d*+\\.?+\\d*+)", i);
 
   // get filter type
   std::regex_search(line, matches, re_filter_type);


### PR DESCRIPTION
I tried to write regex in `parse_apo_filter` with possessive quantifiers to avoid backtracking. Then I added the case insensitive option to make them more robust.

I made some tests, seems it's working. Please @wwmm, test you too.