### PR TITLE
Display icon in window list and alt+tab menu

### DIFF
--- a/data/ui/application.glade
+++ b/data/ui/application.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.1 -->
+<!-- Generated with glade 3.38.2 -->
 <interface domain="pulseeffects">
   <requires lib="gtk+" version="3.24"/>
   <object class="GtkImage" id="image_bypass">
@@ -25,6 +25,7 @@
   </object>
   <object class="GtkApplicationWindow" id="ApplicationUi">
     <property name="can-focus">False</property>
+    <property name="icon-name">pulseeffects</property>
     <child>
       <object class="GtkStack" id="stack">
         <property name="visible">True</property>


### PR DESCRIPTION
This PR allows the pulseeffects icon to be displayed in window lists, window selectors, the alt+tab menu, ... (MATE Desktop Environment, possibly in  others as well)

**Before:**
![before_panel](https://user-images.githubusercontent.com/49864414/116863182-3aba4800-ac06-11eb-8379-5184b13f8eae.png)


![before](https://user-images.githubusercontent.com/49864414/116863200-4279ec80-ac06-11eb-9f3d-1cfa91a77c98.png)


**Ater:**
![after_panel](https://user-images.githubusercontent.com/49864414/116863255-56255300-ac06-11eb-812a-4175c20bc6e5.png)

![after](https://user-images.githubusercontent.com/49864414/116863272-5b829d80-ac06-11eb-978d-43aeb3fd25b3.png)


Possibly fixes https://github.com/wwmm/pulseeffects/issues/546