### PR TITLE
Inclusion of rnnoise.h into C++ code is fixed upstream

### DIFF
--- a/src/rnnoise/gstpernnoise.hpp
+++ b/src/rnnoise/gstpernnoise.hpp
@@ -23,10 +23,7 @@
 #include <gst/audio/gstaudiofilter.h>
 #include <mutex>
 #include <vector>
-
-extern "C" {
-#include "rnnoise.h"
-}
+#include <rnnoise.h>
 
 G_BEGIN_DECLS
 


### PR DESCRIPTION
Latest librnnoise commit is fixed upstream. Check it out here:
https://gitlab.xiph.org/xiph/rnnoise/-/commit/125d8a56e0049728c86c9a575dab348fc9523e96

I just uploaded an updated PKGBUILD on AUR