### PR TITLE
Make key const.

### DIFF
--- a/src/plugin_base.cpp
+++ b/src/plugin_base.cpp
@@ -23,7 +23,7 @@
 
 namespace {
 
-void on_state_changed(GSettings* settings, gchar* key, PluginBase* l) {
+void on_state_changed(GSettings* settings, const gchar* key, PluginBase* l) {
   if (l->plugin_is_installed) {
     int enable = g_settings_get_boolean(settings, key);
 


### PR DESCRIPTION
Otherwise there is an error in C++ mode for converting a string literal to a non-const string.

```
../src/plugin_base.cpp: In constructor 'PluginBase::PluginBase(std::string, std::string, const string&, const string&)':
../src/plugin_base.cpp:146:30: warning: ISO C++ forbids converting a string constant to 'gchar*' {aka 'char*'} [-Wwrite-strings]
  146 |   on_state_changed(settings, "state", this);
      |                              ^~~~~~~
```