### PR TITLE
presets manager was loading wrong values from blocklists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ debian/*
 
 ppastats
 .autobuild
+
+#clion jetbrains ide adds an .idea folder
+.idea

--- a/src/presets_manager.cpp
+++ b/src/presets_manager.cpp
@@ -212,7 +212,7 @@ void PresetsManager::load_blocklist(PresetType preset_type, const boost::propert
   std::vector<std::string> blocklist;
 
   switch (preset_type) {
-    case PresetType::output: {
+    case PresetType::input: {
       try {
         for (const auto& p : root.get_child("input.blocklist")) {
           blocklist.emplace_back(p.second.data());
@@ -225,7 +225,7 @@ void PresetsManager::load_blocklist(PresetType preset_type, const boost::propert
 
       break;
     }
-    case PresetType::input: {
+    case PresetType::output: {
       try {
         for (const auto& p : root.get_child("output.blocklist")) {
           blocklist.emplace_back(p.second.data());


### PR DESCRIPTION
The presets_manager.cpp was loading the wrong values from blocklists specified in the preset .json files. 
The output-blocklist was loading the input-blocklist and vice versa.
Fixed that by just swapping out the conditions in the switch-case.

I also added an entry for people using CLion/Jetbrain IDE's in the .gitignore, so the .idea folder created by the IDE will be ignored